### PR TITLE
Fix archive 3D gesture tester (dynamic import + lerped animation)

### DIFF
--- a/archive/test-3d-model.html
+++ b/archive/test-3d-model.html
@@ -575,13 +575,23 @@ const REST = {
   rightHand:     { x: 0,    y:  0 },
 };
 
+function setArmRest(side) {
+  if (side < 0) {
+    leftArm.uaPivot.rotation.set(REST.leftUpperArm.x, 0, REST.leftUpperArm.z);
+    leftArm.laPivot.rotation.set(REST.leftLowerArm.x, 0, REST.leftLowerArm.z);
+    leftArm.hPivot.rotation.set(REST.leftHand.x, REST.leftHand.y, 0);
+  } else {
+    rightArm.uaPivot.rotation.set(REST.rightUpperArm.x, 0, REST.rightUpperArm.z);
+    rightArm.laPivot.rotation.set(REST.rightLowerArm.x, 0, REST.rightLowerArm.z);
+    rightArm.hPivot.rotation.set(REST.rightHand.x, REST.rightHand.y, 0);
+  }
+}
+
 function applyRest() {
-  leftArm.uaPivot.rotation.set(REST.leftUpperArm.x, 0, REST.leftUpperArm.z);
-  leftArm.laPivot.rotation.set(REST.leftLowerArm.x, 0, REST.leftLowerArm.z);
-  leftArm.hPivot.rotation.set(REST.leftHand.x, REST.leftHand.y, 0);
-  rightArm.uaPivot.rotation.set(REST.rightUpperArm.x, 0, REST.rightUpperArm.z);
-  rightArm.laPivot.rotation.set(REST.rightLowerArm.x, 0, REST.rightLowerArm.z);
-  rightArm.hPivot.rotation.set(REST.rightHand.x, REST.rightHand.y, 0);
+  setArmRest(-1);
+  setArmRest(1);
+  neck.rotation.set(0, 0, 0);
+  head.rotation.set(0, 0, 0);
 }
 applyRest();
 
@@ -590,6 +600,7 @@ let currentSide = 1; // 1 = right
 
 // ── Animation state ───────────────────────────────────────────
 let animating = true;
+let forceRest = false;
 let animTime = 0;        // drives the intensity oscillation
 let lerpT = 0.08;
 
