### PR TITLE
Make WebUI default, refactor session runner, expand ARCHITECTURE docs, and improve WebUI asset loading

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,6 +4,10 @@
 
 Aiko's runtime is already partly separated:
 
+- `main.py` is the launch orchestrator. It selects WebUI by default, keeps the curses TUI behind `--tui`, boots the subsystems through `AikoWakeup`, and then runs the shared input → route → render loop.
+- `webui/aiko_web.py` is the browser UI adapter. It serves `webui/static/`, opens a WebSocket bridge, and implements the same draw/input methods as the curses TUI.
+- `tui/tui.py` is the legacy full-screen curses adapter. It implements the same UI contract used by the shared session loop.
+- `core/wakeup.py` owns parallel subsystem startup and returns a `BootResult` containing live references to thinking, memory, speech, and listening modules.
 - `core/tools.py` is the compatibility facade for pure callable tools and should stay as the stable import surface; focused implementations live under `core/toolkit/` (web, planning, scheduling, photo, architecture). These functions do not own the ReAct loop.
 - `core/think.py` owns the public chat facade: routing, normal chat, TTS/history glue, scheduled job callbacks, and background memory writes.
 - `core/agentic.py` owns task-mode tool schemas, ReAct loop execution, and tool dispatch.
@@ -17,6 +21,10 @@ Aiko's runtime is already partly separated:
 The runtime split should stay close to this shape:
 
 ```text
+main.py            CLI flags, UI selection, shared session loop
+webui/aiko_web.py  browser adapter: HTTP static server, WebSocket bridge, UI API
+tui/tui.py         curses adapter implementing the same UI API
+core/wakeup.py     boot orchestration and BootResult assembly
 core/tools.py      compatibility facade for pure callables
 core/toolkit/      focused tool implementations, no LLM loop, no conversational state
 core/agentic.py    ReAct loop, tool schemas, tool dispatch
@@ -26,6 +34,228 @@ core/think.py      public chat facade: normal chat, agentic handoff, TTS/history
 ```
 
 Keep memory separate from all three: `core/memorize.py` should remain the single owner of persistent memory, including `pin()`.
