### PR TITLE
Update documentation for current runtime (README + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aiko-chan 愛子ちゃん
 
-> A local-first AI companion with a curses TUI, persistent memory, web search, microphone input, and MioTTS voice output.
+> A local-first AI companion with a curses TUI, optional browser WebUI + VRM avatar, persistent memory, web search, microphone input, and MioTTS voice output.
 > Optimised for constrained hardware — runs on a Jetson Orin Nano with 8GB unified RAM.
 
 **Author:** [OppaAI](https://github.com/OppaAI) · Beautiful British Columbia, Canada
@@ -10,7 +10,7 @@
 ![Status](https://img.shields.io/badge/Status-experimental-orange.svg)
 
  
-![LLM](https://img.shields.io/badge/Model-Ministral--3B-967BB6?logo=ai&logoColor=white)
+![LLM](https://img.shields.io/badge/Runtime-llama.cpp_OpenAI--compatible-967BB6?logo=ai&logoColor=white)
 ![Python](https://img.shields.io/badge/Python-3.12-blue?logo=python&logoColor=white)
 ![Ubuntu](https://img.shields.io/badge/Ubuntu-24.04_LTS-orange?logo=ubuntu&logoColor=white)
 ![CUDA](https://img.shields.io/badge/CUDA-12.6-76B900?logo=nvidia)
@@ -18,12 +18,11 @@
 ---
 
 ## Status
-Phase 2 is almost complete
-ASR and TTS are basically running in the TUI interface while the voice recording and playing is through the mic and speaker connected to Jetson (or the hardware running the TUI) itself.
-Still trying to figure out how to stream the voice input and output through network over remote connection via the WebUI interface.
-And a few tweaks and optimizations here and there are still needed to let the voice input and output run smoothly.
+Phase 2 voice is implemented, and Phase 2.5 agentic workflows are now active. The default launch path is still the curses TUI; the browser WebUI/VRM frontend is available with `--webui` and includes a WebSocket bridge for chat, vitals, voice status, expression, viseme, and browser microphone events.
 
-> Know Issues:
+ASR and TTS run through the local machine by default. WebUI microphone streaming exists in the frontend/backend bridge, but full remote voice-device polish is still experimental.
+
+> Known Issues:
 > - TTS via MioTTS sometimes cannot inference proper voice output due to memory constraint (May switch MioTTS model and even BGE 1.5 embedding model to the smallest param ones to squeeze out a bit more RAM)
 > - Time latency between ASR voice input ends to beginning of TTS voice output are still over 5 sec for normal chats. Need to figure out how to do proper synchronized text and speech streaming to save a couple seconds.
 > - ASR may have transcribing errors that output wrong text or even wrong language, especially when accent is present in speaker's voice or when using low quality microphone.
@@ -43,10 +42,10 @@ And a few tweaks and optimizations here and there are still needed to let the vo
 ## Purpose
 This project currently serves as:
 
-- a local AI companion chatbot with persistent memory, web search, TTS, ASR, and a terminal UI;
+- a local AI companion chatbot with persistent memory, web search, TTS, ASR, a terminal UI, and an optional browser WebUI/VRM avatar;
 - a stress test for running a full conversational stack on constrained hardware such as an 8 GB VRAM GPU or Jetson Orin Nano;
 - a precursor and testing sandbox for the larger Grace / AuRoRA project;
-- an experimental playground for memory decay, nightly consolidation, and daily reflection publishing.
+- an experimental playground for memory decay, nightly consolidation, daily reflection publishing, agentic tools, scheduled reminders, and workflow skills.
 
 ---
 
@@ -65,8 +64,8 @@ This project currently serves as:
 
 ```mermaid
 flowchart TD
-    YOU[You] --> TUI[TUI\ncurses]
-    TUI --> THINK[Think\nOllama LLM]
+    YOU[You] --> UI[UI\ncurses or WebUI]
+    UI --> THINK[Think\nllama.cpp/OpenAI-compatible LLM]
     THINK <-->|async| MEM[Memory\nsqlite-vec + fastembed]
     THINK <-->|on demand| SEARCH[Web search\nSearXNG]
     THINK --> SPEAK[Speak\nMioTTS]
@@ -81,35 +80,39 @@ flowchart TD
 
 | Layer | Implementation |
 |---|---|
-| Entry point | `main.py` |
-| Interface | full-screen curses TUI in `tui/` |
-| Chat model | Ollama via `ollama.Client` |
+| Entry point | `main.py` (`--tui` default path, `--webui` optional browser mode) |
+| Interface | full-screen curses TUI in `tui/`; optional browser WebUI in `webui/` |
+| Chat model | llama.cpp or any OpenAI-compatible local server via `openai.OpenAI` |
 | Long-term memory | custom sqlite-vec backend (no server required) |
 | Embeddings | fastembed `BAAI/bge-base-en-v1.5` |
 | Memory lifecycle | Ebbinghaus-style decay, pinned memories, nightly `dream()` consolidation |
-| Web search | local SearXNG instance |
+| Web search | local SearXNG instance through `core/toolkit/web.py` |
 | TTS | external MioTTS HTTP server |
 | ASR | SenseVoice via sherpa-onnx with Silero VAD |
 | Reflection publishing | optional GitHub REST API + Hugo markdown |
+| Agentic task mode | `core/agentic.py` ReAct loop + `core/tools.py` facade + `core/toolkit/` modules |
+| Skills | `skills/<id>/SKILL.md` workflow registry loaded by `core/skills.py` |
+| Scheduling | local schedule/reminder runner using `workspace/schedule.json` |
 
 ---
 
 ## Quickstart
 
-**Prerequisites:** Python 3.12, [uv](https://astral.sh/uv), CUDA 12.6, Docker + Compose, [Ollama](https://ollama.com), a pulled chat model (3B+ recommended).
+**Prerequisites:** Python 3.12, [uv](https://astral.sh/uv), CUDA 12.6, Docker + Compose, a llama.cpp/OpenAI-compatible local LLM server, and a pulled/served chat model (3B+ recommended).
 
 > Full installation walkthrough → **[docs/INSTALL.md](docs/INSTALL.md)**
 
 ```bash
 git clone https://github.com/OppaAI/Aiko-chan.git
 cd Aiko-chan
-cp .env.example .env        # edit: OLLAMA_MODEL, SQLITE_MEMORY_PATH, SEARXNG_URL, MIOTTS_API_URL
+cp .env.example .env        # edit: LLM_BASE_URL, LLM_MODEL, SQLITE_MEMORY_PATH, SEARXNG_URL, MIOTTS_API_URL
 docker compose up -d
 uv sync
-uv run python main.py
+uv run python main.py            # curses TUI, full voice if services are available
 ```
 
 ```bash
+uv run python main.py --webui    # browser WebUI + VRM frontend
 uv run python main.py --text      # keyboard input, no ASR/TTS
 uv run python main.py --debug     # show memory hits each turn
 uv run python main.py --clear-mem # wipe all memories and exit
@@ -140,7 +143,7 @@ uv run python main.py --clear-mem # wipe all memories and exit
 Aiko-chan/
 ├── main.py
 ├── core/
-│   ├── think.py         # Ollama chat loop, streaming, web-search trigger
+│   ├── think.py         # OpenAI-compatible chat loop, routing, streaming, scheduler
 │   ├── memorize.py      # sqlite-vec backend, pinned memories, decay
 │   ├── forget.py        # decay scoring and cleanup gates
 │   ├── dream.py         # midnight consolidation scheduler
@@ -152,13 +155,16 @@ Aiko-chan/
 │   ├── tools.py         # compatibility facade for toolkit tools
 │   ├── toolkit/         # focused tool modules: web, planning, scheduling, photo, architecture
 │   ├── skills.py        # skill registry and workflow retrieval
-│   ├── schedule.py      # schedule reminders (excute scheduled tasks in the future)
+│   ├── schedule.py      # schedule reminders and local scheduled tasks
 │   ├── health.py        # system information
 │   ├── log.py           # rotating log setup
 │   └── silence.py       # stderr suppression
 ├── tui/
-│   ├── tui.py           # curse TUI interface
+│   ├── tui.py           # curses TUI interface
 │   └── identity.py      # ASCII art of TUI interface
+├── webui/
+│   ├── aiko_web.py      # browser UI backend + HTTP/WebSocket bridge
+│   └── static/          # HTML/JS/CSS, VRM avatar, browser audio worklet
 ├── persona/
 │   ├── soul.md          # personality, rules, and voice
 │   ├── skills.md        # human-readable skill index
@@ -167,7 +173,7 @@ Aiko-chan/
 │   └── identity.md      # banner and ASCII art
 ├── skills/
 │   ├── aiko_architect/  # architecture/code workflow skill
-│   ├── aurora_forecase_watch/  # aurora forecase/reminder workflow skill
+│   ├── aurora_forecast_watch/  # aurora forecast/reminder workflow skill
 │   ├── coding_tutor/    # coding tutorial workflow skill
 │   ├── japanese_tutor/  # Japanese tutorial workflow skill
 │   └── wildlife_photo/  # photo-ingestion workflow skill
@@ -195,7 +201,7 @@ Aiko-chan/
 | 1 | Soul — CLI, Ollama, mem0 + Qdrant, SearXNG | ✅ Done |
 | 1.5 | Stream — curses TUI, streaming pipeline, persona, test TTS models | ✅ Done |
 | 2 | Voice — SenseVoice ASR, Silero VAD, MioTTS, hands-free talk | ✅ Done |
-| 2.5 | Agent — tool registry, skill workflows, scheduled local tasks | 🔲 Planned |
+| 2.5 | Agent — tool registry, skill workflows, scheduled local tasks | ✅ Active |
 | 3 | Face — VRM avatar, three-vrm, expressions, lip-sync | 🔲 Planned |
 | 4 | Presence — emotional state, mood, relationship progression | 🔲 Planned |
 | 5 | Mobile — React Native / Flutter, WAN, push notifications | 🔲 Planned |
@@ -210,6 +216,7 @@ Full details → **[docs/ROADMAP.md](docs/ROADMAP.md)**
 
 - Memory uses a custom sqlite-vec backend — no Qdrant server or mem0 required. Qdrant + mem0 were dropped in Phase 2 due to OOM issues on the Jetson Orin Nano.
 - Entry point is `main.py`, not `cli.py` anymore.
+- LLM runtime is now an OpenAI-compatible endpoint (`LLM_BASE_URL`/`LLM_MODEL`), usually llama.cpp `llama-server`; older Ollama-specific settings are archived/outdated.
 - TTS runtime is MioTTS server with 0.4B Q4KM model (Tried XTTS with CoquiTTS, Kokoro and RealtimeTTS, PocketTTS but removed due to Jetson OOM/latency/quality tradeoffs).
 - ASR runtime is SenseVoice via sherpa-onnx with Silero VAD. (Tried ReazonSpeech K2 and faster-whisper but removed due to English capability and RAM usage tradeoffs respectively)
 - Reflection publishing fails safely if `GITHUB_TOKEN` or `GITHUB_REPO` are missing.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,12 +4,12 @@
 
 Aiko's runtime is already partly separated:
 
-- `main.py` is the launch orchestrator. It selects WebUI by default, keeps the curses TUI behind `--tui`, boots the subsystems through `AikoWakeup`, and then runs the shared input → route → render loop.
-- `webui/aiko_web.py` is the browser UI adapter. It serves `webui/static/`, opens a WebSocket bridge, and implements the same draw/input methods as the curses TUI.
+- `main.py` is the launch orchestrator. It selects the curses TUI by default, keeps the browser WebUI behind `--webui`, boots the subsystems through `AikoWakeup`, and then runs the shared input → route → render loop.
+- `webui/aiko_web.py` is the browser UI adapter. It serves `webui/static/`, opens a WebSocket bridge, accepts browser mic-audio frames, broadcasts chat/vitals/voice/expression/viseme events, and implements the same draw/input methods as the curses TUI.
 - `tui/tui.py` is the legacy full-screen curses adapter. It implements the same UI contract used by the shared session loop.
 - `core/wakeup.py` owns parallel subsystem startup and returns a `BootResult` containing live references to thinking, memory, speech, and listening modules.
 - `core/tools.py` is the compatibility facade for pure callable tools and should stay as the stable import surface; focused implementations live under `core/toolkit/` (web, planning, scheduling, photo, architecture). These functions do not own the ReAct loop.
-- `core/think.py` owns the public chat facade: routing, normal chat, TTS/history glue, scheduled job callbacks, and background memory writes.
+- `core/think.py` owns the public chat facade: OpenAI-compatible LLM client setup, semantic/LLM routing, normal chat, TTS/history glue, scheduled job callbacks, idle learner handoff, and background memory writes.
 - `core/agentic.py` owns task-mode tool schemas, ReAct loop execution, and tool dispatch.
 - `core/skills.py` owns local skill document CRUD/search helpers and the `skills/<skill_id>/SKILL.md` registry used by task mode.
 - `core/memorize.py` owns persistent memory CRUD, recall, pinning, decay, cleanup, and nightly consolidation.
@@ -21,7 +21,7 @@ Aiko's runtime is already partly separated:
 The runtime split should stay close to this shape:
 
 ```text
-main.py            CLI flags, UI selection, shared session loop
+main.py            CLI flags, default curses UI selection, optional WebUI selection, shared session loop
 webui/aiko_web.py  browser adapter: HTTP static server, WebSocket bridge, UI API
 tui/tui.py         curses adapter implementing the same UI API
 core/wakeup.py     boot orchestration and BootResult assembly
@@ -30,7 +30,7 @@ core/toolkit/      focused tool implementations, no LLM loop, no conversational 
 core/agentic.py    ReAct loop, tool schemas, tool dispatch
 core/skills.py     skill CRUD and retrieval: load, append, prune, search, skill registry
 skills/<id>/       human-readable repeatable workflow documents
-core/think.py      public chat facade: normal chat, agentic handoff, TTS/history glue
+core/think.py      public chat facade: OpenAI-compatible LLM calls, normal chat, agentic handoff, TTS/history glue
 ```
 
 Keep memory separate from all three: `core/memorize.py` should remain the single owner of persistent memory, including `pin()`.
@@ -41,14 +41,14 @@ Keep memory separate from all three: `core/memorize.py` should remain the single
 flowchart TD
     User[User] --> Entry[main.py]
     Entry --> Choice{UI mode?}
-    Choice -->|default / --webui| WebUI[AikoWeb\nHTTP + WebSocket browser UI]
-    Choice -->|--tui| TUI[AikoTUI\ncurses terminal UI]
+    Choice -->|default / --tui| TUI[AikoTUI\ncurses terminal UI]
+    Choice -->|--webui| WebUI[AikoWeb\nHTTP + WebSocket browser UI]
 
     WebUI --> Session[Shared session loop\n_run_session]
     TUI --> Session
 
     Session --> Wakeup[AikoWakeup.boot]
-    Wakeup --> Think[AikoThink]
+    Wakeup --> Think[AikoThink\nOpenAI-compatible client]
     Wakeup --> Memory[AikoMemorize\nsqlite-vec + embeddings]
     Wakeup --> Speak[AikoSpeak\nMioTTS]
     Wakeup --> Listen[AikoListen\nSenseVoice + Silero VAD]
@@ -81,8 +81,8 @@ sequenceDiagram
     participant Speak as core.speak.AikoSpeak
     participant Listen as core.listen.AikoListen
 
-    User->>Main: python main.py [--webui|--tui|--text]
-    Main->>UI: construct selected UI adapter
+    User->>Main: python main.py [--tui|--webui|--text|--no-asr]
+    Main->>UI: construct selected UI adapter (curses by default, browser with --webui)
     Main->>UI: start init spin loop
     Main->>Wakeup: boot(on_loading, on_done, on_skip)
     par Parallel cognitive boot
@@ -196,6 +196,7 @@ flowchart TD
 flowchart LR
     Browser[Browser\nwebui/static/index.html] <-->|WebSocket JSON| AikoWeb[AikoWeb\nwebui/aiko_web.py]
     Browser -->|HTTP GET / and /assets/Aiko.vrm| Static[Static file server\nwebui/static]
+    Browser -->|binary mic frames| AikoWeb
     AikoWeb -->|get_input queue| Main[main.py shared loop]
     Main -->|add_message / stream_token / vitals / voice state| AikoWeb
     AikoWeb -->|broadcast JSON events| Browser
@@ -256,6 +257,15 @@ flowchart TD
     Decide -->|yes| Final[final_answer]
     Final --> Stream[Return natural answer to UI]
 ```
+
+## Current Runtime Configuration
+
+- `LLM_BASE_URL` and `LLM_MODEL` select the local OpenAI-compatible LLM endpoint. The current code no longer imports `ollama.Client` for chat.
+- `EMBED_MODEL`, `SQLITE_MEMORY_PATH`, and `FASTEMBED_CACHE_PATH` configure local sqlite-vec memory and fastembed embeddings.
+- `ROUTE_ENABLED`/`ROUTE_MODE`/`ROUTE_SEMANTIC_THRESHOLD` are the environment variables read by `core/think.py`; older `AIKO_ROUTE_*` names in stale env files should be migrated.
+- `MIOTTS_API_URL`, `MIOTTS_PRESET`, and `MIOTTS_DEVICE` configure voice output.
+- `ASR_*`, `LISTEN_*`, and `SPEAKER_*` configure SenseVoice, Silero VAD, optional speaker verification, and barge-in.
+- `WORKSPACE_ROOT`, `SCHEDULE_PATH`, and `SCHEDULE_POLL_SECONDS` configure local scheduled work/reminders.
 
 ## Memory Use Rules
 

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -45,6 +45,7 @@ Major accomplishments:
 - asynchronous memory writes
 - web-grounded responses
 - fully local deployment
+- initial Ollama-based chat runtime, later replaced by an OpenAI-compatible local endpoint
 
 Lessons learned:
 
@@ -131,18 +132,24 @@ Goal:
 
 Major additions:
 
+- browser WebUI/VRM bridge groundwork under `webui/` and `webui/static/`
+- OpenAI-compatible local LLM client path for llama.cpp-style servers
 - agentic toolkit focused tool modules
 - agentic tools compatibility facade
-- agentic skills workflow documents `skills.md`
+- agentic skill workflow documents under `skills/<skill_id>/SKILL.md`
 - agentic skill discovery and retrieval in `core/skills.py`
 - agentic task-mode skill context injection
-- initial `wildlife_photo` and `aiko_architect` skills project
+- initial `wildlife_photo`, `aiko_architect`, `coding_tutor`, `japanese_tutor`, and `aurora_forecast_watch` skill projects
+- local scheduling/reminder infrastructure using `workspace/schedule.json`
+- final-answer verification/repair safeguards in the agentic loop
 
 Lessons learned:
 
 - Tools are executable abilities; skills are repeatable workflows.
 - Markdown skill files are for humans and prompts; Python toolkit modules are for actions.
 - `core/tools.py` remains useful as a stable public facade even when implementations move into `core/toolkit/`.
+- The browser WebUI can share the TUI contract, but remote voice-device UX still needs polishing.
+- Environment-variable migrations need docs: `LLM_*` and `ROUTE_*` are now the current names for chat runtime/routing.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,7 +1,7 @@
 [← Back to README](../README.md)
 # Aiko-chan 愛子ちゃん — Installation Guide
 
-This guide walks through installing every component of the Aiko-chan stack from scratch. Follow the sections in order; each one is a prerequisite for the next.
+This guide installs the current Aiko-chan stack: Python 3.12 + `uv`, SearXNG in Docker, a local OpenAI-compatible LLM endpoint (usually llama.cpp `llama-server`), sqlite-vec memory, MioTTS, SenseVoice ASR, the curses TUI, and the optional browser WebUI/VRM frontend.
 
 ---
 
@@ -10,16 +10,15 @@ This guide walks through installing every component of the Aiko-chan stack from 
 1. [System Requirements](#1-system-requirements)
 2. [Python 3.12 via pyenv](#2-python-312-via-pyenv)
 3. [uv Package Manager](#3-uv-package-manager)
-4. [Docker & Docker Compose](#4-docker--docker-compose)
-5. [SearXNG (via Docker)](#5-searxng-via-docker)
-6. [Ollama](#6-ollama)
-7. [Pull a Chat Model](#7-pull-a-chat-model)
-8. [MioTTS Server](#8-miotts-server)
-9. [Clone the Repo & Configure Environment](#9-clone-the-repo--configure-environment)
-10. [Install Python Dependencies](#10-install-python-dependencies)
-11. [Jetson Orin Nano — Extra Steps](#11-jetson-orin-nano--extra-steps)
-12. [Verify the Full Stack](#12-verify-the-full-stack)
-13. [Run Aiko-chan](#13-run-aiko-chan)
+4. [Clone the Repo](#4-clone-the-repo)
+5. [Docker & SearXNG](#5-docker--searxng)
+6. [Local LLM Server](#6-local-llm-server)
+7. [MioTTS Server](#7-miotts-server)
+8. [Configure Environment](#8-configure-environment)
+9. [Install Python Dependencies](#9-install-python-dependencies)
+10. [Jetson Orin Nano Notes](#10-jetson-orin-nano-notes)
+11. [Verify the Full Stack](#11-verify-the-full-stack)
+12. [Run Aiko-chan](#12-run-aiko-chan)
 
 ---
 
@@ -27,346 +26,273 @@ This guide walks through installing every component of the Aiko-chan stack from 
 
 | Requirement | Minimum | Notes |
 |---|---|---|
-| OS | Ubuntu 22.04 / 24.04 | Also works on WSL2 |
-| Python | **3.12.x** | `pyproject.toml` is pinned `>=3.12,<3.13` |
-| RAM | 8 GB | 16 GB recommended for comfort |
-| GPU VRAM | 4 GB | 8 GB for smooth local LLM inference |
-| Storage | 20 GB free | Models are large |
+| OS | Ubuntu 22.04 / 24.04 | Also works on WSL2 for text-only/testing use |
+| Python | **3.12.x** | `pyproject.toml` requires `>=3.12,<3.13` |
+| RAM | 8 GB | 16 GB recommended |
+| GPU/accelerator | optional but recommended | Jetson Orin Nano is the target constrained device |
+| Storage | 20 GB free | LLM, ASR, TTS, and embedding models are large |
 | Docker | 24.x+ | Required for SearXNG |
-
-> **Jetson Orin Nano:** See [Section 11](#11-jetson-orin-nano--extra-steps) for board-specific wheel overrides before running `uv sync`.
+| Local LLM server | OpenAI-compatible `/v1` API | `LLM_BASE_URL` defaults to `http://localhost:8080/v1` |
 
 ---
 
 ## 2. Python 3.12 via pyenv
 
-Aiko-chan requires Python **3.12**. Using `pyenv` avoids polluting your system Python.
-
 ```bash
-# Install pyenv dependencies
 sudo apt update
 sudo apt install -y make build-essential libssl-dev zlib1g-dev \
   libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
   libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
   libffi-dev liblzma-dev git
 
-# Install pyenv
 curl https://pyenv.run | bash
 
-# Add pyenv to your shell (bash example — adjust for zsh/fish)
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
 echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 source ~/.bashrc
 
-# Install Python 3.12 and set it as the local default
 pyenv install 3.12.13
 pyenv global 3.12.13
-
-# Confirm
-python --version   # should print Python 3.12.x
+python --version
 ```
 
 ---
 
 ## 3. uv Package Manager
 
-`uv` is the only supported package manager for this project.
-
 ```bash
-# Install uv (official installer)
 curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Reload your shell so the uv binary is on PATH
-source $HOME/.cargo/env   # or open a new terminal
-
-# Confirm
+source "$HOME/.cargo/env"
 uv --version
 ```
 
----
-
-## 4. Docker & Docker Compose
-
-SearXNG run as Docker containers.
-
-```bash
-# Remove any old Docker installs
-sudo apt remove -y docker docker-engine docker.io containerd runc 2>/dev/null || true
-
-# Install Docker Engine via the official convenience script
-curl -fsSL https://get.docker.com | sudo sh
-
-# Add your user to the docker group (avoids needing sudo for every docker command)
-sudo usermod -aG docker $USER
-newgrp docker   # apply group change without logging out
-
-# Confirm Docker
-docker --version
-
-# Docker Compose is included with Docker Engine as a plugin
-docker compose version
-```
+`uv` is the supported dependency manager for this repo.
 
 ---
 
-## 5. SearXNG (via Docker)
-
-SearXNG is also managed by the project's `docker-compose.yml`. The `searxng/` directory inside the repo holds its configuration, so **clone the repo first** (Section 10) before starting the stack.
-
-Once the repo is cloned, from the project root:
+## 4. Clone the Repo
 
 ```bash
-# Start SearXNG together
-docker compose up -d
-
-# Confirm both containers are running
-docker compose ps
-```
-
-Expected output:
-
-```
-NAME        STATUS
-searxng     running
-```
-
-SearXNG is available at the URL you set in `SEARXNG_URL` (default **http://localhost:8081**).
-
----
-
-## 6. Ollama
-
-Ollama serves the local LLM used by Aiko's `think.py` core.
-
-```bash
-# Install Ollama
-curl -fsSL https://ollama.com/install.sh | sh
-
-# The installer registers a systemd service; confirm it is running
-systemctl status ollama
-
-# If not running, start it manually
-ollama serve
-```
-
-> On a **Jetson**, Ollama detects CUDA automatically. Verify with `ollama run llama3.2 "hello"` and check that GPU utilisation rises in `jtop`.
-
----
-
-## 7. Pull a Chat Model
-
-Pull the model referenced in your `.env` as `OLLAMA_MODEL`. The default in `.env.example` is a Ministral 3B reasoning GGUF:
-
-```bash
-ollama pull hf.co/unsloth/Ministral-3-3B-Reasoning-2512-GGUF:UD-Q4_K_XL
-```
-
-For a more capable model (recommended for grounded search answers — 7B+):
-
-```bash
-ollama pull mistral:7b-instruct
-# or
-ollama pull qwen2.5:7b
-```
-
-Confirm the model loads:
-
-```bash
-ollama run mistral:7b-instruct "Say hello."
-```
-
----
-
-## 8. MioTTS Server
-
-MioTTS is an external HTTP TTS server. Aiko calls it at `MIOTTS_API_URL` (default **http://localhost:8001**).
-
-> If you do not need voice output, set `MIOTTS_API_URL` to an unreachable address and run Aiko in `--text` mode. The client fails gracefully.
-
-**Option A — Run MioTTS via Docker (recommended):**
-
-```bash
-docker run -d --name miotts \
-  -p 8001:8001 \
-  # replace with the actual MioTTS image when available
-  miotts/miotts-server
-```
-
-**Option B — Run MioTTS from source:**
-
-Follow the MioTTS project's own README. Once running, verify the health endpoint:
-
-```bash
-curl http://localhost:8001/health
-# Expected: {"status":"ok"} or similar
-```
-
----
-
-## 9. Clone the Repo & Configure Environment
-
-```bash
-# Clone
 git clone https://github.com/OppaAI/Aiko-chan.git
 cd Aiko-chan
-
-# Copy the example env file
 cp .env.example .env
 ```
 
-Open `.env` in your editor and set at minimum:
+The repo contains `docker-compose.yml`, `searxng/` config, Python source, `webui/static/`, skills, persona files, and docs.
+
+---
+
+## 5. Docker & SearXNG
+
+```bash
+sudo apt remove -y docker docker-engine docker.io containerd runc 2>/dev/null || true
+curl -fsSL https://get.docker.com | sudo sh
+sudo usermod -aG docker "$USER"
+newgrp docker
+
+docker --version
+docker compose version
+```
+
+Start SearXNG from the project root:
+
+```bash
+docker compose up -d
+docker compose ps
+```
+
+Expected service/container: `aiko_searxng` running and listening at `http://localhost:8081`.
+
+---
+
+## 6. Local LLM Server
+
+Aiko's current chat runtime uses the OpenAI Python client against a local OpenAI-compatible endpoint. The default environment values are:
 
 ```dotenv
-# Ollama
-OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=hf.co/unsloth/Ministral-3-3B-Reasoning-2512-GGUF:UD-Q4_K_XL
+LLM_BASE_URL=http://localhost:8080/v1
+LLM_MODEL=ministral
+```
 
-# SearXNG
+A common setup is llama.cpp `llama-server` with a local GGUF model. Example:
+
+```bash
+# Example only: adjust paths, GPU layers, context, and alias for your hardware/model.
+llama-server \
+  -m /path/to/Ministral-3-3B-Reasoning-Q4_K_M.gguf \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --alias ministral \
+  --jinja \
+  -c 4096
+```
+
+Verify the endpoint:
+
+```bash
+curl http://localhost:8080/v1/models
+curl http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"ministral","messages":[{"role":"user","content":"Say hello."}],"max_tokens":32}'
+```
+
+> Older Ollama-specific instructions are no longer the primary path for the current codebase. You can still use any backend that exposes an OpenAI-compatible `/v1` API and matches `LLM_BASE_URL`/`LLM_MODEL`.
+
+---
+
+## 7. MioTTS Server
+
+MioTTS is an external HTTP synthesis service. Aiko calls `MIOTTS_API_URL` and plays the returned audio through `sounddevice`.
+
+```dotenv
+MIOTTS_API_URL=http://localhost:8001
+MIOTTS_MODEL=MioTTS-0.4B-Q4_K_M
+MIOTTS_PRESET=aiko_flat
+```
+
+Typical MioTTS flow:
+
+1. Start the local OpenAI-compatible model server that serves the MioTTS model.
+2. Start MioTTS's `run_server.py` wrapper, pointed at that model server.
+3. Verify the API before launching Aiko.
+
+```bash
+curl http://localhost:8001/health
+uv run python core/speak.py --devices
+uv run python core/speak.py --wait "Hello, I'm Aiko."
+```
+
+If you do not need voice, run Aiko with `--text`; wakeup will skip TTS and ASR.
+
+---
+
+## 8. Configure Environment
+
+Edit `.env`. At minimum, check these values:
+
+```dotenv
+# Identity
+AI_NAME=Aiko
+USER_ID=OppaAI
+
+# Local OpenAI-compatible LLM
+LLM_BASE_URL=http://localhost:8080/v1
+LLM_MODEL=ministral
+LLM_TIMEOUT=120
+LLM_MAX_TOKENS=280
+
+# Memory
+SQLITE_MEMORY_PATH=/home/oppa-ai/.aiko/memory.db
+FASTEMBED_CACHE_PATH=/home/oppa-ai/.cache/fastembed
+EMBED_MODEL=BAAI/bge-base-en-v1.5
+MEMORY_RECALL_LIMIT=5
+
+# Web search
 SEARXNG_URL=http://localhost:8081
 SEARXNG_SECRET=<your_secret_from_searxng_settings.yml>
 
-# MioTTS (leave blank or point to a dummy URL to disable voice)
+# Voice output
 MIOTTS_API_URL=http://localhost:8001
+MIOTTS_PRESET=aiko_flat
 
-# ASR — SenseVoice via sherpa-onnx + Silero VAD
+# Voice input
 ASR_DEVICE=cpu
 ASR_LANGUAGE=auto
 ASR_MODEL=csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17
+
+# Routing and agentic mode (current names read by core/think.py)
+ROUTE_ENABLED=1
+ROUTE_MODE=semantic
+ROUTE_SEMANTIC_THRESHOLD=0.36
+SEARCH_SEMANTIC_THRESHOLD=0.36
+
+# Scheduling/workspace
+TIMEZONE=America/Vancouver
+WORKSPACE_ROOT=workspace
+SCHEDULE_PATH=workspace/schedule.json
+SCHEDULE_POLL_SECONDS=15
 ```
 
-The `SEARXNG_SECRET` must match the `secret_key` value inside `searxng/settings.yml`.
+If your `.env` still has only `AIKO_ROUTE_*` keys, add the `ROUTE_*` keys above; the current code reads `ROUTE_ENABLED`, `ROUTE_MODE`, and `ROUTE_SEMANTIC_THRESHOLD`.
 
 ---
 
-## 10. Install Python Dependencies
-
-```bash
-# From the project root with Python 3.12 active
-uv sync
-```
-
-`uv` reads `pyproject.toml` and `uv.lock`, creates a virtual environment in `.venv/`, and installs all dependencies.
-
-> **If `uv sync` fails on wheel not found:** Check the local wheel paths in `pyproject.toml` for `torch` and `ctranslate2`. On a standard x86 machine, comment out or replace those path overrides with regular PyPI versions. On a Jetson, see Section 12.
-
----
-
-## 11. Jetson Orin Nano — Extra Steps
-
-The Jetson requires board-specific wheels for PyTorch that are not on PyPI.
-
-### 11a. Download Jetson AI Lab wheels
-
-Visit [https://forums.developer.nvidia.com/t/pytorch-for-jetson](https://forums.developer.nvidia.com/t/pytorch-for-jetson) and download the `.whl` files for:
-
-- `torch` (JetPack 6.x compatible)
-- `torchaudio`
-- `torchvision`
-- `ctranslate2` (Jetson build)
-
-Place the wheels in a local directory, e.g. `~/wheels/`.
-
-### 11b. Update pyproject.toml wheel paths
-
-In `pyproject.toml`, confirm the path overrides for `torch` and `ctranslate2` point to your downloaded `.whl` files:
-
-```toml
-[tool.uv.sources]
-torch = { path = "/home/oppa-ai/wheels/torch-<version>-cp310-linux_aarch64.whl" }
-ctranslate2 = { path = "/home/oppa-ai/wheels/ctranslate2-<version>-cp310-linux_aarch64.whl" }
-```
-
-### 11c. Install JetPack dev libraries (if not already present)
-
-```bash
-sudo apt install -y libopenblas-dev libopenmpi-dev
-```
-
-### 11d. Run uv sync
+## 9. Install Python Dependencies
 
 ```bash
 uv sync
 ```
 
-### 11e. PulseAudio default sink (for TTS audio output)
+This installs dependencies from `pyproject.toml`/`uv.lock`, including `openai`, `sqlite-vec`, `fastembed`, `sherpa-onnx`, `silero-vad`, `sounddevice`, `soundfile`, `websockets`, `torch`, and `torchaudio`.
 
-If audio output is silent after install, fix the PulseAudio default sink:
+For browser frontend asset experiments, the repo also has a `package.json` with `three` and `@pixiv/three-vrm`; the checked-in `webui/static/` files are served directly by Python, so `npm install` is not required for normal runtime.
+
+---
+
+## 10. Jetson Orin Nano Notes
+
+- The current `pyproject.toml` uses PyPI dependencies plus an ONNX Runtime CUDA nightly index for `onnxruntime-gpu`.
+- `ASR_DEVICE=cpu` is the documented SenseVoice setting in `.env.example` because CUDA EP availability can vary by JetPack/JP version.
+- Keep `SQLITE_MEMORY_PATH` and `FASTEMBED_CACHE_PATH` on persistent storage, not `/tmp`.
+- If audio output is silent, inspect devices and set `MIOTTS_DEVICE` or the system default sink:
 
 ```bash
-# List available sinks
+uv run python core/speak.py --devices
 pactl list short sinks
-
-# Set the default (replace <sink_name> with your output device)
 pactl set-default-sink <sink_name>
-
-# To make it persist across reboots, add to /etc/pulse/default.pa:
-echo "set-default-sink <sink_name>" | sudo tee -a /etc/pulse/default.pa
 ```
+
+- Watch memory pressure with `jtop` when LLM, MioTTS, ASR, and embeddings are warm.
 
 ---
 
-## 12. Verify the Full Stack
-
-Run this checklist before launching Aiko for the first time:
+## 11. Verify the Full Stack
 
 ```bash
-# 1. SearXNG
+# SearXNG
 curl "http://localhost:8081/search?q=test&format=json" \
   -H "X-Forwarded-For: 127.0.0.1"
-# Expected: JSON search results
 
-# 2. Ollama
-curl http://localhost:11434/api/tags
-# Expected: JSON list of pulled models
+# Local OpenAI-compatible LLM
+curl http://localhost:8080/v1/models
 
-# 3. MioTTS (if using voice)
+# MioTTS (voice mode only)
 curl http://localhost:8001/health
-# Expected: {"status":"ok"} or similar
 
-# 4. Python environment
-uv run python -c "import sqlite_vec; import sherpa_onnx; import silero_vad; print('deps OK')"
-# Expected: deps OK
+# Python imports
+uv run python -c "import sqlite_vec, fastembed, sherpa_onnx, silero_vad, sounddevice, websockets; print('OK')"
 
-# 5. ASR model cache (first voice launch downloads SenseVoice files if absent)
-uv run python -c "from core.listen import ASR_MODEL; print(ASR_MODEL)"
-# Expected: csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17 or your override
+# Skill registry and agentic tool schemas
+uv run python -c "from core.skills import list_skillsets; print(list_skillsets())"
+uv run python -c "from core.agentic import tool_schemas; print([s['function']['name'] for s in tool_schemas()])"
+
+# Memory backend
+uv run python -c "from core.memorize import AikoMemorize; m=AikoMemorize(silent=True); print(m.get_all()[:1])"
 ```
 
 ---
 
-## 13. Run Aiko-chan
+## 12. Run Aiko-chan
 
 ```bash
-# Full voice mode (ASR input + TTS output)
+# Default: curses TUI, full voice if services are available
 uv run python main.py
 
-# Text-only mode (keyboard input, no ASR/TTS)
+# Browser WebUI + VRM frontend
+uv run python main.py --webui
+
+# Keyboard-only, skips ASR and TTS
 uv run python main.py --text
 
-# Text mode with memory debug output
-uv run python main.py --text --debug
+# Keyboard input but keep TTS available
+uv run python main.py --no-asr
 
-# Wipe all stored memories and exit
+# Debug memory hits each turn
+uv run python main.py --debug
+
+# Wipe memories and exit
 uv run python main.py --clear-mem
 ```
 
-On first launch Aiko will:
-1. Connect to SQLite-vec and initialise the memory collection if it does not exist.
-2. Warm up the Ollama model in the background.
-3. Warm up MioTTS in the background (voice mode only).
-4. Open the curses TUI.
-
----
-
-## Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `uv sync` fails — wheel not found | Jetson wheel path wrong | Update path in `pyproject.toml` → Section 12b |
-| SearXNG returns 403 | Wrong `SEARXNG_SECRET` | Match secret in `.env` and `searxng/settings.yml` |
-| Ollama model not found | Model not pulled | `ollama pull <model>` → Section 8 |
-| No TTS audio on Jetson | Wrong PulseAudio sink | `pactl set-default-sink` → Section 11e |
-| ASR import/model error | Missing sherpa-onnx/SenseVoice deps or model cache | Run `uv sync`, then launch once online or set `HF_HUB_OFFLINE=0` |
-| LLM ignores search results | Model too small (< 7B) | Pull a 7B+ model → Section 8 |
-| `curses` import error | Running inside a non-TTY | Run in a real terminal, not a pipe |
+In-app commands include `/quit`, `/reset`, `/memory`, `/clear`, `/remember`, `/think <question>`, `/web <query>`, `/voice`, `/listen`, and `/help`.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -10,20 +10,21 @@ Manual smoke-test checklist for each phase. Run the relevant section after insta
 Run before any phase tests. All items must pass.
 
 - [ ] `curl "http://localhost:8081/search?q=test&format=json"` returns JSON results
-- [ ] `curl http://localhost:11434/api/tags` returns a JSON list containing your configured model
+- [ ] `curl http://localhost:8080/v1/models` returns a JSON list containing your configured `LLM_MODEL`
 - [ ] `curl http://localhost:8001/health` returns `{"status":"ok"}` (voice mode only)
-- [ ] `uv run python -c "import sqlite_vec; import fastembed; print('OK')"` prints `OK`
-- [ ] `docker compose ps` shows `searxng` as `running`
+- [ ] `uv run python -c "import sqlite_vec; import fastembed; import sherpa_onnx; import silero_vad; print('OK')"` prints `OK`
+- [ ] `docker compose ps` shows `aiko_searxng` / `searxng` as `running`
 - [ ] SQLite memory DB path exists and is on persistent storage (not `/tmp`): `ls -lh $SQLITE_MEMORY_PATH`
 
 ---
 
 ## Phase 1 — Soul
 
-*CLI chatbot, Ollama inference, mem0 + Qdrant memory, web search.*
+*CLI/TUI chatbot, OpenAI-compatible local LLM inference, sqlite-vec memory, web search.*
 
-### Ollama / LLM
+### Local LLM Endpoint
 
+- [ ] `curl http://localhost:8080/v1/models` lists the model alias configured as `LLM_MODEL`
 - [ ] Aiko launches without errors in `--text` mode
 - [ ] First message receives a streamed response (tokens appear progressively, not all at once)
 - [ ] Response is coherent and matches the persona defined in `persona/soul.md`
@@ -77,6 +78,14 @@ Run before any phase tests. All items must pass.
 - [ ] Background LLM warmup on startup eliminates cold-start delay on the first real message
 - [ ] Memory writes do not block the streaming response (non-blocking queue worker)
 
+### WebUI / VRM Bridge
+
+- [ ] `uv run python main.py --webui --text` prints the browser URL and serves `webui/static/index.html`
+- [ ] Browser connects to the WebSocket and text chat works end-to-end
+- [ ] Chat messages, streamed tokens, commit events, vitals, and voice state updates appear in the browser
+- [ ] VRM asset loads from `webui/static/assets/Aiko.vrm`
+- [ ] Browser refresh/reconnect does not crash the Python backend
+
 ### TTS — MioTTS
 
 - [ ] `/voice` toggle enables TTS; spoken audio plays for the next assistant response
@@ -123,14 +132,21 @@ Run before any phase tests. All items must pass.
 
 ## Phase 2.5 — Agent
 
-*Agentic task loop, toolkit tools, skillset registry, scheduled local work.*
+*Agentic task loop, toolkit tools, skillset registry, final-answer verification, scheduled local work.*
 
 ### Toolkit & Skill Registry
 
-- [ ] `uv run python -c "from core.skills import list_skillsets; print(list_skillsets())"` lists `wildlife_photo` and `aiko_architect`
-- [ ] `uv run python -c "from core.agentic import tool_schemas; print([s['function']['name'] for s in tool_schemas()])"` includes skill, photo, and repo tools
+- [ ] `uv run python -c "from core.skills import list_skillsets; print(list_skillsets())"` lists `wildlife_photo`, `aiko_architect`, `coding_tutor`, `japanese_tutor`, and `aurora_forecast_watch`
+- [ ] `uv run python -c "from core.agentic import tool_schemas; print([s['function']['name'] for s in tool_schemas()])"` includes web, planning, workspace, scheduling, skill, photo, and repo tools
 - [ ] Asking Aiko to process wildlife photos loads/uses the `wildlife_photo` skill context
 - [ ] Asking Aiko to inspect her architecture loads/uses the `aiko_architect` skill context
+
+### Scheduling / Reminder Workflow
+
+- [ ] Asking Aiko to schedule a reminder creates/updates `workspace/schedule.json`
+- [ ] `list_schedule` reports scheduled jobs with IDs, due times, frequency, and action
+- [ ] `cancel_schedule` removes the selected job and persists the change
+- [ ] Due announce jobs play a short notification/beep when available and inject a reminder turn into chat
 
 ### Photo Workflow
 
@@ -169,7 +185,7 @@ Run before any phase tests. All items must pass.
 
 ### WebSocket Bridge
 
-- [ ] Python backend connects to the browser WebSocket on startup without errors
+- [ ] Python backend starts the browser WebSocket on startup without errors
 - [ ] Expression commands sent from Python appear in the browser within ~100 ms
 - [ ] Reconnection works if the browser tab is refreshed while Python is running
 


### PR DESCRIPTION
### Motivation
- The documentation referenced an older Ollama-first workflow, omitted the browser WebUI/VRM frontend, and had outdated environment variable names and phase status, so docs needed syncing to the current codebase shape. 
- The code now targets an OpenAI-compatible local LLM endpoint (e.g. `llama-server`/`/v1`), includes a browser WebUI with a WebSocket/VRM bridge, and has active Phase 2.5 agentic workflows and scheduling that must be documented. 
- Tests and quickstart examples referenced old ports/keys and deprecated memory stacks (mem0/Qdrant), which risk confusing users, so they were updated to the sqlite-vec/fastembed stack and current service endpoints. 

### Description
- Updated `README.md` to reflect the OpenAI-compatible local LLM runtime via `LLM_BASE_URL`/`LLM_MODEL`, add the optional browser WebUI/VRM frontend and WebSocket bridge, mark Phase 2.5 as active, and refresh quickstart commands (e.g. `--webui`, `--no-asr`).
- Rewrote `docs/INSTALL.md` to document the current stack (local OpenAI-compatible LLM server, MioTTS, SenseVoice ASR, sqlite-vec/fastembed), clarify environment variables (e.g. `ROUTE_*`, `LLM_*`), and consolidate Jetson notes and verification commands.
- Updated `docs/ARCHITECTURE.md` to correct the default UI selection (curses by default, `--webui` optional), document WebUI data flow (including browser mic frames, vitals, expression/viseme events), and add a "Current Runtime Configuration" section describing key env vars.
- Adjusted `docs/HISTORY.md` and `docs/TESTS.md` to record the runtime migration (Ollama → OpenAI-compatible), expand skill listings and scheduling/agentic test coverage, and replace stale endpoints and checks with current ones.
- Fixed small doc typos and renamed `aurora_forecase_watch` → `aurora_forecast_watch`, added `webui/` to the project structure, and added references to `core/agentic.py`, `core/tools.py`, and scheduling/skills features.

### Testing
- Ran bytecode checks with `python -m py_compile main.py core/think.py core/wakeup.py core/agentic.py`, which completed successfully. 
- Executed a doc-sanity script that validated the docs no longer reference `OLLAMA_MODEL` or the old `localhost:11434` endpoint using a short Python check, and the assertions passed. 
- Confirmed changes were staged and committed (commit message: "Update documentation for current runtime") and a PR stub was prepared; no runtime integration tests were run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d725ae140832c867881a48a008c1b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup, architecture, history, and testing guides to match the current app flow and configuration.
  * Added browser WebUI, VRM avatar, agent tools, skills, reminders, and memory workflow coverage.
  * Replaced outdated LLM setup references with current local OpenAI-compatible endpoint instructions.
  * Expanded verification steps for voice, web, skills, scheduling, and reconnect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->