### PR TITLE
Add local scheduler, autonomous tools, intent routing, and TTS pacing improvements

### DIFF
--- a/core/schedule.py
+++ b/core/schedule.py
@@ -1,0 +1,394 @@
+"""
+core/schedule.py
+
+Persistent scheduled jobs, reminders, and wake-up alarms for Aiko.
+
+A scheduled job is a small local record with:
+  - time_of_day: local wall-clock time in HH:MM format
+  - frequency: once, daily, weekdays, weekly, biweekly, monthly, or custom_weekdays
+  - days_of_week: optional weekday names for custom_weekdays/weekly jobs
+  - task: what Aiko should do or say when the job fires
+  - action: announce or agentic
+
+The scheduler is deliberately local-first: jobs are stored in JSON under
+AIKO_WORKSPACE_ROOT and a daemon thread polls for due entries.  It can announce
+or initiate jobs only while Aiko is running on an awake machine.  It does not
+install OS-level cron jobs, wake a sleeping computer, or run after Aiko exits.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Callable
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from core.log import get_logger
+
+log = get_logger(__name__)
+
+WORKSPACE_ROOT = Path(os.getenv("AIKO_WORKSPACE_ROOT", "workspace")).resolve()
+SCHEDULE_PATH = Path(os.getenv("AIKO_SCHEDULE_PATH", WORKSPACE_ROOT / "schedule.json")).resolve()
+LEGACY_REMINDERS_PATH = Path(os.getenv("AIKO_REMINDERS_PATH", WORKSPACE_ROOT / "reminders.json")).resolve()
+DEFAULT_TIMEZONE = os.getenv("AIKO_TIMEZONE", os.getenv("TZ", "UTC"))
+POLL_SECONDS = float(os.getenv("AIKO_SCHEDULE_POLL_SECONDS", os.getenv("AIKO_REMINDER_POLL_SECONDS", 15)))
+
+FREQUENCIES = {"once", "daily", "weekdays", "weekly", "biweekly", "monthly", "custom_weekdays"}
+_WEEKDAYS = {
+    "monday": 0, "mon": 0,
+    "tuesday": 1, "tue": 1, "tues": 1,
+    "wednesday": 2, "wed": 2,
+    "thursday": 3, "thu": 3, "thur": 3, "thurs": 3,
+    "friday": 4, "fri": 4,
+    "saturday": 5, "sat": 5,
+    "sunday": 6, "sun": 6,
+}
+
+
+def _timezone(name: str | None = None) -> ZoneInfo:
+    """Return a ZoneInfo object, falling back to UTC when the name is invalid."""
+    try:
+        return ZoneInfo(name or DEFAULT_TIMEZONE)
+    except ZoneInfoNotFoundError:
+        log.warning("Unknown timezone %s; falling back to UTC", name or DEFAULT_TIMEZONE)
+        return ZoneInfo("UTC")
+
+
+def _now(tz_name: str | None = None) -> datetime:
+    """Return the current timezone-aware datetime for schedule calculations."""
+    return datetime.now(_timezone(tz_name))
+
+
+def _parse_time_of_day(time_of_day: str) -> tuple[int, int]:
+    """Parse HH:MM or H:MM into hour/minute integers."""
+    hour_text, sep, minute_text = time_of_day.strip().partition(":")
+    if not sep:
+        raise ValueError("time_of_day must be HH:MM")
+    hour = int(hour_text)
+    minute = int(minute_text)
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        raise ValueError("time_of_day must be a valid 24-hour time")
+    return hour, minute
+
+
+def _normalize_weekdays(days_of_week: list[str] | str | None) -> list[int]:
+    """Normalize weekday names/integers into sorted Python weekday numbers."""
+    if days_of_week is None:
+        return []
+    if isinstance(days_of_week, str):
+        parts = [p.strip().lower() for p in days_of_week.replace(",", " ").split()]
+    else:
+        parts = [str(p).strip().lower() for p in days_of_week]
+    days: set[int] = set()
+    for part in parts:
+        if not part:
+            continue
+        if part.isdigit():
+            value = int(part)
+            if 0 <= value <= 6:
+                days.add(value)
+                continue
+        if part not in _WEEKDAYS:
+            raise ValueError(f"unknown weekday: {part}")
+        days.add(_WEEKDAYS[part])
+    return sorted(days)
+
+
+def _candidate_at(now: datetime, time_of_day: str) -> datetime:
+    """Return today's candidate datetime at a given wall-clock time."""
+    hour, minute = _parse_time_of_day(time_of_day)
+    return now.replace(hour=hour, minute=minute, second=0, microsecond=0)
+
+
+def _next_for_weekdays(time_of_day: str, weekdays: list[int], tz_name: str | None = None) -> datetime:
+    """Return the next datetime matching one of the requested weekdays."""
+    if not weekdays:
+        raise ValueError("days_of_week is required for this frequency")
+    now = _now(tz_name)
+    base = _candidate_at(now, time_of_day)
+    for offset in range(0, 14):
+        candidate = base + timedelta(days=offset)
+        if candidate.weekday() in weekdays and candidate > now:
+            return candidate
+    raise ValueError("could not calculate next weekday occurrence")
+
+
+def _next_monthly(time_of_day: str, tz_name: str | None = None, anchor_day: int | None = None) -> datetime:
+    """Return the next monthly occurrence on the anchor day, clamped to month length."""
+    import calendar
+
+    now = _now(tz_name)
+    anchor = anchor_day or now.day
+    hour, minute = _parse_time_of_day(time_of_day)
+    year, month = now.year, now.month
+    for _ in range(14):
+        last_day = calendar.monthrange(year, month)[1]
+        day = min(anchor, last_day)
+        candidate = now.replace(year=year, month=month, day=day, hour=hour, minute=minute, second=0, microsecond=0)
+        if candidate > now:
+            return candidate
+        month += 1
+        if month > 12:
+            month = 1
+            year += 1
+    raise ValueError("could not calculate next monthly occurrence")
+
+
+def calculate_next_due(
+    time_of_day: str,
+    frequency: str = "daily",
+    timezone: str | None = None,
+    days_of_week: list[str] | str | None = None,
+    after: datetime | None = None,
+    anchor_day: int | None = None,
+) -> datetime:
+    """Calculate the next due datetime for a scheduled job."""
+    frequency = (frequency or "daily").lower().strip()
+    if frequency not in FREQUENCIES:
+        raise ValueError(f"frequency must be one of: {', '.join(sorted(FREQUENCIES))}")
+
+    tz_name = timezone or DEFAULT_TIMEZONE
+    now = after.astimezone(_timezone(tz_name)) if after else _now(tz_name)
+    candidate = _candidate_at(now, time_of_day)
+
+    if frequency in {"once", "daily"}:
+        return candidate if candidate > now else candidate + timedelta(days=1)
+    if frequency == "weekdays":
+        return _next_for_weekdays(time_of_day, [0, 1, 2, 3, 4], tz_name)
+    if frequency == "custom_weekdays":
+        return _next_for_weekdays(time_of_day, _normalize_weekdays(days_of_week), tz_name)
+    if frequency == "weekly":
+        weekdays = _normalize_weekdays(days_of_week) or [now.weekday()]
+        return _next_for_weekdays(time_of_day, weekdays, tz_name)
+    if frequency == "biweekly":
+        base = candidate if candidate > now else candidate + timedelta(days=14)
+        return base
+    if frequency == "monthly":
+        return _next_monthly(time_of_day, tz_name, anchor_day=anchor_day)
+    raise ValueError(f"unsupported frequency: {frequency}")
+
+
+def _read_raw(path: Path) -> list[dict]:
+    """Read schedule JSON from a path, returning [] when absent/invalid."""
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except Exception as e:
+        log.error("Failed reading schedule file %s: %s", path, e)
+        return []
+
+
+def _migrate_legacy_reminders(records: list[dict]) -> list[dict]:
+    """Convert older reminder records into the scheduled-job shape."""
+    migrated = []
+    for record in records:
+        migrated.append({
+            "id": record.get("id", uuid.uuid4().hex[:12]),
+            "title": record.get("title", "Reminder"),
+            "task": record.get("message", record.get("title", "Reminder")),
+            "time_of_day": record.get("time_of_day", "06:00"),
+            "frequency": "daily" if record.get("repeat") == "daily" else "once",
+            "days_of_week": [],
+            "timezone": record.get("timezone", DEFAULT_TIMEZONE),
+            "next_due": record.get("next_due"),
+            "created_at": record.get("created_at", _now(record.get("timezone")).isoformat()),
+            "last_ran_at": None,
+            "enabled": record.get("enabled", True),
+            "kind": "reminder",
+            "action": "announce",
+        })
+    return migrated
+
+
+def _read_all() -> list[dict]:
+    """Read scheduled jobs, including one-time migration from reminders.json."""
+    records = _read_raw(SCHEDULE_PATH)
+    if records:
+        return records
+    legacy = _read_raw(LEGACY_REMINDERS_PATH)
+    if legacy:
+        records = _migrate_legacy_reminders(legacy)
+        _write_all(records)
+    return records
+
+
+def _write_all(jobs: list[dict]) -> None:
+    """Persist scheduled jobs atomically enough for a single local process."""
+    SCHEDULE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = SCHEDULE_PATH.with_suffix(".tmp")
+    tmp.write_text(json.dumps(jobs, ensure_ascii=False, indent=2), encoding="utf-8")
+    tmp.replace(SCHEDULE_PATH)
+
+
+def schedule_job_record(
+    title: str,
+    task: str,
+    time_of_day: str,
+    frequency: str = "daily",
+    timezone: str | None = None,
+    days_of_week: list[str] | str | None = None,
+    action: str = "agentic",
+) -> dict:
+    """Create and persist a scheduled job record, returning the stored dict."""
+    action = (action or "agentic").lower().strip()
+    if action not in {"announce", "agentic"}:
+        raise ValueError("action must be 'announce' or 'agentic'")
+    tz_name = timezone or DEFAULT_TIMEZONE
+    normalized_days = _normalize_weekdays(days_of_week)
+    due = calculate_next_due(time_of_day, frequency, tz_name, normalized_days)
+    job = {
+        "id": uuid.uuid4().hex[:12],
+        "title": title.strip() or "Scheduled job",
+        "task": task.strip() or title.strip() or "Scheduled job",
+        "time_of_day": time_of_day,
+        "frequency": (frequency or "daily").lower().strip(),
+        "days_of_week": normalized_days,
+        "timezone": tz_name,
+        "next_due": due.isoformat(),
+        "created_at": _now(tz_name).isoformat(),
+        "last_ran_at": None,
+        "enabled": True,
+        "kind": "scheduled_job",
+        "action": action,
+    }
+    jobs = _read_all()
+    jobs.append(job)
+    _write_all(jobs)
+    return job
+
+
+def list_schedule_records(include_disabled: bool = False) -> list[dict]:
+    """Return persisted scheduled jobs, optionally including disabled records."""
+    jobs = _read_all()
+    if include_disabled:
+        return jobs
+    return [job for job in jobs if job.get("enabled", True)]
+
+
+def cancel_schedule_record(job_id: str) -> bool:
+    """Disable a scheduled job by id; returns True when a matching record changed."""
+    changed = False
+    jobs = _read_all()
+    for job in jobs:
+        if job.get("id") == job_id:
+            job["enabled"] = False
+            changed = True
+    if changed:
+        _write_all(jobs)
+    return changed
+
+
+# Backwards-compatible reminder names used by older tools/tests.
+def schedule_reminder_record(title: str, message: str, time_of_day: str, repeat: str = "daily", timezone: str | None = None) -> dict:
+    """Compatibility wrapper: schedule a reminder as a scheduled job."""
+    frequency = "daily" if repeat == "daily" else "once"
+    return schedule_job_record(title, message, time_of_day, frequency, timezone, action="announce")
+
+
+def list_reminder_records(include_disabled: bool = False) -> list[dict]:
+    """Compatibility wrapper: list scheduled jobs."""
+    return list_schedule_records(include_disabled)
+
+
+def cancel_reminder_record(reminder_id: str) -> bool:
+    """Compatibility wrapper: cancel a scheduled job by id."""
+    return cancel_schedule_record(reminder_id)
+
+
+@dataclass
+class DueJob:
+    """A scheduled job event ready to announce or execute."""
+    id: str
+    title: str
+    task: str
+    action: str = "agentic"
+
+
+DueReminder = DueJob
+
+
+class ScheduleRunner:
+    """Background poller that announces due scheduled jobs while Aiko is running."""
+
+    def __init__(self, on_due: Callable[[DueJob], None] | None = None) -> None:
+        self._on_due = on_due
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        """Start the daemon scheduler thread if it is not already running."""
+        if self._thread and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(target=self._run, name="aiko-schedule", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        """Request scheduler shutdown."""
+        self._stop.set()
+
+    def _run(self) -> None:
+        """Poll schedule storage and announce due records."""
+        while not self._stop.is_set():
+            try:
+                self._fire_due()
+            except Exception as e:
+                log.error("Schedule runner failed: %s", e)
+            self._stop.wait(POLL_SECONDS)
+
+    def _fire_due(self) -> None:
+        """Find due jobs, reschedule recurring ones, and disable one-shots."""
+        jobs = _read_all()
+        changed = False
+        due_events: list[DueJob] = []
+
+        for job in jobs:
+            if not job.get("enabled", True):
+                continue
+            tz_name = job.get("timezone") or DEFAULT_TIMEZONE
+            try:
+                due = datetime.fromisoformat(job["next_due"])
+            except Exception:
+                due = calculate_next_due(
+                    job.get("time_of_day", "06:00"),
+                    job.get("frequency", "daily"),
+                    tz_name,
+                    job.get("days_of_week"),
+                )
+                job["next_due"] = due.isoformat()
+                changed = True
+
+            if due <= _now(tz_name):
+                due_events.append(DueJob(
+                    id=job.get("id", ""),
+                    title=job.get("title", "Scheduled job"),
+                    task=job.get("task", "Scheduled job"),
+                    action=job.get("action", "agentic"),
+                ))
+                job["last_ran_at"] = _now(tz_name).isoformat()
+                if job.get("frequency") == "once":
+                    job["enabled"] = False
+                else:
+                    job["next_due"] = calculate_next_due(
+                        job.get("time_of_day", "06:00"),
+                        job.get("frequency", "daily"),
+                        tz_name,
+                        job.get("days_of_week"),
+                        after=_now(tz_name),
+                    ).isoformat()
+                changed = True
+
+        if changed:
+            _write_all(jobs)
+        for event in due_events:
+            if self._on_due:
+                self._on_due(event)
+
+
+ReminderScheduler = ScheduleRunner

--- a/core/schedule.py
+++ b/core/schedule.py
@@ -354,6 +354,8 @@ class ScheduleRunner:
             tz_name = job.get("timezone") or DEFAULT_TIMEZONE
             try:
                 due = datetime.fromisoformat(job["next_due"])
+                if due.tzinfo is None:
+                    due = due.replace(tzinfo=_timezone(tz_name))
             except Exception:
                 due = calculate_next_due(
                     job.get("time_of_day", "06:00"),

--- a/core/speak.py
+++ b/core/speak.py
@@ -274,7 +274,7 @@ class AikoSpeak:
         usable_duration = max(0.05, duration - 0.08)
         start = time.monotonic() + 0.02
         elapsed = 0.0
-        for i, (word, weight) in enumerate(zip(words, weights)):
+        for i, (word, weight) in enumerate(zip(words, weights, strict=True)):
             if self._stop_flag.is_set():
                 break
             sleep_time = (start + elapsed) - time.monotonic()

--- a/core/speak.py
+++ b/core/speak.py
@@ -258,18 +258,30 @@ class AikoSpeak:
                 on_word(word if i == 0 else " " + word)
             return
 
-        weights = [len(w) + 1 for w in words]   # +1 ≈ trailing space/breath
-        total   = sum(weights)
-        start   = time.monotonic()
+        # Keep a small lead-in so the first word appears when audio begins,
+        # then distribute later words by a speech-ish duration estimate.
+        # Punctuation receives extra time because TTS usually pauses there.
+        weights = []
+        for word in words:
+            weight = max(1.0, len(re.sub(r"[^\w]", "", word)) * 0.75) + 0.8
+            if re.search(r"[.!?。！？]$", word):
+                weight += 3.0
+            elif re.search(r"[,;:、]$", word):
+                weight += 1.5
+            weights.append(weight)
+
+        total = sum(weights) or 1.0
+        usable_duration = max(0.05, duration - 0.08)
+        start = time.monotonic() + 0.02
         elapsed = 0.0
         for i, (word, weight) in enumerate(zip(words, weights)):
             if self._stop_flag.is_set():
                 break
-            on_word(word if i == 0 else " " + word)
-            elapsed += duration * (weight / total)
             sleep_time = (start + elapsed) - time.monotonic()
             if sleep_time > 0:
                 time.sleep(sleep_time)
+            on_word(word if i == 0 else " " + word)
+            elapsed += usable_duration * (weight / total)
 
     def _speak_thread_synced(self, text: str, on_word=None) -> None:
         """

--- a/core/think.py
+++ b/core/think.py
@@ -29,8 +29,24 @@ import time
 
 from core.memorize import AikoMemorize
 from core.speak    import AikoSpeak
-from core.tools    import web_search, fetch_and_extract, deep_search
+from core.tools    import (
+    web_search,
+    fetch_and_extract,
+    deep_search,
+    make_plan,
+    create_checklist,
+    save_note,
+    read_workspace_file,
+    summarize_task_state,
+    schedule_job,
+    list_schedule,
+    cancel_schedule,
+    schedule_reminder,
+    list_reminders,
+    cancel_reminder,
+)
 from core.log      import get_logger
+from core.schedule import DueJob, ScheduleRunner
 
 log = get_logger(__name__)
 
@@ -39,6 +55,7 @@ log = get_logger(__name__)
 BOOT_LABELS = {
     'think_start':  'Loading llama.cpp client + persona...',
     'think_warmup': 'Warming up language model...',
+    'think_reminders': 'Starting reminder scheduler...',
 }
 
 # ── config ────────────────────────────────────────────────────────────────────
@@ -51,7 +68,9 @@ _BASE_PREDICT    = 280
 _REASONING_SCALE = 3
 
 _PERSONA_PATH = Path(__file__).resolve().parent.parent / "persona" / "soul.md"
+_USER_PATH = Path(__file__).resolve().parent.parent / "persona" / "user.md"
 _SKILLS_PATH  = Path(__file__).resolve().parent.parent / "persona" / "skills.md"
+_SCHEDULE_PATH = Path(__file__).resolve().parent.parent / "persona" / "schedule.md"
 
 MAX_AGENT_ITER = 8
 
@@ -61,10 +80,12 @@ def _load_persona() -> str:
         raise FileNotFoundError(f"soul.md not found at {_PERSONA_PATH}")
     persona = _PERSONA_PATH.read_text(encoding="utf-8").strip()
     
-    skills_block = ""
-    if _SKILLS_PATH.exists():
-        skills_block = "\n\n" + _SKILLS_PATH.read_text(encoding="utf-8").strip()
-        
+    context_blocks = []
+    for path in (_USER_PATH, _SKILLS_PATH, _SCHEDULE_PATH):
+        if path.exists():
+            context_blocks.append(path.read_text(encoding="utf-8").strip())
+    skills_block = "\n\n" + "\n\n".join(context_blocks) if context_blocks else ""
+
     user_id = os.getenv("USER_ID", "OppaAI")
     today   = datetime.now().strftime("%B %d, %Y")
     return persona.replace("USER_ID_HERE", user_id).replace("TODAY_HERE", today) + skills_block
@@ -89,7 +110,13 @@ _FACTUAL_SIGNALS = frozenset([
 _FACTUAL_RE = re.compile(r'\b(?:' + '|'.join(re.escape(s) for s in _FACTUAL_SIGNALS) + r')\b', re.IGNORECASE)
 _SOCIAL_RE = re.compile(r'\b(?:' + '|'.join(re.escape(s) for s in _SOCIAL_SIGNALS) + r')\b', re.IGNORECASE)
 
-SKILL_TRIGGERS = ["research", "deep dive", "compare", "vs", "which is better", "difference between"]
+SKILL_TRIGGERS = [
+    "research", "deep dive", "compare", "vs", "which is better", "difference between",
+    "plan", "step by step", "help me", "organize", "checklist", "schedule",
+    "draft", "write", "make a", "create a", "build", "debug", "fix", "learn",
+    "apply", "prepare", "autonomous", "agent", "task",
+    "every monday", "weekly", "biweekly", "monthly", "weekdays",
+]
 
 # ── think ─────────────────────────────────────────────────────────────────────
 
@@ -111,6 +138,9 @@ class AikoThink:
         self._idle_learner_thread = threading.Thread(target=self._idle_learner_loop, daemon=True)
         self._idle_learner_thread.start()
 
+        self._reminders = ScheduleRunner(on_due=self._on_scheduled_job_due)
+        self._reminders.start()
+
         self._warmup_thread = threading.Thread(target=self._warmup_llm, daemon=True)
         self._warmup_thread.start()
 
@@ -131,39 +161,139 @@ class AikoThink:
     # ── public api ────────────────────────────────────────────────────────────
 
     def route(self, user_input: str, token_callback=None) -> str:
-        """Main entry point. Routes to agentic loop if skill triggered, else normal chat."""
+        """Main entry point. Uses keyword + semantic intent routing."""
         self._last_chat_time = time.time()
-        
-        # Simple skill router
-        is_skill = any(trigger in user_input.lower() for trigger in SKILL_TRIGGERS)
-        
-        if is_skill:
-            log.info(f"[route] Skill triggered. Entering agentic loop for: {user_input!r}")
+
+        intent = self._route_intent(user_input)
+        if intent != "chat":
+            log.info("[route] Agent intent=%s for: %r", intent, user_input)
             return self.agentic_chat(user_input, token_callback=token_callback)
         return self.chat(user_input, token_callback=token_callback)
 
-    def agentic_chat(self, user_input: str, token_callback=None) -> str:
-        """ReAct-style agentic loop with tool calling."""
-        tools = [
+    def _route_intent(self, user_input: str) -> str:
+        """Classify whether a turn needs autonomous task mode or normal chat."""
+        text = user_input.lower()
+        if any(trigger in text for trigger in SKILL_TRIGGERS):
+            return "keyword"
+        if re.search(r"\b(wake me|remind me|alarm|timer|every morning|every day|daily)\b", text):
+            return "reminder"
+        if _SOCIAL_RE.search(user_input):
+            return "chat"
+        return self._classify_agent_intent(user_input)
+
+    def _classify_agent_intent(self, user_input: str) -> str:
+        """Ask the local model for a compact route label when keywords miss."""
+        try:
+            resp = self._client.chat.completions.create(
+                model=LLAMACPP_MODEL,
+                messages=[{"role": "user", "content": (
+                    "Route message. Labels: chat, research, planning, writing, coding, "
+                    "decision, reminder, ongoing_task. Reply one label only.\n"
+                    f"Message: {user_input!r}"
+                )}],
+                stream=False, max_tokens=8, temperature=0.0,
+            )
+            label = (resp.choices[0].message.content or "chat").strip().lower()
+            label = re.sub(r"[^a-z_].*$", "", label)
+            return label if label in {
+                "research", "planning", "writing", "coding",
+                "decision", "reminder", "ongoing_task",
+            } else "chat"
+        except Exception as e:
+            log.warning("Intent routing failed: %s", e)
+            return "chat"
+
+
+    def _agent_tools(self) -> list[dict]:
+        """Return OpenAI-compatible tool schemas for autonomous task mode."""
+        return [
             {"type": "function", "function": {
-                "name": "web_search", "description": "Search the web for information.",
+                "name": "web_search", "description": "Search web.",
                 "parameters": {"type": "object", "properties": {
                     "query": {"type": "string", "description": "The search query."}},
                     "required": ["query"]}}},
             {"type": "function", "function": {
-                "name": "fetch_page", "description": "Fetch and extract full text from a specific URL.",
+                "name": "fetch_page", "description": "Fetch page text.",
                 "parameters": {"type": "object", "properties": {
                     "url": {"type": "string", "description": "The URL to fetch."}},
                     "required": ["url"]}}},
             {"type": "function", "function": {
-                "name": "final_answer", "description": "Submit the final comprehensive response to the user.",
+                "name": "make_plan", "description": "Make plan.",
+                "parameters": {"type": "object", "properties": {
+                    "goal": {"type": "string"},
+                    "constraints": {"type": "string"},
+                    "max_steps": {"type": "integer"}},
+                    "required": ["goal"]}}},
+            {"type": "function", "function": {
+                "name": "create_checklist", "description": "Make checklist.",
+                "parameters": {"type": "object", "properties": {
+                    "title": {"type": "string"},
+                    "items": {"type": "string", "description": "Newline-separated checklist items."}},
+                    "required": ["title", "items"]}}},
+            {"type": "function", "function": {
+                "name": "save_note", "description": "Save note/draft.",
+                "parameters": {"type": "object", "properties": {
+                    "title": {"type": "string"},
+                    "content": {"type": "string"},
+                    "folder": {"type": "string"}},
+                    "required": ["title", "content"]}}},
+            {"type": "function", "function": {
+                "name": "read_workspace_file", "description": "Read workspace file.",
+                "parameters": {"type": "object", "properties": {
+                    "relative_path": {"type": "string"}},
+                    "required": ["relative_path"]}}},
+            {"type": "function", "function": {
+                "name": "summarize_task_state", "description": "Summarize task state.",
+                "parameters": {"type": "object", "properties": {
+                    "goal": {"type": "string"}, "done": {"type": "string"},
+                    "next_action": {"type": "string"}, "risks": {"type": "string"}},
+                    "required": ["goal"]}}},
+            {"type": "function", "function": {
+                "name": "schedule_job", "description": "Schedule local job/alarm. HH:MM. Frequencies: once,daily,weekdays,weekly,biweekly,monthly,custom_weekdays.",
+                "parameters": {"type": "object", "properties": {
+                    "title": {"type": "string"}, "task": {"type": "string"},
+                    "time_of_day": {"type": "string", "description": "24-hour local time, e.g. 06:00"},
+                    "frequency": {"type": "string", "enum": ["once", "daily", "weekdays", "weekly", "biweekly", "monthly", "custom_weekdays"]},
+                    "timezone": {"type": "string"},
+                    "days_of_week": {"type": "string", "description": "Optional weekdays, e.g. Monday Wednesday Friday"},
+                    "action": {"type": "string", "enum": ["announce", "agentic"], "description": "announce only, or agentic to let Aiko perform a local autonomous task"}},
+                    "required": ["title", "task", "time_of_day"]}}},
+            {"type": "function", "function": {
+                "name": "list_schedule", "description": "List schedule.",
+                "parameters": {"type": "object", "properties": {
+                    "include_disabled": {"type": "boolean"}}}}},
+            {"type": "function", "function": {
+                "name": "cancel_schedule", "description": "Cancel schedule item.",
+                "parameters": {"type": "object", "properties": {
+                    "job_id": {"type": "string"}},
+                    "required": ["job_id"]}}},
+            {"type": "function", "function": {
+                "name": "schedule_reminder", "description": "Simple once/daily reminder.",
+                "parameters": {"type": "object", "properties": {
+                    "title": {"type": "string"}, "message": {"type": "string"},
+                    "time_of_day": {"type": "string"},
+                    "repeat": {"type": "string", "enum": ["once", "daily"]},
+                    "timezone": {"type": "string"}},
+                    "required": ["title", "message", "time_of_day"]}}},
+            {"type": "function", "function": {
+                "name": "final_answer", "description": "Final answer.",
                 "parameters": {"type": "object", "properties": {
                     "answer": {"type": "string", "description": "The final answer text."}},
                     "required": ["answer"]}}},
         ]
 
+    def agentic_chat(self, user_input: str, token_callback=None) -> str:
+        """ReAct-style agentic loop with tool calling."""
+        tools = self._agent_tools()
+
+        agent_system = (
+            f"{self._persona}\n\n"
+            "[TASK MODE] Plan briefly, use tools only when useful, and finish "
+            "with final_answer. Keep private reasoning private. Never claim work "
+            "outside available tools was completed."
+        )
         messages = [
-            {"role": "system", "content": self._persona},
+            {"role": "system", "content": agent_system},
             {"role": "user", "content": user_input},
         ]
 
@@ -204,6 +334,28 @@ class AikoThink:
                     result = deep_search(args.get("query", ""))
                 elif name == "fetch_page":
                     result = fetch_and_extract(args.get("url", ""))
+                elif name == "make_plan":
+                    result = make_plan(args.get("goal", ""), args.get("constraints", ""), int(args.get("max_steps", 8) or 8))
+                elif name == "create_checklist":
+                    result = create_checklist(args.get("title", "Checklist"), args.get("items", ""))
+                elif name == "save_note":
+                    result = save_note(args.get("title", "Aiko note"), args.get("content", ""), args.get("folder", "notes"))
+                elif name == "read_workspace_file":
+                    result = read_workspace_file(args.get("relative_path", ""))
+                elif name == "summarize_task_state":
+                    result = summarize_task_state(args.get("goal", ""), args.get("done", ""), args.get("next_action", ""), args.get("risks", ""))
+                elif name == "schedule_job":
+                    result = schedule_job(args.get("title", "Scheduled job"), args.get("task", "Scheduled job"), args.get("time_of_day", "06:00"), args.get("frequency", "daily"), args.get("timezone"), args.get("days_of_week"), args.get("action", "agentic"))
+                elif name == "list_schedule":
+                    result = list_schedule(bool(args.get("include_disabled", False)))
+                elif name == "cancel_schedule":
+                    result = cancel_schedule(args.get("job_id", ""))
+                elif name == "schedule_reminder":
+                    result = schedule_reminder(args.get("title", "Reminder"), args.get("message", "Reminder"), args.get("time_of_day", "06:00"), args.get("repeat", "daily"), args.get("timezone"))
+                elif name == "list_reminders":
+                    result = list_reminders(bool(args.get("include_disabled", False)))
+                elif name == "cancel_reminder":
+                    result = cancel_reminder(args.get("reminder_id", ""))
                 elif name == "final_answer":
                     final_text = args.get("answer", "")
                     messages.append({
@@ -327,6 +479,30 @@ class AikoThink:
     def set_reasoning(self, enabled: bool) -> None: self._reasoning = enabled
     def set_speak(self, speak) -> None: self._speak = speak
     def wait_for_memory(self) -> None: self._mem_queue.join()
+
+    def _on_scheduled_job_due(self, job: DueJob) -> None:
+        """Announce or execute a due scheduled job without blocking the scheduler."""
+        text = f"{job.title}. {job.task}"
+        log.info("[schedule] due %s action=%s: %s", job.id, job.action, text)
+        if job.action == "announce":
+            if self._speak:
+                self._speak.speak(text)
+            else:
+                print(f"\nAiko scheduled job: {text}", flush=True)
+            return
+        threading.Thread(target=self._run_scheduled_agentic_job, args=(job,), daemon=True).start()
+
+    def _run_scheduled_agentic_job(self, job: DueJob) -> None:
+        """Run a scheduled autonomous task through Aiko's agent loop."""
+        prompt = (
+            "Scheduled job due. Use only local available tools. If external action "
+            "is unavailable, draft/save the best local artifact and state next step.\n\n"
+            f"Title: {job.title}\nTask: {job.task}"
+        )
+        try:
+            self.agentic_chat(prompt)
+        except Exception as e:
+            log.error("Scheduled agentic job failed: %s", e)
 
     # ── idle learner ──────────────────────────────────────────────────────────
 

--- a/core/think.py
+++ b/core/think.py
@@ -42,6 +42,8 @@ from core.tools    import (
     list_schedule,
     cancel_schedule,
     schedule_reminder,
+    list_reminders,
+    cancel_reminder,
 )
 from core.log      import get_logger
 from core.schedule import DueJob, ScheduleRunner
@@ -274,6 +276,15 @@ class AikoThink:
                     "timezone": {"type": "string"}},
                     "required": ["title", "message", "time_of_day"]}}},
             {"type": "function", "function": {
+                "name": "list_reminders", "description": "List reminders.",
+                "parameters": {"type": "object", "properties": {
+                    "include_disabled": {"type": "boolean"}}}}},
+            {"type": "function", "function": {
+                "name": "cancel_reminder", "description": "Cancel reminder by id.",
+                "parameters": {"type": "object", "properties": {
+                    "reminder_id": {"type": "string"}},
+                    "required": ["reminder_id"]}}},
+            {"type": "function", "function": {
                 "name": "final_answer", "description": "Final answer.",
                 "parameters": {"type": "object", "properties": {
                     "answer": {"type": "string", "description": "The final answer text."}},
@@ -350,6 +361,10 @@ class AikoThink:
                     result = cancel_schedule(args.get("job_id", ""))
                 elif name == "schedule_reminder":
                     result = schedule_reminder(args.get("title", "Reminder"), args.get("message", "Reminder"), args.get("time_of_day", "06:00"), args.get("repeat", "daily"), args.get("timezone"))
+                elif name == "list_reminders":
+                    result = list_reminders(bool(args.get("include_disabled", False)))
+                elif name == "cancel_reminder":
+                    result = cancel_reminder(args.get("reminder_id", ""))
                 elif name == "final_answer":
                     final_text = args.get("answer", "")
                     messages.append({

--- a/core/think.py
+++ b/core/think.py
@@ -42,8 +42,6 @@ from core.tools    import (
     list_schedule,
     cancel_schedule,
     schedule_reminder,
-    list_reminders,
-    cancel_reminder,
 )
 from core.log      import get_logger
 from core.schedule import DueJob, ScheduleRunner
@@ -352,10 +350,6 @@ class AikoThink:
                     result = cancel_schedule(args.get("job_id", ""))
                 elif name == "schedule_reminder":
                     result = schedule_reminder(args.get("title", "Reminder"), args.get("message", "Reminder"), args.get("time_of_day", "06:00"), args.get("repeat", "daily"), args.get("timezone"))
-                elif name == "list_reminders":
-                    result = list_reminders(bool(args.get("include_disabled", False)))
-                elif name == "cancel_reminder":
-                    result = cancel_reminder(args.get("reminder_id", ""))
                 elif name == "final_answer":
                     final_text = args.get("answer", "")
                     messages.append({

--- a/core/tools.py
+++ b/core/tools.py
@@ -1,14 +1,57 @@
 """
 core/tools.py
 
-Aiko's tool belt — web search via SearXNG, deep page fetching, and bundling.
-All tools are plain functions that return strings ready for context injection.
+Aiko's tool belt for autonomous work.
+
+The functions in this module are intentionally small, explicit, and boring:
+plain Python callables that return strings safe to inject back into an LLM
+context.  `think.py` decides *when* to use a tool; this module decides *how*
+the work is performed and how failures are reported.
+
+Capabilities:
+  - Web search through SearXNG.
+  - Main-text extraction from individual pages.
+  - Deep-search bundles for research tasks.
+  - Lightweight planning, checklist, note, and file helpers for practical
+    multi-step tasks.
+  - Persistent local scheduled jobs for reminders, wake-up alarms, and recurring tasks.
+
+Safety model:
+  - File helpers are restricted to AIKO_WORKSPACE_ROOT (default: ./workspace).
+  - Shell execution is intentionally not exposed here.  Aiko should explain
+    commands to run, not run arbitrary system commands on behalf of the user.
 """
 
+from __future__ import annotations
+
+import json
 import os
-import requests
-import trafilatura
+import re
+import textwrap
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+try:
+    import requests
+except ImportError:  # pragma: no cover - dependency may be absent in text-only installs
+    requests = None
+
+try:
+    import trafilatura
+except ImportError:  # pragma: no cover - dependency may be absent in text-only installs
+    trafilatura = None
+
 from core.log import get_logger
+from core.schedule import (
+    cancel_reminder_record,
+    cancel_schedule_record,
+    list_reminder_records,
+    list_schedule_records,
+    schedule_job_record,
+    schedule_reminder_record,
+)
 
 log = get_logger(__name__)
 
@@ -16,11 +59,50 @@ log = get_logger(__name__)
 
 SEARXNG_URL = os.getenv("SEARXNG_URL", "http://localhost:8081")
 MAX_RESULTS = int(os.getenv("SEARXNG_MAX_RESULTS", 5))
+WORKSPACE_ROOT = Path(os.getenv("AIKO_WORKSPACE_ROOT", "workspace")).resolve()
+NOTES_DIR = WORKSPACE_ROOT / "notes"
+MAX_WRITE_CHARS = int(os.getenv("AIKO_MAX_WRITE_CHARS", 20_000))
+MAX_READ_CHARS = int(os.getenv("AIKO_MAX_READ_CHARS", 12_000))
+
+# ── formatting helpers ────────────────────────────────────────────────────────
+
+def _now_stamp() -> str:
+    """Return a compact UTC timestamp for generated notes and plans."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+
+def _slugify(text: str, fallback: str = "task") -> str:
+    """Create a stable lowercase file slug from arbitrary user text."""
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", text.lower()).strip("-")
+    return (slug or fallback)[:80]
+
+
+def _safe_path(relative_path: str) -> Path:
+    """Resolve a user path under WORKSPACE_ROOT, rejecting path traversal."""
+    cleaned = relative_path.strip().lstrip("/\\")
+    path = (WORKSPACE_ROOT / cleaned).resolve()
+    if path != WORKSPACE_ROOT and WORKSPACE_ROOT not in path.parents:
+        raise ValueError(f"path escapes workspace: {relative_path}")
+    return path
+
+
+def _json_block(title: str, payload: dict[str, Any]) -> str:
+    """Render machine-readable tool output with a short human title."""
+    return f"[{title}]\n" + json.dumps(payload, ensure_ascii=False, indent=2)
+
 
 # ── web search ────────────────────────────────────────────────────────────────
 
 def web_search(query: str, max_results: int = MAX_RESULTS) -> str:
-    """Search the web via SearXNG and return a compact result string."""
+    """
+    Search the web via SearXNG and return compact numbered results.
+
+    Returns a readable string rather than raw JSON because local models follow
+    that format more reliably during ReAct-style loops.  Failures are encoded as
+    bracketed messages (`[search failed: ...]`) so callers can continue safely.
+    """
+    if requests is None:
+        return "[search failed: requests is not installed]"
     try:
         response = requests.get(
             f"{SEARXNG_URL}/search",
@@ -33,52 +115,233 @@ def web_search(query: str, max_results: int = MAX_RESULTS) -> str:
         return f"[search failed: {e}]"
     except ValueError:
         return "[search failed: invalid JSON response]"
-        
+
     results = data.get("results", [])[:max_results]
     if not results:
         return f"[no results found for: {query}]"
 
     lines = [f"[Web search results for: {query}]"]
-    for i, r in enumerate(results, 1):
-        title   = r.get("title", "").strip()
-        url     = r.get("url", "").strip()
-        content = r.get("content", "").strip()
+    for i, result in enumerate(results, 1):
+        title = result.get("title", "").strip()
+        url = result.get("url", "").strip()
+        content = result.get("content", "").strip()
         lines.append(f"{i}. {title}\n   {url}\n   {content}")
 
     return "\n\n".join(lines)
 
+
 def fetch_and_extract(url: str, max_chars: int = 4000) -> str:
-    """Fetch a URL and extract its main text content using trafilatura."""
+    """
+    Fetch a URL and extract its main article/body text with trafilatura.
+
+    The result is truncated to `max_chars` to protect the context window.  Only
+    HTTP(S) URLs are accepted; unsupported schemes return a failure string.
+    """
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return f"[fetch failed: unsupported URL scheme: {parsed.scheme or 'none'}]"
+    if trafilatura is None:
+        return "[fetch failed: trafilatura is not installed]"
     try:
         downloaded = trafilatura.fetch_url(url)
         if not downloaded:
             return "[fetch failed: empty response]"
         text = trafilatura.extract(downloaded, include_links=False, include_tables=False) or ""
-        return text[:max_chars]
+        return text[:max_chars] if text else "[fetch failed: no extractable text]"
     except Exception as e:
         return f"[fetch failed: {e}]"
 
+
 def deep_search(query: str, max_results: int = 3, fetch_top: int = 2) -> str:
-    """Search → fetch top N pages → return compact bundle."""
+    """
+    Search, fetch the top pages, and return one compact research bundle.
+
+    This is the preferred tool for questions where snippets may be too shallow:
+    comparisons, fact checks, current events, and practical how-to tasks.
+    """
     raw_results = web_search(query, max_results)
     if raw_results.startswith("[search failed") or raw_results.startswith("[no results"):
         return raw_results
 
     bundle = [raw_results]
-    result_blocks = raw_results.split("\n\n")[1:]  # skip the header line
+    result_blocks = raw_results.split("\n\n")[1:]
 
-    for i, r in enumerate(result_blocks[:fetch_top], 1):
-        url = next((l.strip() for l in r.splitlines() if l.strip().startswith("http")), None)
-        if url:
-            page = fetch_and_extract(url)
-            if not page.startswith("[fetch failed"):
-                bundle.append(f"\n[Full page {i}: {url}]\n{page[:2000]}")
+    for i, result in enumerate(result_blocks[:fetch_top], 1):
+        url = next((line.strip() for line in result.splitlines() if line.strip().startswith("http")), None)
+        if not url:
+            continue
+        page = fetch_and_extract(url)
+        if not page.startswith("[fetch failed"):
+            bundle.append(f"\n[Full page {i}: {url}]\n{page[:2000]}")
 
     return "\n\n".join(bundle)
 
+
 def web_search_context(query: str, max_results: int = MAX_RESULTS) -> str | None:
-    """Run a standard web search and return a context-ready prompt string."""
+    """Run web_search and wrap successful results as context for chat mode."""
     results = web_search(query, max_results)
     if results.startswith("[search failed") or results.startswith("[no results"):
         return None
-    return f"[Web search results for: {query}]\n\n{results}\n\nUser asked: {query}"
+    return f"{results}\n\nUser asked: {query}"
+
+
+# ── autonomous planning tools ─────────────────────────────────────────────────
+
+def make_plan(goal: str, constraints: str = "", max_steps: int = 8) -> str:
+    """
+    Create a pragmatic step-by-step plan for a real-world or digital task.
+
+    The plan is heuristic rather than LLM-generated so it can be used as a tool
+    observation inside an agent loop.  Aiko can then refine it in language.
+    """
+    max_steps = max(3, min(max_steps, 12))
+    generic_steps = [
+        "Clarify the desired outcome and success criteria.",
+        "List known facts, constraints, deadlines, and missing information.",
+        "Gather the minimum information needed before acting.",
+        "Break the work into small reversible actions.",
+        "Do the highest-impact safe action first.",
+        "Check the result against the success criteria.",
+        "Adjust the plan if new information changes the situation.",
+        "Summarize what was done, what remains, and the next best action.",
+    ][:max_steps]
+    payload = {
+        "goal": goal,
+        "constraints": constraints or "none stated",
+        "created_at": _now_stamp(),
+        "steps": generic_steps,
+    }
+    return _json_block("plan created", payload)
+
+
+def create_checklist(title: str, items: list[str] | str) -> str:
+    """
+    Build a markdown checklist from a list or newline-separated string.
+
+    Useful when the user wants Aiko to help execute a complicated workflow over
+    multiple turns: moving, studying, debugging, shopping, launching a project,
+    or planning a trip.
+    """
+    if isinstance(items, str):
+        item_list = [line.strip(" -\t") for line in items.splitlines() if line.strip()]
+    else:
+        item_list = [str(item).strip() for item in items if str(item).strip()]
+    if not item_list:
+        item_list = ["Define the first concrete action."]
+    markdown = [f"# {title}", "", f"Created: {_now_stamp()}", ""]
+    markdown.extend(f"- [ ] {item}" for item in item_list)
+    return "\n".join(markdown)
+
+
+def save_note(title: str, content: str, folder: str = "notes") -> str:
+    """
+    Save a note, plan, draft, or task artifact under AIKO_WORKSPACE_ROOT.
+
+    The default location is `workspace/notes`.  Content is truncated at
+    MAX_WRITE_CHARS to avoid accidental huge writes.
+    """
+    base = NOTES_DIR if folder == "notes" else _safe_path(folder)
+    base.mkdir(parents=True, exist_ok=True)
+    filename = f"{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{_slugify(title)}.md"
+    path = base / filename
+    body = content[:MAX_WRITE_CHARS]
+    path.write_text(body, encoding="utf-8")
+    return _json_block("note saved", {"path": str(path), "chars": len(body)})
+
+
+def read_workspace_file(relative_path: str, max_chars: int = MAX_READ_CHARS) -> str:
+    """Read a text file from AIKO_WORKSPACE_ROOT for continuation or review."""
+    try:
+        path = _safe_path(relative_path)
+        if not path.exists() or not path.is_file():
+            return f"[read failed: file not found: {relative_path}]"
+        return path.read_text(encoding="utf-8", errors="replace")[:max_chars]
+    except Exception as e:
+        return f"[read failed: {e}]"
+
+
+def summarize_task_state(goal: str, done: str = "", next_action: str = "", risks: str = "") -> str:
+    """
+    Produce a compact task-state snapshot that can be saved or spoken aloud.
+
+    This helps Aiko behave like a persistent autonomous entity: she can state the
+    current objective, completed work, next action, and risks without pretending
+    she has performed actions outside her tools.
+    """
+    summary = textwrap.dedent(f"""
+        # Task State
+
+        **Goal:** {goal}
+        **Updated:** {_now_stamp()}
+
+        ## Done
+        {done or 'Nothing completed yet.'}
+
+        ## Next Action
+        {next_action or 'Choose the smallest safe next step.'}
+
+        ## Risks / Unknowns
+        {risks or 'No specific risks recorded.'}
+    """).strip()
+    return summary
+
+# ── schedule tools ─────────────────────────────────────────────────────────────
+
+def schedule_job(
+    title: str,
+    task: str,
+    time_of_day: str,
+    frequency: str = "daily",
+    timezone: str | None = None,
+    days_of_week: list[str] | str | None = None,
+    action: str = "agentic",
+) -> str:
+    """Schedule a local recurring job while Aiko is running."""
+    try:
+        job = schedule_job_record(title, task, time_of_day, frequency, timezone, days_of_week, action)
+        return _json_block("scheduled job created", job)
+    except Exception as e:
+        return f"[schedule failed: {e}]"
+
+
+def list_schedule(include_disabled: bool = False) -> str:
+    """List local scheduled jobs from Aiko's schedule file."""
+    jobs = list_schedule_records(include_disabled=include_disabled)
+    return _json_block("schedule", {"count": len(jobs), "items": jobs})
+
+
+def cancel_schedule(job_id: str) -> str:
+    """Cancel/disable a local scheduled job by id."""
+    if cancel_schedule_record(job_id):
+        return _json_block("scheduled job cancelled", {"id": job_id})
+    return f"[scheduled job not found: {job_id}]"
+
+
+# ── reminder compatibility tools ──────────────────────────────────────────────
+
+def schedule_reminder(
+    title: str,
+    message: str,
+    time_of_day: str,
+    repeat: str = "daily",
+    timezone: str | None = None,
+) -> str:
+    """Schedule a local reminder/alarm while Aiko is running."""
+    try:
+        reminder = schedule_reminder_record(title, message, time_of_day, repeat, timezone)
+        return _json_block("reminder scheduled", reminder)
+    except Exception as e:
+        return f"[reminder failed: {e}]"
+
+
+def list_reminders(include_disabled: bool = False) -> str:
+    """List reminders stored in Aiko's local reminder file."""
+    reminders = list_reminder_records(include_disabled=include_disabled)
+    return _json_block("reminders", {"count": len(reminders), "items": reminders})
+
+
+def cancel_reminder(reminder_id: str) -> str:
+    """Cancel/disable a local reminder by id."""
+    if cancel_reminder_record(reminder_id):
+        return _json_block("reminder cancelled", {"id": reminder_id})
+    return f"[reminder not found: {reminder_id}]"

--- a/persona/schedule.md
+++ b/persona/schedule.md
@@ -1,0 +1,27 @@
+# Aiko Schedule
+
+Aiko can keep local scheduled jobs while she is running. This is not cron, a calendar app, or an OS alarm.
+
+## Fields
+
+- **title:** short name, e.g. `Wake up`, `Daily report`.
+- **task:** what to say or do when due.
+- **time_of_day:** 24-hour `HH:MM`, e.g. `06:00`.
+- **frequency:** `once`, `daily`, `weekdays`, `weekly`, `biweekly`, `monthly`, or `custom_weekdays`.
+- **days_of_week:** optional for `weekly`/`custom_weekdays`, e.g. `Monday Wednesday Friday`.
+- **timezone:** optional IANA timezone; otherwise use configured local timezone.
+- **action:** `announce` for reminders/alarms, `agentic` for local work.
+
+## Examples
+
+- "Wake me up every morning at 6am" → `time_of_day="06:00"`, `frequency="daily"`, `action="announce"`.
+- "Remind me every Monday at 9am" → `frequency="weekly"`, `days_of_week="Monday"`, `action="announce"`.
+- "Write my daily report at 5pm" → `frequency="daily"`, `action="agentic"`; draft/save locally.
+- "Send an email every Friday" → draft/stage locally only; cannot actually send without an email tool.
+
+## Limits
+
+- Jobs run only while Aiko is open on an awake machine.
+- Aiko cannot wake a powered-off/sleeping computer.
+- Critical alarms need a phone/OS alarm too.
+- No external send/post/buy/book/delete claims unless a real tool exists.

--- a/persona/skills.md
+++ b/persona/skills.md
@@ -1,72 +1,31 @@
-# AI Assistant Skills
+# Aiko Skills
 
----
+Aiko can chat normally, or enter autonomous task mode when the user wants research, planning, writing, coding help, decisions, schedules, reminders, or ongoing task tracking.
 
-## Skill 1: Deep Research
+## Autonomous Loop
 
-**Triggers:** "research", "deep dive", "explain in depth", "tell me everything about", "what is the full story on"
+1. Clarify the goal only if required details are missing.
+2. Make a short plan for multi-step work.
+3. Use tools when they help: search/fetch for current facts, schedule tools for timed jobs, note/checklist tools for reusable artifacts.
+4. Do the smallest useful safe action first.
+5. Report the result, limits, and next step.
 
-**Procedure:**
+Rules:
+- Keep private chain-of-thought private; share concise reasoning and assumptions.
+- Never claim external actions happened unless a real tool did them.
+- For medical/legal/financial/high-risk topics, be cautious and recommend professional help when appropriate.
 
-1. Call `web_search` with the topic to get an overview and find top sources.
-2. Pick the 2 most relevant URLs from the search results.
-3. Call `fetch_page` on both URLs to read the full text.
-4. Combine the information. Ignore irrelevant details.
-5. Call `final_answer` with a structured report containing:
-   - **Overview:** A short summary of the topic.
-   - **Key Facts:** 3–4 bullet points of the most important information.
-   - **Sources:** A list of the URLs you read.
+## Skill Routes
 
----
+- **Research/current info:** search, fetch if snippets are insufficient, answer with caveats and sources.
+- **Fact check:** compare independent sources; verdict is TRUE, FALSE, MIXED, or UNCLEAR.
+- **Compare/decide:** identify criteria, make a table when useful, recommend based on user needs.
+- **Practical planning:** create steps/checklists for routines, trips, study, moving, budgets, appointments, and preparation.
+- **Coding/debugging:** restate expected behavior, isolate symptoms, suggest patch/commands/tests, avoid inventing unseen files.
+- **Writing:** draft/rewrite emails, messages, resumes, posts, scripts; ask for audience/tone only if missing.
+- **Ongoing tasks:** summarize done/next/risks and save state when useful.
+- **Scheduled jobs:** use `schedule_job` with `action: announce` for alarms/reminders and `action: agentic` for local autonomous tasks such as drafting reports or saving notes. Follow `persona/schedule.md`.
 
-## Skill 2: Fact-Checking
+## Voice Output
 
-**Triggers:** "is it true that", "fact check", "verify", "did X really happen", "is this a scam"
-
-**Procedure:**
-
-1. Call `web_search` with the claim to see what sources say.
-2. Call `fetch_page` on at least 2 different URLs to verify the claim across multiple sources.
-3. Evaluate the evidence.
-4. Call `final_answer` stating clearly:
-   - **Verdict:** TRUE, FALSE, or MIXED.
-   - **Evidence:** What the sources actually said.
-   - **Sources:** The URLs used to verify.
-
----
-
-## Skill 3: Comparisons
-
-**Triggers:** "compare", "vs", "versus", "which is better", "difference between"
-
-**Procedure:**
-
-1. Call `web_search` for the first option to get its specs/pros/cons.
-2. Call `web_search` for the second option to get its specs/pros/cons.
-3. If the search snippets don't have enough detail, call `fetch_page` on a review page.
-4. Call `final_answer` with:
-   - A markdown table comparing the two options side-by-side.
-   - A recommendation based on the user's likely needs.
-
----
-
-## Skill 4: Latest News & Current Events
-
-**Triggers:** "latest", "news", "current", "what happened with", "update on"
-
-**Procedure:**
-
-1. Call `web_search` with the topic (the search engine will prioritize recent results).
-2. Call `fetch_page` on the top news article URL to get the full story, not just the headline.
-3. Call `final_answer` with:
-   - A 2–3 sentence summary of the latest developments.
-   - The source URL.
-
----
-
-## General Rules for Tool Use
-
-- If a `web_search` result has a snippet that fully answers the question, you do not always need to call `fetch_page`. Just go straight to `final_answer`.
-- If a `fetch_page` fails or returns an error, try fetching a different URL from the search results.
-- Never invent URLs. Only use URLs returned by `web_search`.
-- Always use `final_answer` to deliver the response to the user. Do not just output text without calling the tool.
+For spoken replies, use clear sentence chunks, avoid noisy markdown, and summarize before details when the answer is long.

--- a/persona/user.md
+++ b/persona/user.md
@@ -1,0 +1,12 @@
+# User Profile
+
+Use this as stable context about the user. Do not invent details beyond this file or retrieved memories.
+
+- Name/handle: OppaAI.
+- Location: Beautiful British Columbia, Canada.
+- Pronouns/reference: address him as "you" or "Oppa" in conversation.
+- Main project: building Aiko-chan as a local AI companion with memory, voice, scheduling, tools, and autonomous task support.
+- Preferences: direct answers first, practical engineering detail when useful, no hollow praise, no fake positivity.
+- Collaboration style: challenge bad ideas plainly, then help fix them; teasing is okay when it stays light.
+- Current product goal: make Aiko feel less like a research bot and more like a reliable autonomous companion that can plan, remember, schedule, draft, and follow through using available tools.
+- Safety/limits preference: be honest about what Aiko can and cannot actually do.


### PR DESCRIPTION
### Motivation

- Provide a simple local-first scheduler/reminder system so Aiko can store and fire scheduled jobs and reminders while running.
- Expand autonomous agent capabilities with small deterministic tools (planning, checklist, notes, file read) that are safe to expose to the agent loop.
- Improve intent routing to decide when to enter agentic/task mode and start a background scheduler to handle due jobs.
- Make TTS on-screen word emission more natural by pacing words based on estimated speech duration and punctuation.

### Description

- Adds `core/schedule.py` implementing persistent local scheduled jobs, migration from legacy reminders, next-due calculations, and a `ScheduleRunner` background poller that triggers `DueJob` events. 
- Extends `core/tools.py` with search/fetch helpers, `make_plan`, `create_checklist`, `save_note`, `read_workspace_file`, `summarize_task_state` and safe schedule/reminder wrappers that use the scheduler; also adds workspace path safety, slug/JSON helpers, and improved web/fetch formatting.
- Integrates the new tools and scheduler into `core/think.py` by adding intent routing (`_route_intent` / `_classify_agent_intent`), supplying tool schemas to the agentic loop, starting a `ScheduleRunner` on boot, and handling due jobs by announcing or running an agentic job in a separate thread.
- Improves TTS pacing in `core/speak.py` by weighting words (length + punctuation) and aligning emitted words to the synthesized audio duration.
- Adds persona/context files `persona/user.md` and `persona/schedule.md`, and updates `persona/skills.md` to describe autonomous loop behavior and scheduling guidance.

### Testing

- Ran lightweight automated smoke imports and function checks with quick Python commands: `python -c "from core.schedule import calculate_next_due; print(calculate_next_due('06:00'))"` and `python -c "from core.tools import schedule_job; print(schedule_job('Test','Do X','06:00'))"`, and both calls returned expected, parseable outputs.
- Exercised tooling paths via scripted calls for `make_plan`, `create_checklist`, `save_note`, and `read_workspace_file` which returned JSON/markdown blocks and did not raise exceptions in the test environment.
- Performed a scheduler-runner smoke check by instantiating `ScheduleRunner(on_due=...)` and invoking `_fire_due()` against a small test schedule file; the runner discovered and emitted due events as expected.
- No full integration test suite was changed; these tests are lightweight automated smoke checks and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3416ac6780832c8bf69ecea184414c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Local scheduling system for recurring jobs and reminders with timezone support
  * Autonomous task mode with planning, checklists, notes, and workspace tools
  * Enhanced intent routing for intelligent request handling

* **Improvements**
  * Refined speech pacing for better word-timing accuracy
  * Expanded agentic capabilities with structured task management
  * Improved error handling for scheduled jobs

* **Documentation**
  * Added scheduling guide with operational limits
  * Updated autonomous workflow documentation
  * New user profile context configuration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->