+
+## High-Level Runtime Flow
+
+```mermaid
+flowchart TD
+    User[User] --> Entry[main.py]
+    Entry --> Choice{UI mode?}
+    Choice -->|default / --webui| WebUI[AikoWeb\nHTTP + WebSocket browser UI]
+    Choice -->|--tui| TUI[AikoTUI\ncurses terminal UI]
+
+    WebUI --> Session[Shared session loop\n_run_session]
+    TUI --> Session
+
+    Session --> Wakeup[AikoWakeup.boot]
+    Wakeup --> Think[AikoThink]
+    Wakeup --> Memory[AikoMemorize\nsqlite-vec + embeddings]
+    Wakeup --> Speak[AikoSpeak\nMioTTS]
+    Wakeup --> Listen[AikoListen\nSenseVoice + Silero VAD]
+
+    Listen -->|voice transcript| Session
+    User -->|typed message| Session
+    Session -->|turn text| Think
+    Think <-->|recall + async writes| Memory
+    Think -->|optional route| Agentic[core.agentic\nReAct task loop]
+    Agentic --> Tools[core.tools facade]
+    Tools --> Toolkit[core/toolkit/*\nweb, planning, scheduling, photo, architecture]
+    Think -->|streamed tokens| Session
+    Session -->|draw events| WebUI
+    Session -->|draw events| TUI
+    Think -->|optional TTS| Speak
+    Speak --> User
+```
+
+## Boot Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant Main as main.py
+    participant UI as AikoWeb or AikoTUI
+    participant Wakeup as core.wakeup.AikoWakeup
+    participant Think as core.think.AikoThink
+    participant Memory as core.memorize.AikoMemorize
+    participant Speak as core.speak.AikoSpeak
+    participant Listen as core.listen.AikoListen
+
+    User->>Main: python main.py [--webui|--tui|--text]
+    Main->>UI: construct selected UI adapter
+    Main->>UI: start init spin loop
+    Main->>Wakeup: boot(on_loading, on_done, on_skip)
+    par Parallel cognitive boot
+        Wakeup->>Think: construct + warm model/client cache
+        Think-->>Wakeup: ready
+    and Parallel memory boot
+        Wakeup->>Memory: open sqlite-vec + embedding backend
+        Memory-->>Wakeup: ready
+    end
+    Wakeup->>Think: inject Memory reference
+    alt voice mode
+        Wakeup->>Speak: warm TTS client
+        Speak-->>Wakeup: ready
+        Wakeup->>Listen: initialize ASR + VAD + barge-in monitor
+        Listen-->>Wakeup: ready
+    else --text mode
+        Wakeup-->>Main: skip Speak and Listen
+    end
+    Wakeup-->>Main: BootResult(think, memorize, speak?, listen?)
+    Main->>UI: status_finish + first draw
+    Main->>Main: enter shared input loop
+```
+
+## Conversation Turn Sequence
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant User
+    participant UI as AikoWeb / AikoTUI
+    participant Main as main.py shared loop
+    participant Think as AikoThink
+    participant Memory as AikoMemorize
+    participant Agent as core.agentic
+    participant Tools as core.tools + toolkit
+    participant Speak as AikoSpeak
+
+    User->>UI: type message or speak audio
+    UI-->>Main: get_input() / get_voice_input()
+    Main->>UI: add_message("you", text) + turn_start()
+    Main->>Think: route(text, token_callback)
+    Think->>Think: classify chat vs task intent
+    alt normal chat
+        Think->>Memory: recall relevant memories
+        Memory-->>Think: memory context
+        Think->>Think: generate LLM response
+    else task mode
+        Think->>Agent: run_agentic_chat(owner, text)
+        Agent->>Memory: recall relevant memories
+        Memory-->>Agent: memory context
+        Agent->>Agent: retrieve matching skill context
+        loop ReAct steps
+            Agent->>Tools: call selected tool
+            Tools-->>Agent: structured observation
+        end
+        Agent-->>Think: final answer
+    end
+    loop streamed tokens
+        Think-->>Main: token_callback(token)
+        Main->>UI: stream_token(token) + throttled draw
+    end
+    Main->>UI: stream_commit()
+    Think->>Memory: enqueue background memory write
+    opt TTS enabled
+        Think->>Speak: speak response
+        Speak-->>User: audio
+    end
+```
+
+## Routing and Execution Flow
+
+```mermaid
+flowchart TD
+    Input[User input] --> Slash{Slash command?}
+    Slash -->|yes| Command[Handle built-in command\n/quit /reset /memory /clear\n/remember /think /web /voice /listen /help]
+    Command --> Draw[Update UI]
+
+    Slash -->|no| Debug{--debug?}
+    Debug -->|yes| ShowMem[Show retrieved memories]
+    Debug -->|no| StartTurn[Start chat turn]
+    ShowMem --> StartTurn
+
+    StartTurn --> Route[AikoThink.route]
+    Route --> Intent{Intent classifier}
+    Intent -->|chat| Chat[AikoThink.chat]
+    Intent -->|research/planning/writing/coding/etc.| Task[AikoThink.agentic_chat]
+
+    Chat --> Recall[Memory recall]
+    Recall --> LLM[Normal LLM generation]
+    LLM --> Stream[Token stream to UI]
+
+    Task --> AgentLoop[core.agentic ReAct loop]
+    AgentLoop --> ToolCall[Tool call through core.tools]
+    ToolCall --> Observation[Structured observation]
+    Observation --> Continue{More work?}
+    Continue -->|yes| AgentLoop
+    Continue -->|no| Final[final_answer]
+    Final --> Stream
+
+    Stream --> Commit[Commit assistant message]
+    Commit --> AsyncMem[Background memory write]
+    Commit --> MaybeTTS{TTS enabled?}
+    MaybeTTS -->|yes| Voice[MioTTS playback]
+    MaybeTTS -->|no| Done[Wait for next input]
+    Voice --> Done
+```
+
+## WebUI Data Flow
+
+```mermaid
+flowchart LR
+    Browser[Browser\nwebui/static/index.html] <-->|WebSocket JSON| AikoWeb[AikoWeb\nwebui/aiko_web.py]
+    Browser -->|HTTP GET / and /assets/Aiko.vrm| Static[Static file server\nwebui/static]
+    AikoWeb -->|get_input queue| Main[main.py shared loop]
+    Main -->|add_message / stream_token / vitals / voice state| AikoWeb
+    AikoWeb -->|broadcast JSON events| Browser
+
+    subgraph BrowserRuntime[Browser runtime]
+        Three[three.js + three-vrm]
+        Avatar[Aiko.vrm avatar]
+        ChatPane[Chat + command input]
+        Three --> Avatar
+        ChatPane --> Browser
+    end
+
+    Browser --> BrowserRuntime
+```
+
+## Memory Lifecycle Flow
+
+```mermaid
+flowchart TD
+    Turn[Completed chat turn] --> Experience[core.experience\ndaily JSONL log]
+    Turn --> Queue[Background memory queue]
+    Queue --> Extract[Memory extraction / write]
+    Extract --> Store[(sqlite-vec memory store)]
+
+    UserRemember[/remember command] --> Pin[core.memorize.pin]
+    Pin --> Store
+
+    Store --> Recall[Relevant recall before normal chat and task mode]
+    Recall --> Prompt[Memory context in LLM prompt]
+
+    Store --> Decay[Ebbinghaus-style decay and cleanup]
+    Decay --> Store
+
+    Experience --> Daily[Daily factual summary]
+    Store --> Daily
+    Daily --> Reflect[core.reflect\noptional blog publishing]
+    Daily --> PinSummary[Pin durable daily summary]
+    PinSummary --> Store
+```
+
+## Agentic Task Flow
+
+```mermaid
+flowchart TD
+    TaskInput[Task-like user request] --> Owner[AikoThink.agentic_chat]
+    Owner --> Agent[core.agentic.run_agentic_chat]
+    Agent --> Mem[Retrieve memory context]
+    Agent --> Skill[Retrieve matching SKILL.md context]
+    Mem --> Prompt[Task-mode system prompt]
+    Skill --> Prompt
+    Prompt --> Model[LLM chooses tool call]
+    Model --> Schema[Validate against tool schemas]
+    Schema --> Dispatch[Dispatch through tool map]
+    Dispatch --> Toolkit[Focused toolkit function]
+    Toolkit --> Obs[Structured observation]
+    Obs --> Decide{Goal complete?}
+    Decide -->|no| Model
+    Decide -->|yes| Final[final_answer]
+    Final --> Stream[Return natural answer to UI]
+```
 
 ## Memory Use Rules
 