@@ -606,6 +617,7 @@ const cur = {
 };
 
 function toggleAnimate() {
+  forceRest = false;
   animating = !animating;
   const btn = document.getElementById('btnAnimate');
   btn.textContent = animating ? '▶ animate' : '⏸ paused';
@@ -613,6 +625,7 @@ function toggleAnimate() {
 }
 
 function setSide(s) {
+  forceRest = false;
   currentSide = s;
   document.getElementById('btnLeft').classList.toggle('active', s < 0);
   document.getElementById('btnRight').classList.toggle('active', s > 0);
@@ -688,6 +701,18 @@ function syncCurrentRotations() {
   cur.rH.y = rightArm.hPivot.rotation.y;
 }
 
+function updateBoneReadout(side) {
+  const activeUA = side < 0 ? cur.lUA : cur.rUA;
+  const activeLA = side < 0 ? cur.lLA : cur.rLA;
+  const activeH  = side < 0 ? cur.lH  : cur.rH;
+  document.getElementById('bUAx').textContent = activeUA.x.toFixed(3);
+  document.getElementById('bUAz').textContent = activeUA.z.toFixed(3);
+  document.getElementById('bLAx').textContent = activeLA.x.toFixed(3);
+  document.getElementById('bLAz').textContent = activeLA.z.toFixed(3);
+  document.getElementById('bHx').textContent  = activeH.x.toFixed(3);
+  document.getElementById('bHy').textContent  = activeH.y.toFixed(3);
+}
+
 // Compute targets from lookAtHand case and lerp cur toward them
 function tickAnimation(dt) {
   if (animating) animTime += dt;
@@ -712,6 +737,13 @@ function tickAnimation(dt) {
   document.getElementById('valHy').textContent  = (+document.getElementById('slHy').value).toFixed(2);
   document.getElementById('hudInt').textContent = intensity.toFixed(2);
 
+  if (forceRest) {
+    applyRest();
+    syncCurrentRotations();
+    updateBoneReadout(s);
+    return;
+  }
+
   const beforeGesture = snapshotRotations();
 
   lookAtHand({
@@ -733,31 +765,36 @@ function tickAnimation(dt) {
         rH: rightArm.hPivot
       });
 
+  setArmRest(-s);
   applyLerpedRotations(beforeGesture, lerpT);
   syncCurrentRotations();
 
   // ── Update bone readout ──
-  const activeUA = s < 0 ? cur.lUA : cur.rUA;
-  const activeLA = s < 0 ? cur.lLA : cur.rLA;
-  const activeH  = s < 0 ? cur.lH  : cur.rH;
-  document.getElementById('bUAx').textContent = activeUA.x.toFixed(3);
-  document.getElementById('bUAz').textContent = activeUA.z.toFixed(3);
-  document.getElementById('bLAx').textContent = activeLA.x.toFixed(3);
-  document.getElementById('bLAz').textContent = activeLA.z.toFixed(3);
-  document.getElementById('bHx').textContent  = activeH.x.toFixed(3);
-  document.getElementById('bHy').textContent  = activeH.y.toFixed(3);
+  updateBoneReadout(s);
 }
 
 // Stub so sidebar sliders still call something
-function update() { /* driven by render loop */ }
+function update() { forceRest = false; /* driven by render loop */ }
 
 Object.assign(window, { setSide, toggleAnimate, update, resetAll });
 
 function resetAll() {
+  animating = false;
+  forceRest = true;
+  animTime = 0;
+
+  const btn = document.getElementById('btnAnimate');
+  btn.textContent = '⏸ paused';
+  btn.classList.remove('active');
+
   document.getElementById('slIntensity').value = 1;
   ['UAx','UAz','LAx','LAz','Hx','Hy'].forEach(id => {
     document.getElementById('sl' + id).value = 0;
   });
+
+  applyRest();
+  syncCurrentRotations();
+  updateBoneReadout(currentSide);
 }
 
 // ── Resize ────────────────────────────────────────────────────

--- a/archive/test-3d-model.html
+++ b/archive/test-3d-model.html
@@ -397,7 +397,12 @@
 <script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/r128/three.min.js"></script>
 
 <script type="module">
-import { lookAtHand } from './gesture.js';
+const { lookAtHand } = await import('./gesture.js').catch(error => {
+  const message = `Failed to load ./gesture.js: ${error.message}. Serve this file over HTTP instead of opening it with file://.`;
+  console.error(message, error);
+  document.getElementById('hud').insertAdjacentHTML('beforeend', `<br><span style="color:#ff6b9d">${message}</span>`);
+  return { lookAtHand: () => {} };
+});
 // ── Scene setup ──────────────────────────────────────────────
 const canvas = document.getElementById('c');
 const renderer = new THREE.WebGLRenderer({ canvas, antialias: true, alpha: true });
@@ -633,6 +638,56 @@ function blend(from, to, t) { return from + (to - from) * t; }
 
 function lerp(a, b, t) { return a + (b - a) * t; }
 
+function snapshotRotations() {
+  return {
+    lUA: leftArm.uaPivot.rotation.clone(),
+    lLA: leftArm.laPivot.rotation.clone(),
+    lH: leftArm.hPivot.rotation.clone(),
+    rUA: rightArm.uaPivot.rotation.clone(),
+    rLA: rightArm.laPivot.rotation.clone(),
+    rH: rightArm.hPivot.rotation.clone(),
+    neck: neck.rotation.clone(),
+    head: head.rotation.clone(),
+  };
+}
+
+function applyLerpedRotations(from, t) {
+  const pairs = [
+    [leftArm.uaPivot, from.lUA],
+    [leftArm.laPivot, from.lLA],
+    [leftArm.hPivot, from.lH],
+    [rightArm.uaPivot, from.rUA],
+    [rightArm.laPivot, from.rLA],
+    [rightArm.hPivot, from.rH],
+    [neck, from.neck],
+    [head, from.head],
+  ];
+
+  pairs.forEach(([object, start]) => {
+    const target = object.rotation.clone();
+    object.rotation.set(
+      lerp(start.x, target.x, t),
+      lerp(start.y, target.y, t),
+      lerp(start.z, target.z, t)
+    );
+  });
+}
+
+function syncCurrentRotations() {
+  cur.lUA.x = leftArm.uaPivot.rotation.x;
+  cur.lUA.z = leftArm.uaPivot.rotation.z;
+  cur.lLA.x = leftArm.laPivot.rotation.x;
+  cur.lLA.z = leftArm.laPivot.rotation.z;
+  cur.lH.x = leftArm.hPivot.rotation.x;
+  cur.lH.y = leftArm.hPivot.rotation.y;
+  cur.rUA.x = rightArm.uaPivot.rotation.x;
+  cur.rUA.z = rightArm.uaPivot.rotation.z;
+  cur.rLA.x = rightArm.laPivot.rotation.x;
+  cur.rLA.z = rightArm.laPivot.rotation.z;
+  cur.rH.x = rightArm.hPivot.rotation.x;
+  cur.rH.y = rightArm.hPivot.rotation.y;
+}
+
 // Compute targets from lookAtHand case and lerp cur toward them
 function tickAnimation(dt) {
   if (animating) animTime += dt;
@@ -642,6 +697,10 @@ function tickAnimation(dt) {
   const intensity = +document.getElementById('slIntensity').value;
   const io = getIO();
   const s = currentSide;
+
+  const animatedIntensity = animating
+    ? intensity * (0.55 + 0.45 * (0.5 + 0.5 * Math.sin(animTime * 2.4)))
+    : intensity;
 
   // Update display
   document.getElementById('valIntensity').textContent = intensity.toFixed(2);
@@ -653,9 +712,11 @@ function tickAnimation(dt) {
   document.getElementById('valHy').textContent  = (+document.getElementById('slHy').value).toFixed(2);
   document.getElementById('hudInt').textContent = intensity.toFixed(2);
 
+  const beforeGesture = snapshotRotations();
+
   lookAtHand({
         side: currentSide,
-        intensity,
+        intensity: animatedIntensity,
         io,
         REST,
         THREE,
@@ -672,6 +733,9 @@ function tickAnimation(dt) {
         rH: rightArm.hPivot
       });
 
+  applyLerpedRotations(beforeGesture, lerpT);
+  syncCurrentRotations();
+
   // ── Update bone readout ──
   const activeUA = s < 0 ? cur.lUA : cur.rUA;
   const activeLA = s < 0 ? cur.lLA : cur.rLA;
@@ -686,6 +750,8 @@ function tickAnimation(dt) {
 
 // Stub so sidebar sliders still call something
 function update() { /* driven by render loop */ }
+
+Object.assign(window, { setSide, toggleAnimate, update, resetAll });
 
 function resetAll() {
   document.getElementById('slIntensity').value = 1;


### PR DESCRIPTION
### Motivation
- The 3D gesture tester page was loading blank because the module `gesture.js` was not reliably imported when opened directly, and the gestures were not visibly animating the stick-figure model. 
- The sidebar controls (buttons/sliders) were not available to the module-scoped script, preventing interactive testing.

### Description
- Load `gesture.js` with a dynamic `await import('./gesture.js')` and surface a helpful HUD message on failure so the scene still initializes when the module cannot be loaded. 
- Add `snapshotRotations()`, `applyLerpedRotations()` and `syncCurrentRotations()` helper functions and use a `beforeGesture` snapshot plus `lerpT` to smoothly interpolate poses after `lookAtHand` runs. 
- Drive an `animatedIntensity` value (oscillating when animation is enabled) and pass it to `lookAtHand` so the stick figure visibly animates. 
- Expose UI handlers to the global scope with `Object.assign(window, { setSide, toggleAnimate, update, resetAll })` so inline sidebar buttons/sliders work from the module script. 

### Testing
- Ran `git diff --check` to verify there are no whitespace/check errors and it succeeded. 
- Extracted the module script and ran `node --check /tmp/test-3d-module.mjs` to validate the module script syntax and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d49b68a1c832ca036ab83af979b49)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved hand/arm animation blending for smoother pose transitions.
  * Added time-based intensity oscillation when animation is enabled.

* **Bug Fixes**
  * Better handling when the gesture logic fails to load, with an on-screen error instead of a broken page.
  * UI controls now reliably trigger the expected actions from the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->