### PR TITLE
Migrate local LLM calls to OpenAI client, batch memory ops, and harden agent/think flows

### DIFF
--- a/core/agentic.py
+++ b/core/agentic.py
@@ -31,11 +31,26 @@ from core.tools import (
 log = get_logger(__name__)
 
 MAX_AGENT_ITER = int(os.getenv("MAX_AGENT_ITER", 8))
+AGENT_MAX_TOKENS = int(os.getenv("AGENT_MAX_TOKENS", os.getenv("LLM_MAX_TOKENS", 280)))
+
+
+def _tool(schema: dict):
+    """Decorator used to keep schemas and dispatch handlers in one registry."""
+    def decorator(func):
+        _TOOLS[schema["function"]["name"]] = (schema, func)
+        return func
+    return decorator
+
+
+_TOOLS: dict[str, tuple[dict, object]] = {}
 
 
 def tool_schemas() -> list[dict]:
     """Return OpenAI-compatible tool schemas for autonomous task mode."""
-    return [
+    return [schema for schema, _handler in _TOOLS.values()]
+
+
+_TOOL_SCHEMAS = [
         {"type": "function", "function": {
             "name": "web_search", "description": "Search web.",
             "parameters": {"type": "object", "properties": {
@@ -121,35 +136,36 @@ def tool_schemas() -> list[dict]:
     ]
 
 
+def _register_tools() -> None:
+    handlers = {
+        "web_search": lambda args: deep_search(args.get("query", "")),
+        "fetch_page": lambda args: fetch_and_extract(args.get("url", "")),
+        "make_plan": lambda args: make_plan(args.get("goal", ""), args.get("constraints", ""), int(args.get("max_steps", 8) or 8)),
+        "create_checklist": lambda args: create_checklist(args.get("title", "Checklist"), args.get("items", "")),
+        "save_note": lambda args: save_note(args.get("title", "Aiko note"), args.get("content", ""), args.get("folder", "notes")),
+        "read_workspace_file": lambda args: read_workspace_file(args.get("relative_path", "")),
+        "summarize_task_state": lambda args: summarize_task_state(args.get("goal", ""), args.get("done", ""), args.get("next_action", ""), args.get("risks", "")),
+        "schedule_job": lambda args: schedule_job(args.get("title", "Scheduled job"), args.get("task", "Scheduled job"), args.get("time_of_day", "06:00"), args.get("frequency", "daily"), args.get("timezone"), args.get("days_of_week"), args.get("action", "agentic")),
+        "list_schedule": lambda args: list_schedule(bool(args.get("include_disabled", False))),
+        "cancel_schedule": lambda args: cancel_schedule(args.get("job_id", "")),
+        "schedule_reminder": lambda args: schedule_reminder(args.get("title", "Reminder"), args.get("message", "Reminder"), args.get("time_of_day", "06:00"), args.get("repeat", "daily"), args.get("timezone")),
+        "list_reminders": lambda args: list_reminders(bool(args.get("include_disabled", False))),
+        "cancel_reminder": lambda args: cancel_reminder(args.get("reminder_id", "")),
+    }
+    for schema in _TOOL_SCHEMAS:
+        name = schema["function"]["name"]
+        _TOOLS[name] = (schema, handlers.get(name, lambda _args, n=name: f"[unknown tool: {n}]"))
+
+
+_register_tools()
+
+
 def dispatch_tool(name: str, args: dict) -> str:
     """Run one named tool with already-decoded JSON args."""
-    if name == "web_search":
-        return deep_search(args.get("query", ""))
-    if name == "fetch_page":
-        return fetch_and_extract(args.get("url", ""))
-    if name == "make_plan":
-        return make_plan(args.get("goal", ""), args.get("constraints", ""), int(args.get("max_steps", 8) or 8))
-    if name == "create_checklist":
-        return create_checklist(args.get("title", "Checklist"), args.get("items", ""))
-    if name == "save_note":
-        return save_note(args.get("title", "Aiko note"), args.get("content", ""), args.get("folder", "notes"))
-    if name == "read_workspace_file":
-        return read_workspace_file(args.get("relative_path", ""))
-    if name == "summarize_task_state":
-        return summarize_task_state(args.get("goal", ""), args.get("done", ""), args.get("next_action", ""), args.get("risks", ""))
-    if name == "schedule_job":
-        return schedule_job(args.get("title", "Scheduled job"), args.get("task", "Scheduled job"), args.get("time_of_day", "06:00"), args.get("frequency", "daily"), args.get("timezone"), args.get("days_of_week"), args.get("action", "agentic"))
-    if name == "list_schedule":
-        return list_schedule(bool(args.get("include_disabled", False)))
-    if name == "cancel_schedule":
-        return cancel_schedule(args.get("job_id", ""))
-    if name == "schedule_reminder":
-        return schedule_reminder(args.get("title", "Reminder"), args.get("message", "Reminder"), args.get("time_of_day", "06:00"), args.get("repeat", "daily"), args.get("timezone"))
-    if name == "list_reminders":
-        return list_reminders(bool(args.get("include_disabled", False)))
-    if name == "cancel_reminder":
-        return cancel_reminder(args.get("reminder_id", ""))
-    return f"[unknown tool: {name}]"
+    entry = _TOOLS.get(name)
+    if not entry:
+        return f"[unknown tool: {name}]"
+    return entry[1](args)
 
 
 def run_agentic_chat(owner, user_input: str, token_callback=None) -> str:
@@ -176,6 +192,7 @@ def run_agentic_chat(owner, user_input: str, token_callback=None) -> str:
 
     final_text = ""
     last_content = ""
+    seen_calls: set[tuple[str, str]] = set()
 
     for step in range(MAX_AGENT_ITER):
         if token_callback:
@@ -184,7 +201,7 @@ def run_agentic_chat(owner, user_input: str, token_callback=None) -> str:
         try:
             resp = owner._client.chat.completions.create(
                 model=owner._llm_model, messages=messages, tools=tools,
-                tool_choice="auto", stream=False, max_tokens=1024,
+                tool_choice="auto", stream=False, max_tokens=AGENT_MAX_TOKENS,
                 temperature=0.3,
             )
             msg = resp.choices[0].message
@@ -206,6 +223,15 @@ def run_agentic_chat(owner, user_input: str, token_callback=None) -> str:
                 args = {}
 
             log.info("[agent] step %s → %s(%s)", step, name, args)
+            call_key = (name, json.dumps(args, sort_keys=True))
+            if call_key in seen_calls:
+                result = f"[loop guard: repeated tool call skipped for {name}]"
+                messages.append({
+                    "role": "tool", "tool_call_id": call.id,
+                    "name": name, "content": result,
+                })
+                continue
+            seen_calls.add(call_key)
             if token_callback:
                 token_callback(f"__TOOL__:{name}({args})\n")
 

--- a/core/memorize.py
+++ b/core/memorize.py
@@ -1,6 +1,6 @@
 """
 core/memorize.py
-Aiko's persistent memory — custom backend via sqlite-vec + fastembed + Ollama.
+Aiko's persistent memory — custom backend via sqlite-vec + fastembed + llama.cpp.
 Abstracts all memory calls so think.py stays clean.
 
 Memory lifecycle:
@@ -65,8 +65,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-import httpx
 import sqlite_vec
+from openai import OpenAI
 from fastembed import TextEmbedding
 
 from core.forget import compute_weighted_score, should_cleanup, CLEANUP_THRESHOLD
@@ -289,6 +289,20 @@ def _sqlite_is_pinned(conn: sqlite3.Connection, mem_id: str) -> bool:
     return bool(row and row[0])
 
 
+
+
+def _sqlite_pinned_ids(conn: sqlite3.Connection, mem_ids: list[str]) -> set[str]:
+    """Batch fetch pinned memory IDs from the canonical table."""
+    ids = [str(mem_id) for mem_id in mem_ids if mem_id]
+    if not ids:
+        return set()
+    placeholders = ",".join("?" * len(ids))
+    rows = conn.execute(
+        f"SELECT id FROM memories WHERE pinned = 1 AND id IN ({placeholders})",
+        ids,
+    ).fetchall()
+    return {str(row["id"]) for row in rows}
+
 def _sqlite_knn_search(
     conn: sqlite3.Connection,
     vector: list[float],
@@ -348,14 +362,15 @@ class _MemoryBackend:
     def __init__(
         self,
         db_path:         str,
-        ollama_base_url: str,
+        llm_base_url:    str,
         model:           str,
         fastembed_cache: Optional[str] = None,
     ) -> None:
         Path(db_path).parent.mkdir(parents=True, exist_ok=True)
         self._db_path  = db_path
-        self._ollama   = ollama_base_url.rstrip("/")
+        self._llm_base = llm_base_url.rstrip("/")
         self._model    = model
+        self._client   = OpenAI(base_url=self._llm_base, api_key="not-needed")
         self._embedder = TextEmbedding(
             model_name=EMBED_MODEL,
             cache_dir=fastembed_cache,
@@ -400,7 +415,7 @@ class _MemoryBackend:
 
     def _extract_facts(self, messages: list[dict]) -> list[str]:
         """
-        Send conversation to Ollama LLM and parse the returned JSON fact array.
+        Send conversation to the OpenAI-compatible local LLM and parse the returned JSON fact array.
 
         Changes from original:
           - temperature=0.0 for deterministic output — reduces confabulation.
@@ -440,22 +455,15 @@ class _MemoryBackend:
         prompt = _EXTRACT_PROMPT.format(conversation=convo)
 
         try:
-            resp = httpx.post(
-                f"{self._ollama}/api/chat",
-                json={
-                    "model":    self._model,
-                    "messages": [{"role": "user", "content": prompt}],
-                    "stream":   False,
-                    "options": {
-                        "temperature": 0.0,   # deterministic — reduces hallucinated facts
-                        "num_predict": 512,
-                        "num_ctx": int(os.getenv("OLLAMA_NUM_CTX", 4096)),
-                    },
-                },
+            resp = self._client.chat.completions.create(
+                model=self._model,
+                messages=[{"role": "user", "content": prompt}],
+                stream=False,
+                max_tokens=512,
+                temperature=0.0,  # deterministic — reduces hallucinated facts
                 timeout=45,
             )
-            resp.raise_for_status()
-            raw = resp.json()["message"]["content"].strip()
+            raw = (resp.choices[0].message.content or "").strip()
         except Exception as e:
             log.warning(f"Extraction LLM call failed: {e}")
             return []
@@ -700,8 +708,8 @@ class AikoMemorize:
 
         self._mem = _MemoryBackend(
             db_path=db_path,
-            ollama_base_url=os.getenv("OLLAMA_BASE_URL", "http://localhost:11434"),
-            model=os.getenv("EXTRACT_MODEL") or os.getenv("OLLAMA_MODEL"),
+            llm_base_url=os.getenv("LLAMACPP_BASE_URL", "http://localhost:8080/v1"),
+            model=os.getenv("EXTRACT_MODEL") or os.getenv("LLAMACPP_MODEL", "ministral-3b-instruct"),
             fastembed_cache=os.getenv("FASTEMBED_CACHE_PATH"),
         )
         self._conn = self._mem._conn
@@ -809,7 +817,9 @@ class AikoMemorize:
             "",
         ]
         for m in memories:
-            text       = m.get("memory") or m.get("text") or str(m)
+            text       = m.get("memory") or m.get("text")
+            if not text:
+                continue
             created_at = m.get("created_at")
             if created_at:
                 try:
@@ -862,10 +872,15 @@ class AikoMemorize:
 
         mem_ids     = [str(m.get("id", "")) for m in all_mems if m.get("id")]
         payload_map = self._batch_get_payloads(mem_ids)
+        pinned_ids  = _sqlite_pinned_ids(self._conn, mem_ids)
 
-        boosted      = self._dream_boost(all_mems, payload_map, dry_run=dry_run)
-        merged       = self._dream_merge(mem_ids, user_id=user_id, threshold=threshold, dry_run=dry_run)
-        prune_result = self.cleanup(user_id=user_id, dry_run=dry_run, _all_mems=all_mems)
+        boosted      = self._dream_boost(all_mems, payload_map, pinned_ids=pinned_ids, dry_run=dry_run)
+        merged       = self._dream_merge(mem_ids, user_id=user_id, threshold=threshold, pinned_ids=pinned_ids, dry_run=dry_run)
+        if merged > 0 and not dry_run:
+            all_mems = self.get_all(user_id=user_id)
+            mem_ids = [str(m.get("id", "")) for m in all_mems if m.get("id")]
+            pinned_ids = _sqlite_pinned_ids(self._conn, mem_ids)
+        prune_result = self.cleanup(user_id=user_id, dry_run=dry_run, _all_mems=all_mems, _pinned_ids=pinned_ids)
         pruned       = prune_result.get("deleted", 0)
 
         duration = round(time.perf_counter() - t_start, 2)
@@ -880,6 +895,7 @@ class AikoMemorize:
         self,
         all_mems:    list[dict],
         payload_map: dict,
+        pinned_ids:  set[str] | None = None,
         dry_run:     bool = False,
     ) -> int:
         """
@@ -888,13 +904,14 @@ class AikoMemorize:
         Returns count of memories boosted.
         """
         now     = datetime.now(timezone.utc)
-        boosted = 0
+        boost_ids: list[str] = []
+        pinned_ids = pinned_ids or set()
 
         for m in all_mems:
             mem_id = str(m.get("id", ""))
             if not mem_id:
                 continue
-            if _sqlite_is_pinned(self._conn, mem_id):
+            if mem_id in pinned_ids:
                 continue
 
             text     = m.get("memory") or ""
@@ -918,17 +935,26 @@ class AikoMemorize:
             if not is_salient:
                 continue
 
-            if not dry_run:
-                try:
-                    _sqlite_set_payload(self._conn, mem_id, {
-                        "access_count": min(ac + DREAM_BOOST_AMOUNT, 255)
-                    })
-                except Exception as e:
-                    log.warning(f"Boost failed for {mem_id}: {e}")
-                    continue
+            boost_ids.append(mem_id)
 
-            boosted += 1
+        if boost_ids and not dry_run:
+            try:
+                placeholders = ",".join("?" * len(boost_ids))
+                self._conn.execute(
+                    f"""
+                    UPDATE memories
+                    SET access_count = MIN(access_count + ?, 255)
+                    WHERE id IN ({placeholders})
+                    """,
+                    [DREAM_BOOST_AMOUNT] + boost_ids,
+                )
+                self._conn.commit()
+            except Exception as e:
+                log.warning(f"Batch boost failed for {len(boost_ids)} memories: {e}")
+                self._conn.rollback()
+                return 0
 
+        boosted = len(boost_ids)
         if boosted:
             log.info(f"{'(dry-run) ' if dry_run else ''}Boosted {boosted} memories.")
         return boosted
@@ -938,6 +964,7 @@ class AikoMemorize:
         mem_ids:   list[str],
         user_id:   str,
         threshold: float = DREAM_MERGE_THRESHOLD,
+        pinned_ids: set[str] | None = None,
         dry_run:   bool  = False,
     ) -> int:
         """
@@ -946,12 +973,13 @@ class AikoMemorize:
         Returns count of memories deleted as duplicates.
         """
         deleted_ids: set[str] = set()
+        pinned_ids = pinned_ids or set()
         merged = 0
 
         for mem_id in mem_ids:
             if mem_id in deleted_ids:
                 continue
-            if _sqlite_is_pinned(self._conn, mem_id):
+            if mem_id in pinned_ids:
                 continue
 
             vector = _sqlite_get_vector(self._conn, mem_id)
@@ -975,7 +1003,7 @@ class AikoMemorize:
 
                 similarity = 1.0 - row["dist"]
                 n_merged = self._resolve_duplicate(
-                    mem_id, neighbor_id, similarity, dry_run=dry_run
+                    mem_id, neighbor_id, similarity, pinned_ids=pinned_ids, dry_run=dry_run
                 )
                 if n_merged:
                     deleted_ids.add(neighbor_id)
@@ -990,6 +1018,7 @@ class AikoMemorize:
         id_a:    str,
         id_b:    str,
         score:   float,
+        pinned_ids: set[str] | None = None,
         dry_run: bool = False,
     ) -> bool:
         """
@@ -997,14 +1026,24 @@ class AikoMemorize:
         Pinned memories are never deleted. Tie goes to id_a (query origin).
         Returns True if a deletion occurred.
         """
-        if _sqlite_is_pinned(self._conn, id_a) or _sqlite_is_pinned(self._conn, id_b):
+        pinned_ids = pinned_ids or set()
+        if id_a in pinned_ids or id_b in pinned_ids:
             log.info(f"Skipping merge: one or both of ({id_a}, {id_b}) is pinned.")
             return False
 
         payload_map = self._batch_get_payloads([id_a, id_b])
         ac_a, _     = payload_map.get(id_a, (0, "never"))
         ac_b, _     = payload_map.get(id_b, (0, "never"))
-        loser       = id_b if ac_a >= ac_b else id_a
+        row_map = {
+            row["id"]: row["created_at"]
+            for row in self._conn.execute(
+                "SELECT id, created_at FROM memories WHERE id IN (?, ?)", (id_a, id_b)
+            ).fetchall()
+        }
+        if ac_a == ac_b:
+            loser = id_b if row_map.get(id_a, "") >= row_map.get(id_b, "") else id_a
+        else:
+            loser = id_b if ac_a > ac_b else id_a
 
         if dry_run:
             log.info(
@@ -1032,6 +1071,7 @@ class AikoMemorize:
         threshold: float = CLEANUP_THRESHOLD,
         dry_run:   bool  = False,
         _all_mems: Optional[list[dict]] = None,
+        _pinned_ids: Optional[set[str]] = None,
     ) -> dict:
         """
         Prune decayed memories below threshold score.
@@ -1049,6 +1089,7 @@ class AikoMemorize:
 
         mem_ids     = [str(m.get("id", "")) for m in all_mems if m.get("id")]
         payload_map = self._batch_get_payloads(mem_ids)
+        pinned_ids  = _pinned_ids if _pinned_ids is not None else _sqlite_pinned_ids(self._conn, mem_ids)
 
         candidates = []
         kept       = 0
@@ -1058,7 +1099,7 @@ class AikoMemorize:
             ac, la     = payload_map.get(mem_id, (0, "never"))
             created_at = m.get("created_at", "")
 
-            if _sqlite_is_pinned(self._conn, mem_id):
+            if mem_id in pinned_ids:
                 kept += 1
                 continue
 

--- a/core/reflect.py
+++ b/core/reflect.py
@@ -3,7 +3,7 @@ core/reflect.py
 Aiko's nightly experience-summary writer.
 
 Called after dream() completes at 00:00. Pulls the day's chat turns and
-memory snippets, asks Ollama to write a factual daily summary, pins that
+memory snippets, asks the local llama-server to write a factual daily summary, pins that
 summary to persistent memory, then pushes a Hugo-format markdown post to
 GitHub via the REST API (no local clone needed).
 
@@ -18,8 +18,9 @@ Optional:
   REFLECT_MAX_MEMS    — max memory snippets to feed the LLM (default 20)
   REFLECT_MAX_TURNS   — max chat turns to feed the LLM (default 40)
   REFLECT_TAGS        — comma-separated Hugo tags (default "daily-summary,ai-journal,aiko")
-  OLLAMA_MODEL        — reuses the main chat model (already in VRAM)
-  OLLAMA_BASE_URL     — default http://localhost:11434
+  LLAMACPP_MODEL      — reuses the main chat model (already in VRAM)
+  LLAMACPP_BASE_URL   — default http://localhost:8080/v1
+  REFLECT_ASCII      — true/false toggle for ASCII art generation (default true)
 """
 from dotenv import load_dotenv
 load_dotenv()
@@ -33,6 +34,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Optional
 
 import requests
+from openai import OpenAI
 
 from core.log import get_logger
 from core.experience import load_chat_turns
@@ -46,14 +48,16 @@ GITHUB_REPO       = os.getenv("GITHUB_REPO", "")          # e.g. "OppaAI/oppaai.
 GITHUB_BRANCH     = os.getenv("GITHUB_BRANCH", "main")
 HUGO_CONTENT_PATH = os.getenv("HUGO_CONTENT_PATH", "content/posts")
 
-OLLAMA_MODEL      = os.getenv("OLLAMA_MODEL", "")
-OLLAMA_BASE_URL   = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+LLAMACPP_MODEL    = os.getenv("LLAMACPP_MODEL", os.getenv("OLLAMA_MODEL", "ministral-3b-instruct"))
+LLAMACPP_BASE_URL = os.getenv("LLAMACPP_BASE_URL", "http://localhost:8080/v1")
+_LLM_CLIENT       = OpenAI(base_url=LLAMACPP_BASE_URL, api_key="not-needed")
 
 SOUL_PATH         = os.getenv("SOUL_PATH", "persona/soul.md")
 
 REFLECT_MAX_MEMS  = int(os.getenv("REFLECT_MAX_MEMS", 20))
 REFLECT_MAX_TURNS = int(os.getenv("REFLECT_MAX_TURNS", 40))
 REFLECT_TAGS      = os.getenv("REFLECT_TAGS", "daily-summary,ai-journal,aiko")
+REFLECT_ASCII     = os.getenv("REFLECT_ASCII", "true").strip().lower() not in {"0", "false", "no", "off"}
 
 _GITHUB_API       = "https://api.github.com"
 
@@ -129,32 +133,27 @@ def _build_reflection_system() -> str:
 
 # ── LLM helpers ───────────────────────────────────────────────────────────────
 
-def _ollama_chat(system: str, user: str, max_tokens: int = 400) -> str:
+def _llm_chat(system: str, user: str, max_tokens: int = 400) -> str:
     """
-    Single-shot Ollama /api/chat call. Returns stripped response text.
-    Raises on HTTP or JSON failure so callers can catch cleanly.
+    Single-shot OpenAI-compatible llama-server chat call.
+    Raises on API failure so callers can catch cleanly.
     """
-    payload = {
-        "model":  OLLAMA_MODEL,
-        "stream": False,
-        "options": {"num_predict": max_tokens, "temperature": 0.75},
-        "messages": [
+    resp = _LLM_CLIENT.chat.completions.create(
+        model=LLAMACPP_MODEL,
+        messages=[
             {"role": "system", "content": system},
-            {"role": "user",   "content": user},
+            {"role": "user", "content": user},
         ],
-    }
-    resp = requests.post(
-        f"{OLLAMA_BASE_URL}/api/chat",
-        json=payload,
+        stream=False,
+        max_tokens=max_tokens,
+        temperature=0.75,
         timeout=120,
     )
-    resp.raise_for_status()
-    data = resp.json()
-    return data["message"]["content"].strip()
+    return (resp.choices[0].message.content or "").strip()
 
 
 def _generate_reflection(snippets: list[str], turns: list[dict], date: datetime) -> str:
-    """Ask Ollama for a factual daily summary using chats + memories."""
+    """Ask llama-server for a factual daily summary using chats + memories."""
     bullet_list = "\n".join(f"- {s}" for s in snippets) or "- No memory snippets available."
     turn_lines = []
     for turn in turns[:REFLECT_MAX_TURNS]:
@@ -168,13 +167,13 @@ def _generate_reflection(snippets: list[str], turns: list[dict], date: datetime)
         turns=turns_text,
         snippets=bullet_list,
     )
-    return _ollama_chat(_build_reflection_system(), user_prompt, max_tokens=500)
+    return _llm_chat(_build_reflection_system(), user_prompt, max_tokens=500)
 
 
 def _generate_ascii(prose: str) -> str:
-    """Ask Ollama to draw ASCII art matching the reflection's mood."""
+    """Ask llama-server to draw ASCII art matching the reflection's mood."""
     user_prompt = _ASCII_USER.format(prose=prose[:600])  # truncate for token budget
-    raw = _ollama_chat(_ASCII_SYSTEM, user_prompt, max_tokens=200)
+    raw = _llm_chat(_ASCII_SYSTEM, user_prompt, max_tokens=200)
 
     # Strip any accidental code fences the model may have added
     raw = re.sub(r"^```[a-z]*\n?", "", raw, flags=re.MULTILINE)
@@ -220,7 +219,7 @@ def _build_hugo_post(
         f'draft: false\n'
         f'tags:\n'
         f'{tags_yaml}\n'
-        f'summary: "{prose[:120].replace(chr(34), chr(39))}…"\n'
+        f'summary: "{prose[:120].replace('"', "'")}…"\n'
         f'word_count: {word_count}\n'
         f'read_time: {read_mins} min\n'
         f'---'
@@ -321,9 +320,6 @@ def generate_and_post(
     write_time = datetime.now(timezone.utc)
     date       = date or write_time - timedelta(days=1)
 
-    if not OLLAMA_MODEL:
-        log.error("OLLAMA_MODEL not set.")
-        return {"success": False, "error": "OLLAMA_MODEL not set"}
 
     # Extract text snippets — deduplicate, cap at REFLECT_MAX_MEMS
     # Caller is responsible for sorting memories by recency before passing in.
@@ -354,10 +350,13 @@ def generate_and_post(
         return {"success": False, "error": str(e)}
 
     # Step 2: ASCII art
-    try:
-        ascii_art = _generate_ascii(prose)
-    except Exception as e:
-        log.warning(f"ASCII art generation failed ({e}) — using fallback.")
+    if REFLECT_ASCII:
+        try:
+            ascii_art = _generate_ascii(prose)
+        except Exception as e:
+            log.warning(f"ASCII art generation failed ({e}) — using fallback.")
+            ascii_art = "  ~  ( Aiko )  ~\n   `-- * --'"
+    else:
         ascii_art = "  ~  ( Aiko )  ~\n   `-- * --'"
 
     # Step 3: Build Hugo post

--- a/core/skills.py
+++ b/core/skills.py
@@ -55,12 +55,21 @@ def search_skills(query: str, path: str | Path = DEFAULT_SKILLS_PATH, limit: int
     terms = [t.casefold() for t in query.split() if t.strip()]
     if not terms:
         return []
+    lines = [line.strip() for line in load_skills(path).splitlines() if line.strip()]
     results: list[str] = []
-    for line in load_skills(path).splitlines():
-        text = line.strip()
+    for text in lines:
         folded = text.casefold()
-        if text and all(term in folded for term in terms):
+        if all(term in folded for term in terms):
             results.append(text)
         if len(results) >= limit:
-            break
+            return results
+
+    # Fallback: tolerate one typo/extra term by matching any term when AND yields nothing.
+    if not results:
+        for text in lines:
+            folded = text.casefold()
+            if any(term in folded for term in terms):
+                results.append(text)
+            if len(results) >= limit:
+                break
     return results

--- a/core/think.py
+++ b/core/think.py
@@ -51,8 +51,10 @@ LLAMACPP_BASE_URL = os.getenv("LLAMACPP_BASE_URL", "http://localhost:8080/v1")
 LLAMACPP_MODEL    = os.getenv("LLAMACPP_MODEL",    "ministral-3b-instruct")
 CONTEXT_WINDOW_TURNS = int(os.getenv("CONTEXT_WINDOW_TURNS", 8))
 
-_BASE_PREDICT    = 280
+_BASE_PREDICT    = int(os.getenv("LLM_MAX_TOKENS", os.getenv("BASE_PREDICT", 280)))
+_AGENT_MAX_TOKENS = int(os.getenv("AGENT_MAX_TOKENS", _BASE_PREDICT * 4))
 _REASONING_SCALE = 3
+_IDLE_LEARN_SECONDS = int(os.getenv("IDLE_LEARN_SECONDS", 1800))
 
 _PERSONA_PATH = Path(__file__).resolve().parent.parent / "persona" / "soul.md"
 _USER_PATH = Path(__file__).resolve().parent.parent / "persona" / "user.md"
@@ -115,6 +117,7 @@ class AikoThink:
         self._history:  list[dict] = []
         self._history_lock = threading.Lock()
         self._pending_search_query: str | None = None
+        self._route_chat_classified: str | None = None
         self._reasoning = False
         self._mem_queue  = queue.Queue()
         self._mem_worker = threading.Thread(target=self._mem_write_loop, daemon=True)
@@ -163,6 +166,8 @@ class AikoThink:
             return "keyword"
         if re.search(r"\b(wake me|remind me|alarm|timer|every morning|every day|daily)\b", text):
             return "reminder"
+        if _FACTUAL_RE.search(user_input):
+            return "chat"
         if _SOCIAL_RE.search(user_input):
             return "chat"
         return self._classify_agent_intent(user_input)
@@ -181,10 +186,13 @@ class AikoThink:
             )
             label = (resp.choices[0].message.content or "chat").strip().lower()
             label = re.sub(r"[^a-z_].*$", "", label)
-            return label if label in {
+            if label in {
                 "research", "planning", "writing", "coding",
                 "decision", "reminder", "ongoing_task",
-            } else "chat"
+            }:
+                return label
+            self._route_chat_classified = user_input
+            return "chat"
         except Exception as e:
             log.warning("Intent routing failed: %s", e)
             return "chat"
@@ -318,7 +326,7 @@ class AikoThink:
         """Background autonomous learning loop."""
         while True:
             time.sleep(300)  # check every 5 minutes
-            if time.time() - self._last_chat_time < 300:
+            if time.time() - self._last_chat_time < _IDLE_LEARN_SECONDS:
                 continue  # user has been active recently, don't interrupt
                 
             if self._speak and self._speak.is_playing():
@@ -334,13 +342,18 @@ class AikoThink:
                     continue
                     
                 topic = candidates[-1] # simplistic: look at last user query
+                learned_tag = f"[self-learned:{topic}]"
+                if any(learned_tag in (m.get("content") or "") for m in self._history):
+                    continue
+                if self._memorize.search(learned_tag, limit=1):
+                    continue
                 
                 # Run silent agentic research
                 result = self.agentic_chat(f"Research this topic briefly: {topic}")
                 
                 # Store as self-learned memory
                 self._memorize.add([
-                    {"role": "system", "content": f"[self-learned:{topic}]"},
+                    {"role": "system", "content": learned_tag},
                     {"role": "assistant", "content": result[:800]}
                 ])
                 log.info(f"[learner] Successfully learned about: {topic}")
@@ -366,7 +379,7 @@ class AikoThink:
                 self._speak.feed(text)
                 self._speak.play_async()
 
-    def _stream_response(self, messages: list[dict], system: str = "", silent: bool = True, token_callback=None) -> str:
+    def _stream_response(self, messages: list[dict], system: str = "", token_callback=None) -> str:
         full_response = []
         max_tokens = _BASE_PREDICT * _REASONING_SCALE if self._reasoning else _BASE_PREDICT
         all_messages = [{"role": "system", "content": system}] + messages if system else messages
@@ -389,7 +402,7 @@ class AikoThink:
                 delta = chunk.choices[0].delta if chunk.choices else None
                 token = (delta.content or "") if delta else ""
                 full_response.append(token)
-                if not silent and token_callback: token_callback(token)
+                # Streaming is collected here; user-facing emission is centralized in _emit().
         except Exception as e:
             msg = f"Stream failed: {e}"
             log.error(msg)
@@ -402,6 +415,9 @@ class AikoThink:
     def _is_data_intent(self, user_input: str) -> bool:
         if _FACTUAL_RE.search(user_input): return True
         if _SOCIAL_RE.search(user_input): return False
+        if self._route_chat_classified == user_input:
+            self._route_chat_classified = None
+            return False
         is_data, resolved_query = self._classify_and_resolve(user_input)
         self._pending_search_query = resolved_query if is_data else None
         return is_data


### PR DESCRIPTION
### Motivation
- Ensure memory extraction and nightly reflection work against the OpenAI-compatible local LLM (llama-server) instead of direct Ollama/httpx calls so Jetson deployments don't silently fail. 
- Fix silent failures and correctness issues in the nightly dream/cleanup pipeline and make boost/merge operations efficient and robust. 
- Reduce risk of agent loops, align token budgets, and tame aggressive background learning to improve stability on resource-constrained devices.

### Description
- Replaced direct Ollama/httpx calls with an OpenAI-compatible client for local LLM interactions in `core/memorize.py` and `core/reflect.py`, and added `LLAMACPP_*` defaults and a `_llm_chat/_LLM_CLIENT` wrapper; added `REFLECT_ASCII` toggle to skip the ASCII-art LLM call.  
- Batch pinned-memory handling and boosts in `core/memorize.py`: added `_sqlite_pinned_ids()`, pass `pinned_ids` through `dream()` → `_dream_boost()`/`_dream_merge()`/`cleanup()`, refresh `all_mems` after merges, and convert per-memory boost updates to a single `UPDATE ... WHERE id IN (...)` commit. 
- Improve duplicate resolution in `_resolve_duplicate()` to use `created_at` as a tiebreaker when access counts tie, preferring the newer memory; avoid injecting raw dict reprs into context by skipping malformed memory entries in `format_for_context()`. 
- Harden agent/think logic: in `core/think.py` factual signals win before social checks, classification-to-chat caching avoids double LLM calls for the same turn, unified token-budget env vars (`LLM_MAX_TOKENS`/`AGENT_MAX_TOKENS`), removed dead `silent` parameter from `_stream_response`, and increased idle-learner interval + dedup guard for self-learned topics. 
- Consolidated tool schemas and dispatch in `core/agentic.py` into a single registry with `_register_tools()` and `_TOOLS`, added `AGENT_MAX_TOKENS` usage for agent calls, and added a loop-guard to skip repeated identical tool calls. 
- Added an OR-style fallback to `core/skills.py::search_skills()` so a strict AND match returning nothing will fall back to looser matching.

### Testing
- Ran static compilation checks: `python -m py_compile core/memorize.py core/reflect.py core/think.py core/agentic.py core/skills.py` which completed without syntax errors. (✅)
- Ran repository check: `git diff --check` (no whitespace/merge errors found). (✅)
- Per-file smoke reviews performed by running quick grep/inspection of the modified LLM-call and memory-path sites to confirm replacements and new env var usages. (manual verification)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a343e7512f4832c9e66f8ee7c1160b1)