### PR TITLE
Make WebUI the default interface and improve VRM load failure message

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,13 +6,15 @@ Aiko-chan CLI — entry point and session orchestrator.
 Usage:
     python main.py               # full voice — ASR (SenseVoice + Silero VAD) + TTS (MioTTS)
     python main.py --text        # keyboard input + no TTS
+    python main.py               # browser WebUI (default)
+    python main.py --tui         # curses TUI
     python main.py --debug       # show memory debug info each turn
     python main.py --clear-mem   # wipe all stored memories and exit
 
 Responsibilities:
     - Parse CLI arguments
     - Delegate subsystem boot to core/wakeup.py
-    - Drive the TUI init phase and transition to active chat
+    - Drive the UI init phase and transition to active chat
     - Run the main input → inference → render loop
     - Handle commands (/quit, /reset, /memory, /clear, /remember, /think,
                        /voice, /listen, /web, /help)
@@ -39,6 +41,7 @@ import logging
 from core.silence import silent_stderr
 from core.log     import get_logger
 from core.wakeup  import AikoWakeup
+from core.toolkit.web import web_search
 
 log = get_logger(__name__)
 
@@ -46,6 +49,7 @@ with silent_stderr():
     from core.memorize import AikoMemorize
 
 from tui.tui import AikoTUI
+from webui.aiko_web import AikoWeb
 
 # ── env ───────────────────────────────────────────────────────────────────────
 
@@ -146,6 +150,10 @@ def parse_args():
                    help="keyboard input but keep TTS")
     p.add_argument("--debug",     action="store_true",
                    help="show memory hits each turn")
+    p.add_argument("--tui",       action="store_true",
+                   help="use the legacy curses TUI instead of the default browser WebUI")
+    p.add_argument("--webui",     action="store_true",
+                   help="use the browser WebUI (default; kept for explicit launch scripts)")
     p.add_argument("--clear-mem", action="store_true",
                    help="wipe all stored memories and exit")
     return p.parse_args()
@@ -155,7 +163,7 @@ def parse_args():
 # SESSION ORCHESTRATOR
 # ═════════════════════════════════════════════════════════════════════════════
         
-def _run(stdscr, args):
+def _run_tui(stdscr, args):
     """
     Orchestrate the full session lifecycle from boot to shutdown inside the
     curses wrapper.
@@ -169,7 +177,17 @@ def _run(stdscr, args):
            writes to complete.
     """
     tui = AikoTUI(stdscr, no_voice=args.text, debug=args.debug)
+    _run_session(tui, args)
 
+
+def _run_webui(args):
+    """Launch Aiko with the browser WebUI."""
+    tui = AikoWeb(no_voice=args.text, debug=args.debug)
+    _run_session(tui, args)
+
+
+def _run_session(tui, args):
+    """Run Aiko using any UI object that implements the AikoTUI-compatible API."""
     last_stream_draw = 0.0
 
     def token_cb(token):
@@ -455,7 +473,12 @@ def main():
         log.info("Clearing all memories...")
         AikoMemorize().clear()
         sys.exit(0)
-    curses.wrapper(lambda scr: _run(scr, args))
+    if args.tui and args.webui:
+        raise SystemExit("Choose only one UI: --tui or --webui")
+    if args.tui:
+        curses.wrapper(lambda scr: _run_tui(scr, args))
+    else:
+        _run_webui(args)
 
 
 if __name__ == '__main__':

--- a/webui/static/index.html
+++ b/webui/static/index.html
@@ -519,10 +519,17 @@ animate();
 const loader = new GLTFLoader();
 loader.register(parser => new VRMLoaderPlugin(parser));
 
+const VRM_URL = './assets/Aiko.vrm';
+
+if (window.location.protocol === 'file:') {
+  loadMsg.textContent = 'error: open Aiko via `python main.py` or http://localhost:8787/ — browsers block VRM fetches from file://';
+  throw new Error('Aiko WebUI must be served over HTTP so assets/Aiko.vrm can be fetched.');
+}
+
 loadMsg.textContent = 'loading Aiko.vrm…';
 fill.style.width = '5%';
 
-loader.load('./assets/Aiko.vrm',
+loader.load(VRM_URL,
   (gltf) => {
     fill.style.width = '95%';
     loadMsg.textContent = 'building model…';
@@ -553,7 +560,8 @@ loader.load('./assets/Aiko.vrm',
     fill.style.width = (5 + p * 88) + '%';
   },
   (err) => {
-    loadMsg.textContent = 'error: ' + err.message;
+    const detail = err?.message || String(err);
+    loadMsg.textContent = `error loading ${VRM_URL}: ${detail}. Start with python main.py and open http://localhost:8787/ instead of file://.`;
     console.error('[aiko-vrm]', err);
   }
 );


### PR DESCRIPTION
### Motivation
- Default the application to the browser WebUI so `python main.py` launches the WebUI instead of the curses TUI. 
- Provide a clear explanation when the VRM asset fails to load due to opening `index.html` via `file://` which browsers block. 
- Keep the legacy curses TUI available behind a flag for backward compatibility.

### Description
- Made the WebUI the default launch path in `main.py` and added CLI flags `--tui` (use curses TUI) and `--webui` (explicit WebUI). 
- Split the runner into `_run_tui`, `_run_webui`, and a shared `_run_session` so both UIs reuse the same session loop and command/ASR/TTS flow. 
- Added missing `web_search` import and imported `AikoWeb` from `webui.aiko_web` so the WebUI path integrates cleanly. 
- Updated `webui/static/index.html` to use a `VRM_URL` constant, guard against `file://` loads with a helpful message, and emit a clearer VRM load error instructing users to serve the UI over HTTP (e.g. via `python main.py`).

### Testing
- Ran byte-compile checks with `python -m py_compile main.py webui/aiko_web.py`, which succeeded. 
- Attempting to run `python main.py --help` in this environment failed due to a missing dependency: `ModuleNotFoundError: No module named 'dotenv'`, so runtime smoke tests were not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ae95c555c832ca37652c986c978db)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Browser-based interface is now the default launch mode
  * Added `--tui` flag to explicitly launch the text-based interface
  * Added `--webui` flag for explicit browser mode

* **Bug Fixes**
  * Improved error detection when accessing the application locally
  * Enhanced error messages for asset loading failures with clearer setup guidance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->