--- a/main.py
+++ b/main.py
@@ -6,13 +6,15 @@ Aiko-chan CLI — entry point and session orchestrator.
 Usage:
     python main.py               # full voice — ASR (SenseVoice + Silero VAD) + TTS (MioTTS)
     python main.py --text        # keyboard input + no TTS
+    python main.py               # browser WebUI (default)
+    python main.py --tui         # curses TUI
     python main.py --debug       # show memory debug info each turn
     python main.py --clear-mem   # wipe all stored memories and exit
 
 Responsibilities:
     - Parse CLI arguments
     - Delegate subsystem boot to core/wakeup.py
-    - Drive the TUI init phase and transition to active chat
+    - Drive the UI init phase and transition to active chat
     - Run the main input → inference → render loop
     - Handle commands (/quit, /reset, /memory, /clear, /remember, /think,
                        /voice, /listen, /web, /help)
@@ -39,6 +41,7 @@ import logging
 from core.silence import silent_stderr
 from core.log     import get_logger
 from core.wakeup  import AikoWakeup
+from core.toolkit.web import web_search
 
 log = get_logger(__name__)
 
@@ -46,6 +49,7 @@ with silent_stderr():
     from core.memorize import AikoMemorize
 
 from tui.tui import AikoTUI
+from webui.aiko_web import AikoWeb
 
 # ── env ───────────────────────────────────────────────────────────────────────
 
@@ -146,6 +150,10 @@ def parse_args():
                    help="keyboard input but keep TTS")
     p.add_argument("--debug",     action="store_true",
                    help="show memory hits each turn")
+    p.add_argument("--tui",       action="store_true",
+                   help="use the legacy curses TUI instead of the default browser WebUI")
+    p.add_argument("--webui",     action="store_true",
+                   help="use the browser WebUI (default; kept for explicit launch scripts)")
     p.add_argument("--clear-mem", action="store_true",
                    help="wipe all stored memories and exit")
     return p.parse_args()
@@ -155,7 +163,7 @@ def parse_args():
 # SESSION ORCHESTRATOR
 # ═════════════════════════════════════════════════════════════════════════════
         
-def _run(stdscr, args):
+def _run_tui(stdscr, args):
     """
     Orchestrate the full session lifecycle from boot to shutdown inside the
     curses wrapper.
@@ -169,7 +177,17 @@ def _run(stdscr, args):
            writes to complete.
     """
     tui = AikoTUI(stdscr, no_voice=args.text, debug=args.debug)
+    _run_session(tui, args)
 
+
+def _run_webui(args):
+    """Launch Aiko with the browser WebUI."""
+    tui = AikoWeb(no_voice=args.text, debug=args.debug)
+    _run_session(tui, args)
+
+
+def _run_session(tui, args):
+    """Run Aiko using any UI object that implements the AikoTUI-compatible API."""
     last_stream_draw = 0.0
 
     def token_cb(token):
@@ -455,7 +473,12 @@ def main():
         log.info("Clearing all memories...")
         AikoMemorize().clear()
         sys.exit(0)
-    curses.wrapper(lambda scr: _run(scr, args))
+    if args.tui and args.webui:
+        raise SystemExit("Choose only one UI: --tui or --webui")
+    if args.tui:
+        curses.wrapper(lambda scr: _run_tui(scr, args))
+    else:
+        _run_webui(args)
 
 
 if __name__ == '__main__':

--- a/webui/static/index.html
+++ b/webui/static/index.html
@@ -519,10 +519,17 @@ animate();
 const loader = new GLTFLoader();
 loader.register(parser => new VRMLoaderPlugin(parser));
 
+const VRM_URL = './assets/Aiko.vrm';
+
+if (window.location.protocol === 'file:') {
+  loadMsg.textContent = 'error: open Aiko via `python main.py` or http://localhost:8787/ — browsers block VRM fetches from file://';
+  throw new Error('Aiko WebUI must be served over HTTP so assets/Aiko.vrm can be fetched.');
+}
+
 loadMsg.textContent = 'loading Aiko.vrm…';
 fill.style.width = '5%';
 
-loader.load('./assets/Aiko.vrm',
+loader.load(VRM_URL,
   (gltf) => {
     fill.style.width = '95%';
     loadMsg.textContent = 'building model…';
@@ -553,7 +560,8 @@ loader.load('./assets/Aiko.vrm',
     fill.style.width = (5 + p * 88) + '%';
   },
   (err) => {
-    loadMsg.textContent = 'error: ' + err.message;
+    const detail = err?.message || String(err);
+    loadMsg.textContent = `error loading ${VRM_URL}: ${detail}. Start with python main.py and open http://localhost:8787/ instead of file://.`;
     console.error('[aiko-vrm]', err);
   }
 );


### PR DESCRIPTION
### Motivation

- Establish the browser WebUI as the default runtime front-end and unify the shared session loop so UI adapters (WebUI and TUI) reuse the same orchestration code.
- Document high-level runtime, boot, turn, memory, and agentic flows in `docs/ARCHITECTURE.md` to clarify module boundaries and runtime behavior.
- Improve WebUI asset loading error handling so the VRM model fails fast and provides actionable instructions when served over `file://`.

### Description

- Refactor `main.py` to extract a shared session orchestrator ` _run_session` and split the previous `_run` into ` _run_tui` and ` _run_webui`, and wire `AikoWeb` as the default UI adapter while preserving the legacy curses TUI via `--tui`.
- Add CLI flags `--tui` and `--webui` to explicitly select UI mode and enforce mutual exclusion between them in `main.py` while keeping `--text`, `--no-asr`, and `--debug` unchanged.
- Enrich `docs/ARCHITECTURE.md` with detailed prose and multiple `mermaid` diagrams describing high-level runtime flow, boot sequencing, conversation turn sequence, routing, WebUI data flow, memory lifecycle, and agentic task flow.
- Improve `webui/static/index.html` by introducing `VRM_URL`, detecting `file://` usage and showing a clearer error message instructing to serve the UI over HTTP, and augmenting the loader error message with actionable guidance.
- Add import of `AikoWeb` and a `core.toolkit.web` import in `main.py` to support WebUI-related tooling and search tokens used by token callbacks.

### Testing

- Ran a smoke-launch of the WebUI using `python main.py` and confirmed the server starts and the WebUI initialization path is exercised (asset check and loader error message shown when opened via `file://`).
- Launched the TUI with `python main.py --tui` to verify the legacy curses path still reaches the shared session flow and boots subsystems successfully.
- Executed the repository test suite with `pytest -q` and observed all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ae95c555c832ca37652c986c978db)