### PR TITLE
Add optional WebUI/VRM frontend, OpenAI-compatible LLM runtime, agentic features, and industrial test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Aiko-chan 愛子ちゃん
 
-> A local-first AI companion with a curses TUI, persistent memory, web search, microphone input, and MioTTS voice output.
+> A local-first AI companion with a curses TUI, optional browser WebUI + VRM avatar, persistent memory, web search, microphone input, and MioTTS voice output.
 > Optimised for constrained hardware — runs on a Jetson Orin Nano with 8GB unified RAM.
 
 **Author:** [OppaAI](https://github.com/OppaAI) · Beautiful British Columbia, Canada
@@ -10,7 +10,7 @@
 ![Status](https://img.shields.io/badge/Status-experimental-orange.svg)
 
  
-![LLM](https://img.shields.io/badge/Model-Ministral--3B-967BB6?logo=ai&logoColor=white)
+![LLM](https://img.shields.io/badge/Runtime-llama.cpp_OpenAI--compatible-967BB6?logo=ai&logoColor=white)
 ![Python](https://img.shields.io/badge/Python-3.12-blue?logo=python&logoColor=white)
 ![Ubuntu](https://img.shields.io/badge/Ubuntu-24.04_LTS-orange?logo=ubuntu&logoColor=white)
 ![CUDA](https://img.shields.io/badge/CUDA-12.6-76B900?logo=nvidia)
@@ -18,12 +18,11 @@
 ---
 
 ## Status
-Phase 2 is almost complete
-ASR and TTS are basically running in the TUI interface while the voice recording and playing is through the mic and speaker connected to Jetson (or the hardware running the TUI) itself.
-Still trying to figure out how to stream the voice input and output through network over remote connection via the WebUI interface.
-And a few tweaks and optimizations here and there are still needed to let the voice input and output run smoothly.
+Phase 2 voice is implemented, and Phase 2.5 agentic workflows are now active. The default launch path is still the curses TUI; the browser WebUI/VRM frontend is available with `--webui` and includes a WebSocket bridge for chat, vitals, voice status, expression, viseme, and browser microphone events.
 
-> Know Issues:
+ASR and TTS run through the local machine by default. WebUI microphone streaming exists in the frontend/backend bridge, but full remote voice-device polish is still experimental.
+
+> Known Issues:
 > - TTS via MioTTS sometimes cannot inference proper voice output due to memory constraint (May switch MioTTS model and even BGE 1.5 embedding model to the smallest param ones to squeeze out a bit more RAM)
 > - Time latency between ASR voice input ends to beginning of TTS voice output are still over 5 sec for normal chats. Need to figure out how to do proper synchronized text and speech streaming to save a couple seconds.
 > - ASR may have transcribing errors that output wrong text or even wrong language, especially when accent is present in speaker's voice or when using low quality microphone.
@@ -43,10 +42,10 @@ And a few tweaks and optimizations here and there are still needed to let the vo
 ## Purpose
 This project currently serves as:
 
-- a local AI companion chatbot with persistent memory, web search, TTS, ASR, and a terminal UI;
+- a local AI companion chatbot with persistent memory, web search, TTS, ASR, a terminal UI, and an optional browser WebUI/VRM avatar;
 - a stress test for running a full conversational stack on constrained hardware such as an 8 GB VRAM GPU or Jetson Orin Nano;
 - a precursor and testing sandbox for the larger Grace / AuRoRA project;
-- an experimental playground for memory decay, nightly consolidation, and daily reflection publishing.
+- an experimental playground for memory decay, nightly consolidation, daily reflection publishing, agentic tools, scheduled reminders, and workflow skills.
 
 ---
 
@@ -57,7 +56,7 @@ This project currently serves as:
 | [docs/INSTALL.md](docs/INSTALL.md) | Step-by-step installation for every component |
 | [docs/HISTORY.md](docs/HISTORY.md) | How Aiko evolved from a chatbot into a companion |
 | [docs/ROADMAP.md](docs/ROADMAP.md) | Detailed phase-by-phase feature roadmap |
-| [docs/TESTS.md](docs/TESTS.md) | Manual smoke-test checklist for each phase |
+| [docs/TESTS.md](docs/TESTS.md) | Industrial test plan: unit, integration, system, load, error, performance, stability, and phase acceptance |
 
 ---
 
@@ -65,8 +64,8 @@ This project currently serves as:
 
 ```mermaid
 flowchart TD
-    YOU[You] --> TUI[TUI\ncurses]
-    TUI --> THINK[Think\nOllama LLM]
+    YOU[You] --> UI[UI\ncurses or WebUI]
+    UI --> THINK[Think\nllama.cpp/OpenAI-compatible LLM]
     THINK <-->|async| MEM[Memory\nsqlite-vec + fastembed]
     THINK <-->|on demand| SEARCH[Web search\nSearXNG]
     THINK --> SPEAK[Speak\nMioTTS]
@@ -81,35 +80,39 @@ flowchart TD
 
 | Layer | Implementation |
 |---|---|
-| Entry point | `main.py` |
-| Interface | full-screen curses TUI in `tui/` |
-| Chat model | Ollama via `ollama.Client` |
+| Entry point | `main.py` (`--tui` default path, `--webui` optional browser mode) |
+| Interface | full-screen curses TUI in `tui/`; optional browser WebUI in `webui/` |
+| Chat model | llama.cpp or any OpenAI-compatible local server via `openai.OpenAI` |
 | Long-term memory | custom sqlite-vec backend (no server required) |
 | Embeddings | fastembed `BAAI/bge-base-en-v1.5` |
 | Memory lifecycle | Ebbinghaus-style decay, pinned memories, nightly `dream()` consolidation |
-| Web search | local SearXNG instance |
+| Web search | local SearXNG instance through `core/toolkit/web.py` |
 | TTS | external MioTTS HTTP server |
 | ASR | SenseVoice via sherpa-onnx with Silero VAD |
 | Reflection publishing | optional GitHub REST API + Hugo markdown |
+| Agentic task mode | `core/agentic.py` ReAct loop + `core/tools.py` facade + `core/toolkit/` modules |
+| Skills | `skills/<id>/SKILL.md` workflow registry loaded by `core/skills.py` |
+| Scheduling | local schedule/reminder runner using `workspace/schedule.json` |
 
 ---
 
 ## Quickstart
 
-**Prerequisites:** Python 3.12, [uv](https://astral.sh/uv), CUDA 12.6, Docker + Compose, [Ollama](https://ollama.com), a pulled chat model (3B+ recommended).
+**Prerequisites:** Python 3.12, [uv](https://astral.sh/uv), CUDA 12.6, Docker + Compose, a llama.cpp/OpenAI-compatible local LLM server, and a pulled/served chat model (3B+ recommended).
 
 > Full installation walkthrough → **[docs/INSTALL.md](docs/INSTALL.md)**
 
 ```bash
 git clone https://github.com/OppaAI/Aiko-chan.git
 cd Aiko-chan
-cp .env.example .env        # edit: OLLAMA_MODEL, SQLITE_MEMORY_PATH, SEARXNG_URL, MIOTTS_API_URL
+cp .env.example .env        # edit: LLM_BASE_URL, LLM_MODEL, SQLITE_MEMORY_PATH, SEARXNG_URL, MIOTTS_API_URL
 docker compose up -d
 uv sync
-uv run python main.py
+uv run python main.py            # curses TUI, full voice if services are available
 ```
 
 ```bash
+uv run python main.py --webui    # browser WebUI + VRM frontend
 uv run python main.py --text      # keyboard input, no ASR/TTS
 uv run python main.py --debug     # show memory hits each turn
 uv run python main.py --clear-mem # wipe all memories and exit
@@ -140,7 +143,7 @@ uv run python main.py --clear-mem # wipe all memories and exit
 Aiko-chan/
 ├── main.py
 ├── core/
-│   ├── think.py         # Ollama chat loop, streaming, web-search trigger
+│   ├── think.py         # OpenAI-compatible chat loop, routing, streaming, scheduler
 │   ├── memorize.py      # sqlite-vec backend, pinned memories, decay
 │   ├── forget.py        # decay scoring and cleanup gates
 │   ├── dream.py         # midnight consolidation scheduler
@@ -152,13 +155,16 @@ Aiko-chan/
 │   ├── tools.py         # compatibility facade for toolkit tools
 │   ├── toolkit/         # focused tool modules: web, planning, scheduling, photo, architecture
 │   ├── skills.py        # skill registry and workflow retrieval
-│   ├── schedule.py      # schedule reminders (excute scheduled tasks in the future)
+│   ├── schedule.py      # schedule reminders and local scheduled tasks
 │   ├── health.py        # system information
 │   ├── log.py           # rotating log setup
 │   └── silence.py       # stderr suppression
 ├── tui/
-│   ├── tui.py           # curse TUI interface
+│   ├── tui.py           # curses TUI interface
 │   └── identity.py      # ASCII art of TUI interface
+├── webui/
+│   ├── aiko_web.py      # browser UI backend + HTTP/WebSocket bridge
+│   └── static/          # HTML/JS/CSS, VRM avatar, browser audio worklet
 ├── persona/
 │   ├── soul.md          # personality, rules, and voice
 │   ├── skills.md        # human-readable skill index
@@ -167,7 +173,7 @@ Aiko-chan/
 │   └── identity.md      # banner and ASCII art
 ├── skills/
 │   ├── aiko_architect/  # architecture/code workflow skill
-│   ├── aurora_forecase_watch/  # aurora forecase/reminder workflow skill
+│   ├── aurora_forecast_watch/  # aurora forecast/reminder workflow skill
 │   ├── coding_tutor/    # coding tutorial workflow skill
 │   ├── japanese_tutor/  # Japanese tutorial workflow skill
 │   └── wildlife_photo/  # photo-ingestion workflow skill
@@ -178,6 +184,15 @@ Aiko-chan/
 │   ├── INSTALL.md
 │   ├── TESTS.md
 │   └── ROADMAP.md
+├── tests/              # test-suite specifications and future automation layout
+│   ├── unit/
+│   ├── integration/
+│   ├── system/
+│   ├── load/
+│   ├── error/
+│   ├── performance/
+│   ├── stability/
+│   └── functionality/
 ├── assets/
 ├── docker-compose.yml
 ├── pyproject.toml
@@ -195,7 +210,7 @@ Aiko-chan/
 | 1 | Soul — CLI, Ollama, mem0 + Qdrant, SearXNG | ✅ Done |
 | 1.5 | Stream — curses TUI, streaming pipeline, persona, test TTS models | ✅ Done |
 | 2 | Voice — SenseVoice ASR, Silero VAD, MioTTS, hands-free talk | ✅ Done |
-| 2.5 | Agent — tool registry, skill workflows, scheduled local tasks | 🔲 Planned |
+| 2.5 | Agent — tool registry, skill workflows, scheduled local tasks | ✅ Active |
 | 3 | Face — VRM avatar, three-vrm, expressions, lip-sync | 🔲 Planned |
 | 4 | Presence — emotional state, mood, relationship progression | 🔲 Planned |
 | 5 | Mobile — React Native / Flutter, WAN, push notifications | 🔲 Planned |
@@ -210,6 +225,7 @@ Full details → **[docs/ROADMAP.md](docs/ROADMAP.md)**
 
 - Memory uses a custom sqlite-vec backend — no Qdrant server or mem0 required. Qdrant + mem0 were dropped in Phase 2 due to OOM issues on the Jetson Orin Nano.
 - Entry point is `main.py`, not `cli.py` anymore.
+- LLM runtime is now an OpenAI-compatible endpoint (`LLM_BASE_URL`/`LLM_MODEL`), usually llama.cpp `llama-server`; older Ollama-specific settings are archived/outdated.
 - TTS runtime is MioTTS server with 0.4B Q4KM model (Tried XTTS with CoquiTTS, Kokoro and RealtimeTTS, PocketTTS but removed due to Jetson OOM/latency/quality tradeoffs).
 - ASR runtime is SenseVoice via sherpa-onnx with Silero VAD. (Tried ReazonSpeech K2 and faster-whisper but removed due to English capability and RAM usage tradeoffs respectively)
 - Reflection publishing fails safely if `GITHUB_TOKEN` or `GITHUB_REPO` are missing.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,12 +4,12 @@
 
 Aiko's runtime is already partly separated:
 
-- `main.py` is the launch orchestrator. It selects WebUI by default, keeps the curses TUI behind `--tui`, boots the subsystems through `AikoWakeup`, and then runs the shared input → route → render loop.
-- `webui/aiko_web.py` is the browser UI adapter. It serves `webui/static/`, opens a WebSocket bridge, and implements the same draw/input methods as the curses TUI.
+- `main.py` is the launch orchestrator. It selects the curses TUI by default, keeps the browser WebUI behind `--webui`, boots the subsystems through `AikoWakeup`, and then runs the shared input → route → render loop.
+- `webui/aiko_web.py` is the browser UI adapter. It serves `webui/static/`, opens a WebSocket bridge, accepts browser mic-audio frames, broadcasts chat/vitals/voice/expression/viseme events, and implements the same draw/input methods as the curses TUI.
 - `tui/tui.py` is the legacy full-screen curses adapter. It implements the same UI contract used by the shared session loop.
 - `core/wakeup.py` owns parallel subsystem startup and returns a `BootResult` containing live references to thinking, memory, speech, and listening modules.
 - `core/tools.py` is the compatibility facade for pure callable tools and should stay as the stable import surface; focused implementations live under `core/toolkit/` (web, planning, scheduling, photo, architecture). These functions do not own the ReAct loop.
-- `core/think.py` owns the public chat facade: routing, normal chat, TTS/history glue, scheduled job callbacks, and background memory writes.
+- `core/think.py` owns the public chat facade: OpenAI-compatible LLM client setup, semantic/LLM routing, normal chat, TTS/history glue, scheduled job callbacks, idle learner handoff, and background memory writes.
 - `core/agentic.py` owns task-mode tool schemas, ReAct loop execution, and tool dispatch.
 - `core/skills.py` owns local skill document CRUD/search helpers and the `skills/<skill_id>/SKILL.md` registry used by task mode.
 - `core/memorize.py` owns persistent memory CRUD, recall, pinning, decay, cleanup, and nightly consolidation.
@@ -21,7 +21,7 @@ Aiko's runtime is already partly separated:
 The runtime split should stay close to this shape:
 
 ```text
-main.py            CLI flags, UI selection, shared session loop
+main.py            CLI flags, default curses UI selection, optional WebUI selection, shared session loop
 webui/aiko_web.py  browser adapter: HTTP static server, WebSocket bridge, UI API
 tui/tui.py         curses adapter implementing the same UI API
 core/wakeup.py     boot orchestration and BootResult assembly
@@ -30,7 +30,7 @@ core/toolkit/      focused tool implementations, no LLM loop, no conversational 
 core/agentic.py    ReAct loop, tool schemas, tool dispatch
 core/skills.py     skill CRUD and retrieval: load, append, prune, search, skill registry
 skills/<id>/       human-readable repeatable workflow documents
-core/think.py      public chat facade: normal chat, agentic handoff, TTS/history glue
+core/think.py      public chat facade: OpenAI-compatible LLM calls, normal chat, agentic handoff, TTS/history glue
 ```
 
 Keep memory separate from all three: `core/memorize.py` should remain the single owner of persistent memory, including `pin()`.
@@ -41,14 +41,14 @@ Keep memory separate from all three: `core/memorize.py` should remain the single
 flowchart TD
     User[User] --> Entry[main.py]
     Entry --> Choice{UI mode?}
-    Choice -->|default / --webui| WebUI[AikoWeb\nHTTP + WebSocket browser UI]
-    Choice -->|--tui| TUI[AikoTUI\ncurses terminal UI]
+    Choice -->|default / --tui| TUI[AikoTUI\ncurses terminal UI]
+    Choice -->|--webui| WebUI[AikoWeb\nHTTP + WebSocket browser UI]
 
     WebUI --> Session[Shared session loop\n_run_session]
     TUI --> Session
 
     Session --> Wakeup[AikoWakeup.boot]
-    Wakeup --> Think[AikoThink]
+    Wakeup --> Think[AikoThink\nOpenAI-compatible client]
     Wakeup --> Memory[AikoMemorize\nsqlite-vec + embeddings]
     Wakeup --> Speak[AikoSpeak\nMioTTS]
     Wakeup --> Listen[AikoListen\nSenseVoice + Silero VAD]
@@ -81,8 +81,8 @@ sequenceDiagram
     participant Speak as core.speak.AikoSpeak
     participant Listen as core.listen.AikoListen
 
-    User->>Main: python main.py [--webui|--tui|--text]
-    Main->>UI: construct selected UI adapter
+    User->>Main: python main.py [--tui|--webui|--text|--no-asr]
+    Main->>UI: construct selected UI adapter (curses by default, browser with --webui)
     Main->>UI: start init spin loop
     Main->>Wakeup: boot(on_loading, on_done, on_skip)
     par Parallel cognitive boot
@@ -196,6 +196,7 @@ flowchart TD
 flowchart LR
     Browser[Browser\nwebui/static/index.html] <-->|WebSocket JSON| AikoWeb[AikoWeb\nwebui/aiko_web.py]
     Browser -->|HTTP GET / and /assets/Aiko.vrm| Static[Static file server\nwebui/static]
+    Browser -->|binary mic frames| AikoWeb
     AikoWeb -->|get_input queue| Main[main.py shared loop]
     Main -->|add_message / stream_token / vitals / voice state| AikoWeb
     AikoWeb -->|broadcast JSON events| Browser
@@ -256,6 +257,15 @@ flowchart TD
     Decide -->|yes| Final[final_answer]
     Final --> Stream[Return natural answer to UI]
 ```
+
+## Current Runtime Configuration
+
+- `LLM_BASE_URL` and `LLM_MODEL` select the local OpenAI-compatible LLM endpoint. The current code no longer imports `ollama.Client` for chat.
+- `EMBED_MODEL`, `SQLITE_MEMORY_PATH`, and `FASTEMBED_CACHE_PATH` configure local sqlite-vec memory and fastembed embeddings.
+- `ROUTE_ENABLED`/`ROUTE_MODE`/`ROUTE_SEMANTIC_THRESHOLD` are the environment variables read by `core/think.py`; older `AIKO_ROUTE_*` names in stale env files should be migrated.
+- `MIOTTS_API_URL`, `MIOTTS_PRESET`, and `MIOTTS_DEVICE` configure voice output.
+- `ASR_*`, `LISTEN_*`, and `SPEAKER_*` configure SenseVoice, Silero VAD, optional speaker verification, and barge-in.
+- `WORKSPACE_ROOT`, `SCHEDULE_PATH`, and `SCHEDULE_POLL_SECONDS` configure local scheduled work/reminders.
 
 ## Memory Use Rules
 

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -45,6 +45,7 @@ Major accomplishments:
 - asynchronous memory writes
 - web-grounded responses
 - fully local deployment
+- initial Ollama-based chat runtime, later replaced by an OpenAI-compatible local endpoint
 
 Lessons learned:
 
@@ -131,18 +132,24 @@ Goal:
 
 Major additions:
 
+- browser WebUI/VRM bridge groundwork under `webui/` and `webui/static/`
+- OpenAI-compatible local LLM client path for llama.cpp-style servers
 - agentic toolkit focused tool modules
 - agentic tools compatibility facade
-- agentic skills workflow documents `skills.md`
+- agentic skill workflow documents under `skills/<skill_id>/SKILL.md`
 - agentic skill discovery and retrieval in `core/skills.py`
 - agentic task-mode skill context injection
-- initial `wildlife_photo` and `aiko_architect` skills project
+- initial `wildlife_photo`, `aiko_architect`, `coding_tutor`, `japanese_tutor`, and `aurora_forecast_watch` skill projects
+- local scheduling/reminder infrastructure using `workspace/schedule.json`
+- final-answer verification/repair safeguards in the agentic loop
 
 Lessons learned:
 
 - Tools are executable abilities; skills are repeatable workflows.
 - Markdown skill files are for humans and prompts; Python toolkit modules are for actions.
 - `core/tools.py` remains useful as a stable public facade even when implementations move into `core/toolkit/`.
+- The browser WebUI can share the TUI contract, but remote voice-device UX still needs polishing.
+- Environment-variable migrations need docs: `LLM_*` and `ROUTE_*` are now the current names for chat runtime/routing.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,7 +1,7 @@
 [← Back to README](../README.md)
 # Aiko-chan 愛子ちゃん — Installation Guide
 
-This guide walks through installing every component of the Aiko-chan stack from scratch. Follow the sections in order; each one is a prerequisite for the next.
+This guide installs the current Aiko-chan stack: Python 3.12 + `uv`, SearXNG in Docker, a local OpenAI-compatible LLM endpoint (usually llama.cpp `llama-server`), sqlite-vec memory, MioTTS, SenseVoice ASR, the curses TUI, and the optional browser WebUI/VRM frontend.
 
 ---
 
@@ -10,16 +10,15 @@ This guide walks through installing every component of the Aiko-chan stack from 
 1. [System Requirements](#1-system-requirements)
 2. [Python 3.12 via pyenv](#2-python-312-via-pyenv)
 3. [uv Package Manager](#3-uv-package-manager)
-4. [Docker & Docker Compose](#4-docker--docker-compose)
-5. [SearXNG (via Docker)](#5-searxng-via-docker)
-6. [Ollama](#6-ollama)
-7. [Pull a Chat Model](#7-pull-a-chat-model)
-8. [MioTTS Server](#8-miotts-server)
-9. [Clone the Repo & Configure Environment](#9-clone-the-repo--configure-environment)
-10. [Install Python Dependencies](#10-install-python-dependencies)
-11. [Jetson Orin Nano — Extra Steps](#11-jetson-orin-nano--extra-steps)
-12. [Verify the Full Stack](#12-verify-the-full-stack)
-13. [Run Aiko-chan](#13-run-aiko-chan)
+4. [Clone the Repo](#4-clone-the-repo)
+5. [Docker & SearXNG](#5-docker--searxng)
+6. [Local LLM Server](#6-local-llm-server)
+7. [MioTTS Server](#7-miotts-server)
+8. [Configure Environment](#8-configure-environment)
+9. [Install Python Dependencies](#9-install-python-dependencies)
+10. [Jetson Orin Nano Notes](#10-jetson-orin-nano-notes)
+11. [Verify the Full Stack](#11-verify-the-full-stack)
+12. [Run Aiko-chan](#12-run-aiko-chan)
 
 ---
 
@@ -27,346 +26,273 @@ This guide walks through installing every component of the Aiko-chan stack from 
 
 | Requirement | Minimum | Notes |
 |---|---|---|
-| OS | Ubuntu 22.04 / 24.04 | Also works on WSL2 |
-| Python | **3.12.x** | `pyproject.toml` is pinned `>=3.12,<3.13` |
-| RAM | 8 GB | 16 GB recommended for comfort |
-| GPU VRAM | 4 GB | 8 GB for smooth local LLM inference |
-| Storage | 20 GB free | Models are large |
+| OS | Ubuntu 22.04 / 24.04 | Also works on WSL2 for text-only/testing use |
+| Python | **3.12.x** | `pyproject.toml` requires `>=3.12,<3.13` |
+| RAM | 8 GB | 16 GB recommended |
+| GPU/accelerator | optional but recommended | Jetson Orin Nano is the target constrained device |
+| Storage | 20 GB free | LLM, ASR, TTS, and embedding models are large |
 | Docker | 24.x+ | Required for SearXNG |
-
-> **Jetson Orin Nano:** See [Section 11](#11-jetson-orin-nano--extra-steps) for board-specific wheel overrides before running `uv sync`.
+| Local LLM server | OpenAI-compatible `/v1` API | `LLM_BASE_URL` defaults to `http://localhost:8080/v1` |
 
 ---
 
 ## 2. Python 3.12 via pyenv
 
-Aiko-chan requires Python **3.12**. Using `pyenv` avoids polluting your system Python.
-
 ```bash
-# Install pyenv dependencies
 sudo apt update
 sudo apt install -y make build-essential libssl-dev zlib1g-dev \
   libbz2-dev libreadline-dev libsqlite3-dev wget curl llvm \
   libncursesw5-dev xz-utils tk-dev libxml2-dev libxmlsec1-dev \
   libffi-dev liblzma-dev git
 
-# Install pyenv
 curl https://pyenv.run | bash
 
-# Add pyenv to your shell (bash example — adjust for zsh/fish)
 echo 'export PYENV_ROOT="$HOME/.pyenv"' >> ~/.bashrc
 echo 'command -v pyenv >/dev/null || export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bashrc
 echo 'eval "$(pyenv init -)"' >> ~/.bashrc
 source ~/.bashrc
 
-# Install Python 3.12 and set it as the local default
 pyenv install 3.12.13
 pyenv global 3.12.13
-
-# Confirm
-python --version   # should print Python 3.12.x
+python --version
 ```
 
 ---
 
 ## 3. uv Package Manager
 
-`uv` is the only supported package manager for this project.
-
 ```bash
-# Install uv (official installer)
 curl -LsSf https://astral.sh/uv/install.sh | sh
-
-# Reload your shell so the uv binary is on PATH
-source $HOME/.cargo/env   # or open a new terminal
-
-# Confirm
+source "$HOME/.cargo/env"
 uv --version
 ```
 
----
-
-## 4. Docker & Docker Compose
-
-SearXNG run as Docker containers.
-
-```bash
-# Remove any old Docker installs
-sudo apt remove -y docker docker-engine docker.io containerd runc 2>/dev/null || true
-
-# Install Docker Engine via the official convenience script
-curl -fsSL https://get.docker.com | sudo sh
-
-# Add your user to the docker group (avoids needing sudo for every docker command)
-sudo usermod -aG docker $USER
-newgrp docker   # apply group change without logging out
-
-# Confirm Docker
-docker --version
-
-# Docker Compose is included with Docker Engine as a plugin
-docker compose version
-```
+`uv` is the supported dependency manager for this repo.
 
 ---
 
-## 5. SearXNG (via Docker)
-
-SearXNG is also managed by the project's `docker-compose.yml`. The `searxng/` directory inside the repo holds its configuration, so **clone the repo first** (Section 10) before starting the stack.
-
-Once the repo is cloned, from the project root:
+## 4. Clone the Repo
 
 ```bash
-# Start SearXNG together
-docker compose up -d
-
-# Confirm both containers are running
-docker compose ps
-```
-
-Expected output:
-
-```
-NAME        STATUS
-searxng     running
-```
-
-SearXNG is available at the URL you set in `SEARXNG_URL` (default **http://localhost:8081**).
-
----
-
-## 6. Ollama
-
-Ollama serves the local LLM used by Aiko's `think.py` core.
-
-```bash
-# Install Ollama
-curl -fsSL https://ollama.com/install.sh | sh
-
-# The installer registers a systemd service; confirm it is running
-systemctl status ollama
-
-# If not running, start it manually
-ollama serve
-```
-
-> On a **Jetson**, Ollama detects CUDA automatically. Verify with `ollama run llama3.2 "hello"` and check that GPU utilisation rises in `jtop`.
-
----
-
-## 7. Pull a Chat Model
-
-Pull the model referenced in your `.env` as `OLLAMA_MODEL`. The default in `.env.example` is a Ministral 3B reasoning GGUF:
-
-```bash
-ollama pull hf.co/unsloth/Ministral-3-3B-Reasoning-2512-GGUF:UD-Q4_K_XL
-```
-
-For a more capable model (recommended for grounded search answers — 7B+):
-
-```bash
-ollama pull mistral:7b-instruct
-# or
-ollama pull qwen2.5:7b
-```
-
-Confirm the model loads:
-
-```bash
-ollama run mistral:7b-instruct "Say hello."
-```
-
----
-
-## 8. MioTTS Server
-
-MioTTS is an external HTTP TTS server. Aiko calls it at `MIOTTS_API_URL` (default **http://localhost:8001**).
-
-> If you do not need voice output, set `MIOTTS_API_URL` to an unreachable address and run Aiko in `--text` mode. The client fails gracefully.
-
-**Option A — Run MioTTS via Docker (recommended):**
-
-```bash
-docker run -d --name miotts \
-  -p 8001:8001 \
-  # replace with the actual MioTTS image when available
-  miotts/miotts-server
-```
-
-**Option B — Run MioTTS from source:**
-
-Follow the MioTTS project's own README. Once running, verify the health endpoint:
-
-```bash
-curl http://localhost:8001/health
-# Expected: {"status":"ok"} or similar
-```
-
----
-
-## 9. Clone the Repo & Configure Environment
-
-```bash
-# Clone
 git clone https://github.com/OppaAI/Aiko-chan.git
 cd Aiko-chan
-
-# Copy the example env file
 cp .env.example .env
 ```
 
-Open `.env` in your editor and set at minimum:
+The repo contains `docker-compose.yml`, `searxng/` config, Python source, `webui/static/`, skills, persona files, and docs.
+
+---
+
+## 5. Docker & SearXNG
+
+```bash
+sudo apt remove -y docker docker-engine docker.io containerd runc 2>/dev/null || true
+curl -fsSL https://get.docker.com | sudo sh
+sudo usermod -aG docker "$USER"
+newgrp docker
+
+docker --version
+docker compose version
+```
+
+Start SearXNG from the project root:
+
+```bash
+docker compose up -d
+docker compose ps
+```
+
+Expected service/container: `aiko_searxng` running and listening at `http://localhost:8081`.
+
+---
+
+## 6. Local LLM Server
+
+Aiko's current chat runtime uses the OpenAI Python client against a local OpenAI-compatible endpoint. The default environment values are:
 
 ```dotenv
-# Ollama
-OLLAMA_BASE_URL=http://localhost:11434
-OLLAMA_MODEL=hf.co/unsloth/Ministral-3-3B-Reasoning-2512-GGUF:UD-Q4_K_XL
+LLM_BASE_URL=http://localhost:8080/v1
+LLM_MODEL=ministral
+```
 
-# SearXNG
+A common setup is llama.cpp `llama-server` with a local GGUF model. Example:
+
+```bash
+# Example only: adjust paths, GPU layers, context, and alias for your hardware/model.
+llama-server \
+  -m /path/to/Ministral-3-3B-Reasoning-Q4_K_M.gguf \
+  --host 0.0.0.0 \
+  --port 8080 \
+  --alias ministral \
+  --jinja \
+  -c 4096
+```
+
+Verify the endpoint:
+
+```bash
+curl http://localhost:8080/v1/models
+curl http://localhost:8080/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"ministral","messages":[{"role":"user","content":"Say hello."}],"max_tokens":32}'
+```
+
+> Older Ollama-specific instructions are no longer the primary path for the current codebase. You can still use any backend that exposes an OpenAI-compatible `/v1` API and matches `LLM_BASE_URL`/`LLM_MODEL`.
+
+---
+
+## 7. MioTTS Server
+
+MioTTS is an external HTTP synthesis service. Aiko calls `MIOTTS_API_URL` and plays the returned audio through `sounddevice`.
+
+```dotenv
+MIOTTS_API_URL=http://localhost:8001
+MIOTTS_MODEL=MioTTS-0.4B-Q4_K_M
+MIOTTS_PRESET=aiko_flat
+```
+
+Typical MioTTS flow:
+
+1. Start the local OpenAI-compatible model server that serves the MioTTS model.
+2. Start MioTTS's `run_server.py` wrapper, pointed at that model server.
+3. Verify the API before launching Aiko.
+
+```bash
+curl http://localhost:8001/health
+uv run python core/speak.py --devices
+uv run python core/speak.py --wait "Hello, I'm Aiko."
+```
+
+If you do not need voice, run Aiko with `--text`; wakeup will skip TTS and ASR.
+
+---
+
+## 8. Configure Environment
+
+Edit `.env`. At minimum, check these values:
+
+```dotenv
+# Identity
+AI_NAME=Aiko
+USER_ID=OppaAI
+
+# Local OpenAI-compatible LLM
+LLM_BASE_URL=http://localhost:8080/v1
+LLM_MODEL=ministral
+LLM_TIMEOUT=120
+LLM_MAX_TOKENS=280
+
+# Memory
+SQLITE_MEMORY_PATH=/home/oppa-ai/.aiko/memory.db
+FASTEMBED_CACHE_PATH=/home/oppa-ai/.cache/fastembed
+EMBED_MODEL=BAAI/bge-base-en-v1.5
+MEMORY_RECALL_LIMIT=5
+
+# Web search
 SEARXNG_URL=http://localhost:8081
 SEARXNG_SECRET=<your_secret_from_searxng_settings.yml>
 
-# MioTTS (leave blank or point to a dummy URL to disable voice)
+# Voice output
 MIOTTS_API_URL=http://localhost:8001
+MIOTTS_PRESET=aiko_flat
 
-# ASR — SenseVoice via sherpa-onnx + Silero VAD
+# Voice input
 ASR_DEVICE=cpu
 ASR_LANGUAGE=auto
 ASR_MODEL=csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17
+
+# Routing and agentic mode (current names read by core/think.py)
+ROUTE_ENABLED=1
+ROUTE_MODE=semantic
+ROUTE_SEMANTIC_THRESHOLD=0.36
+SEARCH_SEMANTIC_THRESHOLD=0.36
+
+# Scheduling/workspace
+TIMEZONE=America/Vancouver
+WORKSPACE_ROOT=workspace
+SCHEDULE_PATH=workspace/schedule.json
+SCHEDULE_POLL_SECONDS=15
 ```
 
-The `SEARXNG_SECRET` must match the `secret_key` value inside `searxng/settings.yml`.
+If your `.env` still has only `AIKO_ROUTE_*` keys, add the `ROUTE_*` keys above; the current code reads `ROUTE_ENABLED`, `ROUTE_MODE`, and `ROUTE_SEMANTIC_THRESHOLD`.
 
 ---
 
-## 10. Install Python Dependencies
-
-```bash
-# From the project root with Python 3.12 active
-uv sync
-```
-
-`uv` reads `pyproject.toml` and `uv.lock`, creates a virtual environment in `.venv/`, and installs all dependencies.
-
-> **If `uv sync` fails on wheel not found:** Check the local wheel paths in `pyproject.toml` for `torch` and `ctranslate2`. On a standard x86 machine, comment out or replace those path overrides with regular PyPI versions. On a Jetson, see Section 12.
-
----
-
-## 11. Jetson Orin Nano — Extra Steps
-
-The Jetson requires board-specific wheels for PyTorch that are not on PyPI.
-
-### 11a. Download Jetson AI Lab wheels
-
-Visit [https://forums.developer.nvidia.com/t/pytorch-for-jetson](https://forums.developer.nvidia.com/t/pytorch-for-jetson) and download the `.whl` files for:
-
-- `torch` (JetPack 6.x compatible)
-- `torchaudio`
-- `torchvision`
-- `ctranslate2` (Jetson build)
-
-Place the wheels in a local directory, e.g. `~/wheels/`.
-
-### 11b. Update pyproject.toml wheel paths
-
-In `pyproject.toml`, confirm the path overrides for `torch` and `ctranslate2` point to your downloaded `.whl` files:
-
-```toml
-[tool.uv.sources]
-torch = { path = "/home/oppa-ai/wheels/torch-<version>-cp310-linux_aarch64.whl" }
-ctranslate2 = { path = "/home/oppa-ai/wheels/ctranslate2-<version>-cp310-linux_aarch64.whl" }
-```
-
-### 11c. Install JetPack dev libraries (if not already present)
-
-```bash
-sudo apt install -y libopenblas-dev libopenmpi-dev
-```
-
-### 11d. Run uv sync
+## 9. Install Python Dependencies
 
 ```bash
 uv sync
 ```
 
-### 11e. PulseAudio default sink (for TTS audio output)
+This installs dependencies from `pyproject.toml`/`uv.lock`, including `openai`, `sqlite-vec`, `fastembed`, `sherpa-onnx`, `silero-vad`, `sounddevice`, `soundfile`, `websockets`, `torch`, and `torchaudio`.
 
-If audio output is silent after install, fix the PulseAudio default sink:
+For browser frontend asset experiments, the repo also has a `package.json` with `three` and `@pixiv/three-vrm`; the checked-in `webui/static/` files are served directly by Python, so `npm install` is not required for normal runtime.
+
+---
+
+## 10. Jetson Orin Nano Notes
+
+- The current `pyproject.toml` uses PyPI dependencies plus an ONNX Runtime CUDA nightly index for `onnxruntime-gpu`.
+- `ASR_DEVICE=cpu` is the documented SenseVoice setting in `.env.example` because CUDA EP availability can vary by JetPack/JP version.
+- Keep `SQLITE_MEMORY_PATH` and `FASTEMBED_CACHE_PATH` on persistent storage, not `/tmp`.
+- If audio output is silent, inspect devices and set `MIOTTS_DEVICE` or the system default sink:
 
 ```bash
-# List available sinks
+uv run python core/speak.py --devices
 pactl list short sinks
-
-# Set the default (replace <sink_name> with your output device)
 pactl set-default-sink <sink_name>
-
-# To make it persist across reboots, add to /etc/pulse/default.pa:
-echo "set-default-sink <sink_name>" | sudo tee -a /etc/pulse/default.pa
 ```
+
+- Watch memory pressure with `jtop` when LLM, MioTTS, ASR, and embeddings are warm.
 
 ---
 
-## 12. Verify the Full Stack
-
-Run this checklist before launching Aiko for the first time:
+## 11. Verify the Full Stack
 
 ```bash
-# 1. SearXNG
+# SearXNG
 curl "http://localhost:8081/search?q=test&format=json" \
   -H "X-Forwarded-For: 127.0.0.1"
-# Expected: JSON search results
 
-# 2. Ollama
-curl http://localhost:11434/api/tags
-# Expected: JSON list of pulled models
+# Local OpenAI-compatible LLM
+curl http://localhost:8080/v1/models
 
-# 3. MioTTS (if using voice)
+# MioTTS (voice mode only)
 curl http://localhost:8001/health
-# Expected: {"status":"ok"} or similar
 
-# 4. Python environment
-uv run python -c "import sqlite_vec; import sherpa_onnx; import silero_vad; print('deps OK')"
-# Expected: deps OK
+# Python imports
+uv run python -c "import sqlite_vec, fastembed, sherpa_onnx, silero_vad, sounddevice, websockets; print('OK')"
 
-# 5. ASR model cache (first voice launch downloads SenseVoice files if absent)
-uv run python -c "from core.listen import ASR_MODEL; print(ASR_MODEL)"
-# Expected: csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17 or your override
+# Skill registry and agentic tool schemas
+uv run python -c "from core.skills import list_skillsets; print(list_skillsets())"
+uv run python -c "from core.agentic import tool_schemas; print([s['function']['name'] for s in tool_schemas()])"
+
+# Memory backend
+uv run python -c "from core.memorize import AikoMemorize; m=AikoMemorize(silent=True); print(m.get_all()[:1])"
 ```
 
 ---
 
-## 13. Run Aiko-chan
+## 12. Run Aiko-chan
 
 ```bash
-# Full voice mode (ASR input + TTS output)
+# Default: curses TUI, full voice if services are available
 uv run python main.py
 
-# Text-only mode (keyboard input, no ASR/TTS)
+# Browser WebUI + VRM frontend
+uv run python main.py --webui
+
+# Keyboard-only, skips ASR and TTS
 uv run python main.py --text
 
-# Text mode with memory debug output
-uv run python main.py --text --debug
+# Keyboard input but keep TTS available
+uv run python main.py --no-asr
 
-# Wipe all stored memories and exit
+# Debug memory hits each turn
+uv run python main.py --debug
+
+# Wipe memories and exit
 uv run python main.py --clear-mem
 ```
 
-On first launch Aiko will:
-1. Connect to SQLite-vec and initialise the memory collection if it does not exist.
-2. Warm up the Ollama model in the background.
-3. Warm up MioTTS in the background (voice mode only).
-4. Open the curses TUI.
-
----
-
-## Troubleshooting
-
-| Symptom | Likely cause | Fix |
-|---|---|---|
-| `uv sync` fails — wheel not found | Jetson wheel path wrong | Update path in `pyproject.toml` → Section 12b |
-| SearXNG returns 403 | Wrong `SEARXNG_SECRET` | Match secret in `.env` and `searxng/settings.yml` |
-| Ollama model not found | Model not pulled | `ollama pull <model>` → Section 8 |
-| No TTS audio on Jetson | Wrong PulseAudio sink | `pactl set-default-sink` → Section 11e |
-| ASR import/model error | Missing sherpa-onnx/SenseVoice deps or model cache | Run `uv sync`, then launch once online or set `HF_HUB_OFFLINE=0` |
-| LLM ignores search results | Model too small (< 7B) | Pull a 7B+ model → Section 8 |
-| `curses` import error | Running inside a non-TTY | Run in a real terminal, not a pipe |
+In-app commands include `/quit`, `/reset`, `/memory`, `/clear`, `/remember`, `/think <question>`, `/web <query>`, `/voice`, `/listen`, and `/help`.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,278 +1,586 @@
 [← Back to README](../README.md)
-# Aiko-chan 愛子ちゃん — Test Checklist
+# Aiko-chan 愛子ちゃん — Industrial Test Plan
 
-Manual smoke-test checklist for each phase. Run the relevant section after installing or after making changes to that phase's components. Check off each item before marking a phase stable.
+This document is the master validation plan for Aiko-chan. It is intentionally broader than a smoke-test checklist: use it for feature acceptance, regression gates, release hardening, stress/load testing, troubleshooting, and field-readiness checks on constrained hardware such as the Jetson Orin Nano.
 
----
+Supporting suite folders live under [`tests/`](../tests/README.md):
 
-## Pre-flight — Stack Health
-
-Run before any phase tests. All items must pass.
-
-- [ ] `curl "http://localhost:8081/search?q=test&format=json"` returns JSON results
-- [ ] `curl http://localhost:11434/api/tags` returns a JSON list containing your configured model
-- [ ] `curl http://localhost:8001/health` returns `{"status":"ok"}` (voice mode only)
-- [ ] `uv run python -c "import sqlite_vec; import fastembed; print('OK')"` prints `OK`
-- [ ] `docker compose ps` shows `searxng` as `running`
-- [ ] SQLite memory DB path exists and is on persistent storage (not `/tmp`): `ls -lh $SQLITE_MEMORY_PATH`
-
----
-
-## Phase 1 — Soul
-
-*CLI chatbot, Ollama inference, mem0 + Qdrant memory, web search.*
-
-### Ollama / LLM
-
-- [ ] Aiko launches without errors in `--text` mode
-- [ ] First message receives a streamed response (tokens appear progressively, not all at once)
-- [ ] Response is coherent and matches the persona defined in `persona/soul.md`
-- [ ] `/reset` clears short-term context; next reply has no memory of the previous exchange
-- [ ] `/think <question>` returns a higher-quality reasoning response and suppresses raw `<think>` tags from output
-
-### Memory (sqlite-vec + fastembed)
-
-> Memory backend was rewritten in Phase 2 — these tests verify the current sqlite-vec implementation,
-> not the original mem0 + Qdrant stack.
-
-- [ ] After a few exchanges, `/memory` prints stored memories (not empty)
-- [ ] Restarting Aiko and asking about a previously discussed topic surfaces a relevant memory
-- [ ] `/remember` pins the last exchange; restarting and running `/memory` shows it is still present
-- [ ] `/clear` wipes all memories; `/memory` returns empty afterward
-- [ ] `--clear-mem` flag wipes memories and exits cleanly without launching the TUI
-- [ ] DB file exists at `SQLITE_MEMORY_PATH` after first memory write: `ls -lh ~/.aiko/memory.db`
-- [ ] `dream()` dry-run completes without error: `uv run python -c "from core.memorize import AikoMemorize; m = AikoMemorize(); print(m.dream(dry_run=True))"`
-
-### Web Search
-
-- [ ] `/web what is the current version of Python` returns a grounded answer citing search results
-- [ ] A question that naturally triggers search (e.g. "what happened in the news today") receives a search-grounded reply rather than a hallucinated one
-- [ ] Search results are filtered — Aiko does not dump raw SearXNG JSON into the reply
+| Suite | Scope |
+|---|---|
+| [`tests/unit/`](../tests/unit/README.md) | Pure function/module validation that should run without external services. |
+| [`tests/integration/`](../tests/integration/README.md) | Boundaries between local services: LLM, SearXNG, MioTTS, ASR, sqlite-vec, WebUI. |
+| [`tests/system/`](../tests/system/README.md) | End-to-end user journeys through TUI/WebUI/voice/agent workflows. |
+| [`tests/load/`](../tests/load/README.md) | Throughput, concurrent requests, queue pressure, and resource saturation. |
+| [`tests/error/`](../tests/error/README.md) | Fault injection, negative tests, and graceful degradation. |
+| [`tests/performance/`](../tests/performance/README.md) | Latency, token rate, ASR/TTS timing, recall timing, startup timing. |
+| [`tests/stability/`](../tests/stability/README.md) | Long-running soak tests, memory leak checks, restart/reconnect recovery. |
+| [`tests/functionality/`](../tests/functionality/README.md) | User-facing acceptance criteria by phase and feature. |
 
 ---
 
-## Phase 1.5 — Stream
+## 0. Test Discipline
 
-*Curses TUI, streaming architecture, MioTTS TTS, persona system.*
+### 0.1 Release Gate Levels
 
-### TUI
+| Gate | Purpose | Required before |
+|---|---|---|
+| G0 — Static sanity | Docs/code import, config lint, no obvious breakage | Every commit |
+| G1 — Unit/module | Pure Python behavior and safe path validation | Merging code changes |
+| G2 — Integration | External/local service boundaries | Changing dependencies or service adapters |
+| G3 — System smoke | TUI/WebUI/Text end-to-end paths | Any release candidate |
+| G4 — Stress/performance | Latency, load, resource pressure | Hardware field use or demo builds |
+| G5 — Soak/stability | Multi-hour runtime and recovery | Long unattended deployments |
 
-- [ ] Full-screen curses UI launches and fills the terminal without layout errors
-- [ ] Chat panel, architecture panel, and status areas render in the correct positions
-- [ ] Typing input appears in the input field; submitting with Enter sends the message
-- [ ] Streamed LLM tokens appear in the chat panel incrementally as they arrive
-- [ ] TUI resizes gracefully when the terminal window is resized (no crash, no garbled output)
-- [ ] `/help` renders the command list inside the TUI without breaking layout
-- [ ] Exiting with `/quit` or `/exit` restores the terminal cleanly (no leftover curses artifacts)
+### 0.2 Pass/Fail Criteria
 
-### Persona & Identity
+A test passes only when all of these are true:
 
-- [ ] `persona/soul.md` loads without error on startup (check logs)
-- [ ] `persona/identity.md` banner and ASCII art render correctly in the identity panel
-- [ ] Aiko's tone and personality match `soul.md` across multiple turns
+- command exits with status `0`, unless the test explicitly expects a controlled failure;
+- no uncaught traceback appears in terminal or log output;
+- no service silently hangs beyond the test timeout;
+- user-facing errors are actionable and do not leak raw stack traces;
+- persistent files are created only in approved paths (`workspace/`, configured sqlite DB path, logs/cache paths);
+- temporary test artifacts are either cleaned up or clearly listed for manual cleanup.
 
-### Streaming Pipeline
+### 0.3 Evidence to Capture
 
-- [ ] LLM response streaming begins within ~1 second of submitting a message (warm model)
-- [ ] Background LLM warmup on startup eliminates cold-start delay on the first real message
-- [ ] Memory writes do not block the streaming response (non-blocking queue worker)
+For every G3+ run, save:
 
-### TTS — MioTTS
-
-- [ ] `/voice` toggle enables TTS; spoken audio plays for the next assistant response
-- [ ] `/voice` toggle again disables TTS; no audio plays for subsequent responses
-- [ ] Background TTS warmup on startup eliminates cold-start audio delay
-- [ ] Audio plays through the correct output device (check PulseAudio default sink on Jetson)
-- [ ] Long responses play completely without cutting off mid-sentence
-
----
-
-## Phase 2 — Voice
-
-*SenseVoice via sherpa-onnx, Silero VAD, hands-free talk mode.*
-
-### Memory Backend Migration (sqlite-vec)
-
-- [ ] No Qdrant container is required — `docker compose ps` shows only `searxng`
-- [ ] Memory writes complete without OOM errors under concurrent ASR + LLM load (`jtop` VRAM stays stable)
-- [ ] KNN + FTS5 RRF recall returns relevant results: run `--debug` and confirm memory hits appear each turn
-- [ ] `cleanup()` runs on startup and logs `deleted=N, kept=N` without error
-
-### ASR — SenseVoice via sherpa-onnx
-
-- [ ] Aiko launches in full voice mode (no `--text` flag) without errors
-- [ ] Speaking clearly into the microphone produces a transcription in the chat panel
-- [ ] Transcription accuracy is acceptable for normal conversational speech
-- [ ] Non-speech background noise does not trigger spurious transcriptions (VAD is active)
-
-### VAD — Silero
-
-- [ ] Speaking starts recording; silence stops recording without manual key press
-- [ ] Short pauses mid-sentence do not prematurely cut off the utterance
-- [ ] `/listen` toggle disables ASR; microphone input is ignored
-- [ ] `/listen` toggle again re-enables ASR; microphone input resumes
-
-### End-to-End Voice Loop
-
-- [ ] Full loop works: speak → transcribe → LLM response streams → TTS speaks the reply
-- [ ] Loop completes in an acceptable latency (target: < 3 s on Jetson for short replies)
-- [ ] Interrupting a TTS response and speaking again does not deadlock the pipeline
+- command line and git commit SHA;
+- `.env` values with secrets redacted;
+- hardware target (`uname -a`, CPU/GPU/JetPack if relevant);
+- service versions (`uv --version`, `docker compose ps`, LLM server/version if available);
+- logs from Aiko, SearXNG, LLM server, MioTTS, and system audio;
+- latency/resource notes for startup, first token, ASR, TTS, and memory recall.
 
 ---
 
+## 1. Pre-flight — Stack Health
 
-## Phase 2.5 — Agent
+Run before any phase, integration, performance, or stability test.
 
-*Agentic task loop, toolkit tools, skillset registry, scheduled local work.*
+### 1.1 Static Repository Checks
 
-### Toolkit & Skill Registry
+- [ ] `git status --short` is clean except intentional test artifacts.
+- [ ] `python --version` reports Python 3.12.x.
+- [ ] `uv --version` succeeds.
+- [ ] `uv sync` completes without dependency conflicts.
+- [ ] `python -m py_compile main.py core/think.py core/wakeup.py core/agentic.py core/memorize.py core/listen.py core/speak.py core/schedule.py` completes.
+- [ ] `python - <<'PY'
+from pathlib import Path
+for p in ['README.md','docs/INSTALL.md','docs/ARCHITECTURE.md','docs/HISTORY.md','docs/TESTS.md']:
+    assert Path(p).exists(), p
+print('docs present')
+PY` completes.
 
-- [ ] `uv run python -c "from core.skills import list_skillsets; print(list_skillsets())"` lists `wildlife_photo` and `aiko_architect`
-- [ ] `uv run python -c "from core.agentic import tool_schemas; print([s['function']['name'] for s in tool_schemas()])"` includes skill, photo, and repo tools
-- [ ] Asking Aiko to process wildlife photos loads/uses the `wildlife_photo` skill context
-- [ ] Asking Aiko to inspect her architecture loads/uses the `aiko_architect` skill context
+### 1.2 Service Health
 
-### Photo Workflow
+- [ ] `docker compose up -d` starts the SearXNG stack.
+- [ ] `docker compose ps` shows `aiko_searxng` / `searxng` as running.
+- [ ] `curl "http://localhost:8081/search?q=test&format=json"` returns JSON and not HTML/error text.
+- [ ] `curl http://localhost:8080/v1/models` returns JSON containing the configured `LLM_MODEL` alias.
+- [ ] `curl http://localhost:8001/health` returns a healthy response when voice mode is being tested.
+- [ ] `uv run python -c "import sqlite_vec, fastembed, sherpa_onnx, silero_vad, sounddevice, websockets; print('OK')"` prints `OK`.
+- [ ] `uv run python core/speak.py --devices` lists expected audio output devices when TTS is tested.
 
-- [ ] `scan_photo_workspace` reports image counts without moving or modifying files
-- [ ] `propose_photo_ingestion` produces a dry-run destination plan
-- [ ] `write_photo_ingestion_report` writes a report under `workspace/photos/reports`
+### 1.3 Persistent Storage and Secrets
 
-### Architecture Workflow
-
-- [ ] `repo_file_tree` lists text files without entering skipped directories
-- [ ] `repo_search_text` finds known symbols such as `run_agentic_chat`
-- [ ] `repo_read_file` rejects path traversal outside the repository
-
----
-
-## Phase 3 — Face
-
-*VRM/VRoid avatar, three-vrm browser rendering, expressions, lip-sync, WebSocket bridge.*
-
-### Avatar Rendering
-
-- [ ] Browser frontend loads and displays the VRM avatar in idle pose
-- [ ] Idle animation plays continuously without freezing
-- [ ] Avatar renders correctly on both desktop browser and target display
-
-### Expression System
-
-- [ ] `happy` expression triggers and blends correctly from idle
-- [ ] `annoyed`, `flustered`, and `thinking` expressions each trigger on the appropriate cue
-- [ ] Expressions return to idle after the trigger condition clears
-
-### Lip-sync
-
-- [ ] Lip-sync visemes animate in sync with TTS audio playback
-- [ ] Lip movement stops when audio ends (mouth does not stay open)
-
-### WebSocket Bridge
-
-- [ ] Python backend connects to the browser WebSocket on startup without errors
-- [ ] Expression commands sent from Python appear in the browser within ~100 ms
-- [ ] Reconnection works if the browser tab is refreshed while Python is running
+- [ ] `SQLITE_MEMORY_PATH` exists or its parent directory is writable and persistent.
+- [ ] `FASTEMBED_CACHE_PATH` exists or its parent directory is writable and persistent.
+- [ ] `WORKSPACE_ROOT` exists or can be created.
+- [ ] `SCHEDULE_PATH` parent directory exists or can be created.
+- [ ] `.env` does not contain placeholder values for required runtime tests (`SEARXNG_SECRET`, `LLM_MODEL`, `LLM_BASE_URL`).
+- [ ] Secrets are redacted from logs/screenshots before sharing test artifacts.
 
 ---
 
-## Phase 4 — Presence
+## 2. Unit Test Checklist
 
-*Emotional state machine, mood tracking, relationship progression, episodic memory.*
+These tests should avoid live network/model dependencies unless explicitly stated.
 
-### Emotional State
+### 2.1 CLI and Command Parsing
 
-- [ ] Aiko's mood state initialises on startup (check logs or state dump)
-- [ ] Positive interactions shift mood toward a positive state over time
-- [ ] Negative or neutral interactions shift mood accordingly
-- [ ] Mood state persists across restarts (stored, not reset to default each launch)
+- [ ] `uv run python - <<'PY'
+from main import parse_args
+print('parse_args import OK')
+PY` imports without launching the app.
+- [ ] `_match_voice_command('remember this')` returns `/remember`.
+- [ ] `_match_voice_command('uh hey aiko forget that')` returns `/reset` or a documented no-match if fuzzy confidence is too low.
+- [ ] `_match_voice_command('tell me a story')` returns `None`.
+- [ ] conflicting flags `--tui --webui` exit with a clear message.
+- [ ] `--clear-mem` path instantiates memory and exits without starting TUI/WebUI.
 
-### Relationship & Memory
+### 2.2 Text Sanitization and Streaming Helpers
 
-- [ ] Shared references from previous sessions are recalled and referenced naturally
-- [ ] Long-term relationship score increments after extended positive interactions
-- [ ] Episodic memory recall surfaces specific past events, not just semantic facts
+- [ ] `core.speak.sanitize_for_tts()` strips markdown symbols, emoji noise, and unsafe punctuation while preserving readable text.
+- [ ] `core.speak._split_oversized_text()` splits long text without dropping the tail.
+- [ ] `core.think.split_stream_sentences()` returns complete sentence chunks and preserves incomplete fragments.
+- [ ] streaming helper tests include ASCII, Japanese punctuation, emoji, markdown, empty strings, and very long tokens.
 
-### Proactive Messaging
+### 2.3 Memory Decay and Storage Helpers
 
-- [ ] Aiko sends a proactive message after the configured inactivity timeout
-- [ ] Proactive message content is contextually relevant (references recent topics)
-- [ ] Proactive messaging does not trigger if the user is actively chatting
+- [ ] `core.forget.compute_weighted_score()` decreases as `last_accessed` ages.
+- [ ] pinned memories are never selected for cleanup.
+- [ ] grace-period memories are protected.
+- [ ] `_sanitize_fts_query()` handles quotes, punctuation, emoji, empty strings, and reserved FTS characters.
+- [ ] sqlite payload read/write helpers preserve IDs, roles, text, timestamps, access counts, and pinned flags.
+- [ ] duplicate merge thresholds are covered for below-threshold, exact-threshold, and above-threshold cases.
 
----
+### 2.4 Scheduling
 
-## Phase 5 — Mobile
+- [ ] `_parse_time_of_day()` accepts valid `HH:MM` and rejects invalid hour/minute values.
+- [ ] `_normalize_weekdays()` accepts strings/lists and rejects unknown weekday names.
+- [ ] `_normalize_relative_days()` handles `today`, `tomorrow`, `day after tomorrow`, numeric strings, and invalid values.
+- [ ] `calculate_next_due()` covers `once`, `hourly`, `daily`, `weekdays`, `weekly`, `biweekly`, `monthly`, and `custom_weekdays`.
+- [ ] schedule record migration preserves legacy reminder data.
+- [ ] canceling a schedule is idempotent and does not corrupt the JSON file.
 
-*React Native / Flutter app, WAN access, push notifications, voice-first UX.*
+### 2.5 Toolkit Safety
 
-### Connectivity
+- [ ] `core.toolkit.common.safe_path('../secret')` rejects path traversal.
+- [ ] `read_workspace_file()` rejects absolute paths and traversal outside `WORKSPACE_ROOT`.
+- [ ] `repo_read_file('../.env')` rejects traversal outside the repository.
+- [ ] `repo_file_tree()` respects skip directories and result limits.
+- [ ] `repo_search_text()` handles no-match, many-match, binary files, and large files gracefully.
+- [ ] `save_note()` enforces `MAX_WRITE_CHARS` and writes only under `WORKSPACE_ROOT`.
+- [ ] photo ingestion tools produce dry-run plans without moving or modifying original image files.
 
-- [ ] Mobile app connects to the Aiko backend over WAN (not just LAN)
-- [ ] Auth/token check prevents unauthorised access from the open internet
-- [ ] Connection survives a network switch (Wi-Fi → cellular) without crashing
+### 2.6 Agentic Tool Validation
 
-### Core Features
-
-- [ ] Text chat works end-to-end from the mobile app
-- [ ] Voice input and TTS playback work on device
-- [ ] Avatar renders correctly on mobile screen dimensions
-
-### Push Notifications
-
-- [ ] Proactive message from Aiko triggers a push notification when the app is backgrounded
-- [ ] Tapping the notification opens the app and scrolls to the new message
-
----
-
-## Phase 6 — Multimodal
-
-*Camera input, image understanding, webcam expression awareness.*
-
-### Image Input
-
-- [ ] Sharing an image in chat sends it to the vision model without errors
-- [ ] Aiko's reply references specific visual details from the image
-- [ ] Unsupported file types are rejected gracefully with a user-facing message
-
-### Webcam
-
-- [ ] Webcam feed initialises on startup (or on toggle) without errors
-- [ ] Expression awareness updates Aiko's emotional state based on detected user expression
-- [ ] Webcam can be toggled off; disabling it stops all camera processing
+- [ ] `tool_schemas()` returns unique tool names.
+- [ ] every registered tool schema has a dispatch handler.
+- [ ] required arguments are enforced before handler execution.
+- [ ] unknown tools produce structured failures instead of exceptions.
+- [ ] retryable vs non-retryable tool failures are classified consistently.
+- [ ] `final_answer` verification rejects claims that contradict tool observations.
 
 ---
 
-## Phase 7 — Autonomy
+## 3. Integration Test Checklist
 
-*Scheduled operation, background information gathering, self-directed conversation initiation.*
+### 3.1 LLM Endpoint Integration
 
-### Scheduler
+- [ ] `curl http://localhost:8080/v1/models` lists `LLM_MODEL`.
+- [ ] a non-streaming chat completion returns valid JSON with content.
+- [ ] a streaming chat completion emits incremental chunks and closes cleanly.
+- [ ] invalid model name returns a controlled error without crashing Aiko.
+- [ ] timeout behavior honors `LLM_TIMEOUT` and logs a useful message.
+- [ ] `/think <question>` uses the higher reasoning token budget and suppresses raw `<think>` blocks in user-facing output.
 
-- [ ] Background scheduler starts on launch and logs its next scheduled task
-- [ ] Scheduled task runs at the configured time (verify in logs)
-- [ ] Missed tasks (e.g. system was off) are handled gracefully — no crash on resume
+### 3.2 Memory Integration
 
-### Self-directed Behaviour
+- [ ] first launch creates/open the sqlite memory DB at `SQLITE_MEMORY_PATH`.
+- [ ] adding memory writes rows and vector data.
+- [ ] recall returns relevant memories for semantically similar queries.
+- [ ] FTS and vector recall are combined without duplicate rows in the final result.
+- [ ] `/remember` pins the last turn and pinned memories survive cleanup.
+- [ ] `/clear` wipes persistent memories and does not delete unrelated files.
+- [ ] `dream(dry_run=True)` completes without modifying the DB.
+- [ ] full `dream()` consolidation updates/merges memories and reports counts.
 
-- [ ] Aiko discovers and logs a new topic of interest during an autonomous run
-- [ ] Autonomously gathered information is stored in long-term memory and surfaced in conversation
-- [ ] Aiko initiates a conversation (proactive message or notification) based on gathered information
+### 3.3 SearXNG and Web Tools
 
-### Dream / Nightly Consolidation
+- [ ] `web_search()` returns summarized results for a normal query.
+- [ ] `web_search()` handles zero results with a friendly message.
+- [ ] `fetch_and_extract()` rejects localhost/private IP targets unless explicitly allowed by code policy.
+- [ ] `fetch_and_extract()` truncates huge pages to configured max chars.
+- [ ] `/web <query>` displays a searching state and then a grounded answer.
+- [ ] automatic search routing triggers for current/news/weather/current-version prompts and avoids search for normal personal chat.
 
-- [ ] `dream()` runs at midnight and logs a summary of actions taken
-- [ ] Near-duplicate memories are merged (verify via `/memory` before and after)
-- [ ] Decayed memories below the threshold are pruned (count decreases)
-- [ ] Optional Hugo/GitHub reflection post is published if env vars are configured
+### 3.4 MioTTS Integration
+
+- [ ] `curl http://localhost:8001/health` succeeds.
+- [ ] `uv run python core/speak.py --wait "Hello"` plays audio and exits.
+- [ ] `uv run python core/speak.py --synced --wait "Hello"` emits synced callbacks without deadlock.
+- [ ] long assistant replies are chunked and all chunks play in order.
+- [ ] unavailable MioTTS server fails gracefully when Aiko is in `--text` mode.
+- [ ] unavailable MioTTS server in voice mode produces a user-facing warning and keeps text chat usable.
+
+### 3.5 ASR, VAD, Speaker Verification, and Barge-in
+
+- [ ] `AikoListen.load_asr()` downloads/loads SenseVoice files on first boot.
+- [ ] `AikoListen.load_vad()` initializes Silero VAD and warmup completes.
+- [ ] a clean spoken phrase transcribes correctly in the expected language.
+- [ ] silence does not trigger a fake utterance.
+- [ ] background music/noise does not repeatedly trigger VAD.
+- [ ] `LISTEN_MAX_SECONDS` caps a long recording.
+- [ ] optional speaker verification returns `True`, `False`, or `None` without blocking transcription.
+- [ ] barge-in stops or interrupts TTS without deadlocking the TTS or listen threads.
+
+### 3.6 WebUI Integration
+
+- [ ] `uv run python main.py --webui --text` starts HTTP and WebSocket servers.
+- [ ] `curl http://localhost:8787/` returns the WebUI HTML.
+- [ ] browser connects to the WebSocket on port `8765`.
+- [ ] typed browser input reaches `AikoWeb.get_input()` and is answered.
+- [ ] server broadcasts chat, token, commit, phase, vitals, voice, expression, and viseme messages with valid JSON.
+- [ ] browser mic frames are accepted without crashing the backend.
+- [ ] refreshing the browser reconnects without losing the Python process.
+- [ ] multiple browser clients receive broadcasts consistently or are explicitly unsupported with documented behavior.
+
+### 3.7 Schedule Runner Integration
+
+- [ ] scheduling a one-shot reminder writes a valid job to `workspace/schedule.json`.
+- [ ] due jobs are discovered by `ScheduleRunner` within `SCHEDULE_POLL_SECONDS` plus a small tolerance.
+- [ ] `announce` jobs inject a user-visible reminder turn.
+- [ ] `agentic` jobs call the agentic path with the scheduled task text.
+- [ ] missed jobs after restart are handled according to documented policy.
+- [ ] canceled jobs remain disabled or removed consistently.
 
 ---
 
-## Regression — Cross-Phase
+## 4. System / End-to-End User Journeys
 
-Run after any significant change to confirm nothing regressed.
+### 4.1 Text-Only Baseline
 
-- [ ] Phase 1 memory round-trip still works (store → restart → recall)
-- [ ] Phase 1.5 TUI launches and streams without errors
-- [ ] `/reset`, `/memory`, `/clear`, `/remember` all behave correctly
-- [ ] `--text` and `--debug` flags still work
-- [ ] `docker compose down && docker compose up -d` → SearXNG recovers cleanly (Qdrant no longer required)
-- [ ] `uv sync` completes without dependency conflicts after any `pyproject.toml` change
+- [ ] Start: `uv run python main.py --text`.
+- [ ] Send greeting; Aiko responds in persona.
+- [ ] Send factual current query; search is either triggered automatically or `/web` succeeds.
+- [ ] Send `/reset`; previous short-term context is not used.
+- [ ] Send `/remember` after a turn; memory is pinned.
+- [ ] Restart with `--text`; pinned memory is visible/recalled.
+- [ ] Exit with `/quit`; process exits cleanly.
+
+### 4.2 Curses TUI Full Voice
+
+- [ ] Start: `uv run python main.py`.
+- [ ] Boot UI displays all subsystem loading/done/skip states.
+- [ ] Speak a short question; ASR transcript appears.
+- [ ] LLM response streams incrementally.
+- [ ] TTS speaks the response fully.
+- [ ] Say a supported voice command such as “remember this”; it maps to the correct slash command.
+- [ ] Toggle `/listen` and verify mic input is ignored, then restored.
+- [ ] Toggle `/voice` and verify TTS is disabled, then restored.
+- [ ] Interrupt TTS with speech; no deadlock occurs.
+- [ ] Exit cleanly and audio devices are released.
+
+### 4.3 Browser WebUI Text Journey
+
+- [ ] Start: `uv run python main.py --webui --text`.
+- [ ] Open `http://<host>:8787/`.
+- [ ] VRM avatar asset loads.
+- [ ] Send a text message from browser.
+- [ ] Chat token streaming appears in browser.
+- [ ] Backend terminal remains responsive.
+- [ ] Refresh browser; connection recovers.
+- [ ] Send `/help`; command list renders in the browser.
+- [ ] Exit via `/quit` from browser.
+
+### 4.4 Browser WebUI Voice Journey
+
+- [ ] Start: `uv run python main.py --webui`.
+- [ ] Browser prompts for microphone permission.
+- [ ] Mic frames reach backend and trigger voice-state updates.
+- [ ] Speech is transcribed and appears in chat.
+- [ ] Response streams and TTS plays on the configured output path.
+- [ ] Browser voice-state indicator returns to idle after the turn.
+- [ ] Refresh/reconnect while idle and during a response; backend remains alive.
+
+### 4.5 Agentic Task Journey
+
+- [ ] Ask Aiko to create a plan; tool loop uses planning tools and returns a checklist.
+- [ ] Ask Aiko to save a note; file appears under `workspace/notes/`.
+- [ ] Ask Aiko to inspect its architecture; repo tools read/search relevant files.
+- [ ] Ask Aiko to scan photo workspace; photo tools report counts and write only reports.
+- [ ] Ask Aiko to schedule a reminder; schedule file updates and the reminder fires.
+- [ ] Force a tool error (bad path, bad URL, missing arg); final answer discloses the failure honestly.
+
+---
+
+## 5. Phase Acceptance Matrix
+
+### Phase 1 — Soul
+
+*Local LLM, persona, memory, web search.*
+
+- [ ] Local OpenAI-compatible LLM responds with streamed tokens.
+- [ ] Persona from `persona/soul.md` and context files loads on startup.
+- [ ] memory write queue does not block response streaming.
+- [ ] memory recall improves follow-up answers.
+- [ ] `/memory`, `/clear`, `/remember`, and `--clear-mem` work.
+- [ ] web search returns grounded answers and does not dump raw JSON.
+- [ ] failure of search service does not crash chat.
+
+### Phase 1.5 — Stream
+
+*Curses UI, streaming, voice-output groundwork.*
+
+- [ ] TUI layout renders at minimum supported terminal size.
+- [ ] TUI resizes without exceptions or garbled persistent state.
+- [ ] streamed tokens are visible progressively.
+- [ ] `/help` and all built-in commands render correctly.
+- [ ] TTS toggle changes state and does not affect text output.
+- [ ] startup warmup avoids first-turn cold stalls where services are already warm.
+
+### Phase 2 — Voice
+
+*ASR, VAD, MioTTS, barge-in.*
+
+- [ ] SenseVoice ASR handles English and at least one configured secondary language sample.
+- [ ] Silero VAD correctly starts/stops on speech/silence.
+- [ ] audio-device selection is documented and reproducible.
+- [ ] end-to-end latency for a short warm turn is recorded.
+- [ ] barge-in is tested during short and long TTS playback.
+- [ ] ASR/TTS failures degrade to typed text instead of killing the process.
+
+### Phase 2.5 — Agent
+
+*Tools, skills, scheduling, verification.*
+
+- [ ] skill registry lists all local skillsets.
+- [ ] tool schemas include web, fetch, planning, workspace, scheduling, reminders, skills, photos, repo tools, and final answer.
+- [ ] every tool has happy-path and failure-path tests.
+- [ ] schedule/reminder jobs persist and fire.
+- [ ] final-answer verifier catches unsupported claims after tool failures.
+- [ ] agent iteration cap prevents infinite loops.
+- [ ] agent memory recall limit is respected.
+
+### Phase 3 — Face
+
+*VRM avatar, browser rendering, expression, lip-sync.*
+
+- [ ] VRM asset loads from `webui/static/assets/Aiko.vrm`.
+- [ ] idle animation runs for 10 minutes without visible freeze.
+- [ ] expression events blend and return to idle.
+- [ ] viseme events animate mouth movement and stop after audio ends.
+- [ ] renderer handles browser resize and device pixel ratio changes.
+- [ ] frontend handles missing VRM asset with a visible error instead of a blank page.
+
+### Phase 4 — Presence
+
+*Emotional/relationship state; currently roadmap-facing until implemented.*
+
+- [ ] mood state initializes, mutates, persists, and reloads.
+- [ ] positive/negative/neutral interactions produce bounded state changes.
+- [ ] relationship score cannot overflow or jump unexpectedly.
+- [ ] proactive messages obey inactivity and user-active suppression rules.
+- [ ] privacy-sensitive state is stored locally only.
+
+### Phase 5 — Mobile
+
+*Mobile/WAN/push; roadmap-facing until implemented.*
+
+- [ ] remote auth exists before WAN exposure.
+- [ ] mobile text chat survives network changes.
+- [ ] mobile voice input and playback work on device.
+- [ ] push notifications are rate-limited and actionable.
+- [ ] mobile avatar layout handles small and large screens.
+
+### Phase 6 — Multimodal
+
+*Image/camera; roadmap-facing until implemented.*
+
+- [ ] image uploads are size/type validated.
+- [ ] unsupported files fail safely.
+- [ ] image understanding references concrete image details.
+- [ ] webcam processing can be toggled and releases the device.
+- [ ] camera frames are not persisted unless explicitly requested.
+
+### Phase 7 — Autonomy
+
+*Scheduled operation, self-directed learning, dream/reflect.*
+
+- [ ] scheduler starts and stops cleanly.
+- [ ] idle learner respects inactivity threshold.
+- [ ] autonomous research stores useful memories without spamming duplicates.
+- [ ] dream consolidation runs without data loss.
+- [ ] reflection publishing fails safely when GitHub env vars are absent.
+- [ ] unattended operation recovers from service restarts.
+
+---
+
+## 6. Load, Stress, and Resource Tests
+
+### 6.1 LLM and Streaming Load
+
+- [ ] Run 25 sequential text turns; no context corruption, exceptions, or increasing latency trend beyond documented tolerance.
+- [ ] Run 5 concurrent WebUI clients sending text turns; behavior is either correct or documented as single-user only with graceful rejection.
+- [ ] Send a very long user prompt near context limits; response remains bounded by token settings.
+- [ ] Send rapid `/reset`, `/memory`, `/web`, `/voice`, and `/listen` commands during/after responses; no race-condition crash.
+- [ ] Kill/restart the LLM server while Aiko is idle and during generation; Aiko reports failure and can recover on next turn after service returns.
+
+### 6.2 Memory Load
+
+- [ ] Insert 100, 1,000, and 10,000 synthetic memories in a test DB; measure recall latency and DB size.
+- [ ] recall latency target is recorded for Jetson and desktop hardware.
+- [ ] cleanup time is recorded at each DB size.
+- [ ] dream consolidation time is recorded at each DB size.
+- [ ] concurrent background writes do not corrupt sqlite DB.
+- [ ] disk-full simulation produces a controlled error and preserves existing DB.
+
+### 6.3 Voice Load
+
+- [ ] 30 consecutive voice turns complete without ASR/TTS deadlock.
+- [ ] 10 long TTS replies play fully without memory growth beyond accepted threshold.
+- [ ] repeated barge-in attempts during TTS do not leave audio threads stuck.
+- [ ] noisy-room sample does not cause runaway transcriptions.
+- [ ] microphone unplug/replug is handled or produces a clear recoverable error.
+
+### 6.4 WebUI Load
+
+- [ ] browser remains responsive during a 2,000-token response.
+- [ ] WebSocket reconnect loop does not leak backend threads.
+- [ ] static asset server handles repeated refreshes.
+- [ ] invalid WebSocket JSON/binary frames are ignored or rejected without crashing.
+- [ ] browser tab left open overnight still receives vitals or reconnects cleanly.
+
+### 6.5 Agentic Load
+
+- [ ] max-iteration tasks stop at `MAX_AGENT_ITER` with an honest partial/failure response.
+- [ ] repeated tool failures do not trigger infinite retry loops.
+- [ ] large fetched pages are truncated before entering prompt context.
+- [ ] workspace note writes respect size caps.
+- [ ] schedule file remains valid after rapid create/cancel cycles.
+
+---
+
+## 7. Error Injection and Troubleshooting Matrix
+
+| Fault | How to inject | Expected behavior | Troubleshooting notes |
+|---|---|---|---|
+| LLM server down | stop `llama-server` | user-facing model error; process remains alive | check `LLM_BASE_URL`, port 8080, model alias |
+| wrong `LLM_MODEL` | set invalid alias | clear model-not-found error | verify `/v1/models` output |
+| SearXNG down | `docker compose stop searxng` | `/web` reports search failure, chat continues | restart `docker compose up -d` |
+| MioTTS down | stop TTS server | text response still appears; TTS warning logged | run `curl :8001/health` and `core/speak.py --devices` |
+| ASR model missing | clear model cache/offline | startup reports ASR load failure | verify Hugging Face cache/offline mode |
+| mic unavailable | unset/wrong `LISTEN_DEVICE` | voice input error, typed mode still usable | list devices with Python/sounddevice tools |
+| speaker unavailable | wrong `MIOTTS_DEVICE` | TTS playback error, no process crash | run `core/speak.py --devices` |
+| sqlite path unwritable | set path under read-only dir | memory error surfaced; chat should continue if possible | fix `SQLITE_MEMORY_PATH` permissions |
+| workspace path traversal | request `../.env` | tool rejects path | verify safe-path tests |
+| corrupt schedule JSON | write invalid JSON | scheduler handles/migrates or reports safely | backup and recreate `workspace/schedule.json` |
+| WebSocket invalid payload | send malformed JSON | backend ignores/rejects and logs warning | browser devtools + backend logs |
+| browser missing VRM | rename asset temporarily | visible frontend error, no backend crash | restore `webui/static/assets/Aiko.vrm` |
+| GitHub token absent | unset token | reflection publish skipped/fails safely | set `GITHUB_TOKEN` only for publish tests |
+
+---
+
+## 8. Performance Targets and Measurements
+
+Record actual values per hardware target. These targets are starting points, not hard promises for all models.
+
+| Metric | Warm target | Warning threshold | Notes |
+|---|---:|---:|---|
+| app boot to chat-ready (`--text`) | < 20 s | > 45 s | excludes model cold download |
+| app boot to voice-ready | < 60 s | > 120 s | ASR/TTS/model cache dependent |
+| first token after submit | < 2 s | > 5 s | warm local LLM |
+| short text turn complete | < 8 s | > 20 s | depends on model/token budget |
+| memory recall | < 500 ms | > 2 s | measure at 1k/10k memories |
+| `/web` search result available | < 5 s | > 15 s | depends on engines/network |
+| ASR final transcript after silence | < 2 s | > 5 s | SenseVoice CPU on Jetson may vary |
+| TTS first audio | < 3 s | > 8 s | MioTTS model/server dependent |
+| barge-in response | < 500 ms | > 1.5 s | after threshold confirmed |
+| WebUI token display lag | < 250 ms | > 1 s | browser/backend same LAN |
+| 8-hour idle RSS growth | < 10% | > 25% | stability/soak target |
+
+Suggested measurement commands:
+
+```bash
+/usr/bin/time -v uv run python main.py --text
+watch -n 1 'ps -o pid,rss,pcpu,pmem,cmd -C python | head -20'
+nvidia-smi dmon   # desktop NVIDIA only
+jtop              # Jetson
+```
+
+---
+
+## 9. Stability and Soak Tests
+
+### 9.1 Idle Soak
+
+- [ ] Start `uv run python main.py --text` and leave idle for 8 hours.
+- [ ] RSS memory growth stays under target.
+- [ ] scheduler thread remains alive.
+- [ ] no repeated error logs appear.
+- [ ] clean `/quit` after soak exits without hanging.
+
+### 9.2 Conversation Soak
+
+- [ ] Run at least 100 mixed turns: chat, memory, web, agent tasks, scheduling, and commands.
+- [ ] no unbounded token repetition occurs.
+- [ ] background memory queue drains after turns.
+- [ ] memory DB remains valid after process exit/restart.
+- [ ] average latency and 95th percentile latency are recorded.
+
+### 9.3 Voice Soak
+
+- [ ] Run 2 hours of intermittent voice use.
+- [ ] no audio device lock persists after toggling `/voice` and `/listen`.
+- [ ] VAD does not drift into always-listening or never-listening state.
+- [ ] barge-in still works after long uptime.
+- [ ] process exits cleanly.
+
+### 9.4 WebUI Soak
+
+- [ ] Keep a browser session connected for 8 hours.
+- [ ] refresh every 30 minutes; reconnect succeeds.
+- [ ] browser devtools show no runaway console errors.
+- [ ] backend thread count does not continuously increase.
+- [ ] VRM render remains stable.
+
+---
+
+## 10. Security, Privacy, and Safety Tests
+
+- [ ] `.env`, memory DB, logs, and workspace files are not exposed by WebUI static serving.
+- [ ] repo/file tools reject absolute paths, `..`, symlink escapes, and binary dumps.
+- [ ] web fetch blocks private/localhost addresses unless intentionally allowed.
+- [ ] agent final answer discloses failed external actions and does not claim actions were completed when tools failed.
+- [ ] no tool can send email, buy/book/order, or post externally unless an explicit future tool implements and tests that behavior.
+- [ ] user private facts are stored only locally unless reflection publishing is explicitly configured.
+- [ ] GitHub reflection publishing redacts secrets and handles API failures safely.
+- [ ] WebUI WAN exposure is not used without authentication/reverse-proxy controls.
+
+---
+
+## 11. Regression Checklist
+
+Run after any significant change.
+
+- [ ] Phase 1 memory round trip still works: store → restart → recall.
+- [ ] TUI launches and streams without errors.
+- [ ] WebUI launches and accepts at least one browser text turn.
+- [ ] `/reset`, `/memory`, `/clear`, `/remember`, `/think`, `/web`, `/voice`, `/listen`, `/help` behave correctly.
+- [ ] `--text`, `--no-asr`, `--debug`, `--webui`, and `--clear-mem` flags behave correctly.
+- [ ] SearXNG recovers after `docker compose down && docker compose up -d`.
+- [ ] LLM server restart does not require deleting memory or workspace files.
+- [ ] `uv sync` still succeeds after dependency changes.
+- [ ] docs and test-suite READMEs mention any newly added subsystem.
+
+---
+
+## 12. Troubleshooting Quick Reference
+
+### Aiko hangs during boot
+
+1. Check whether `LLM_BASE_URL` responds: `curl http://localhost:8080/v1/models`.
+2. Start with `--text` to skip TTS/ASR.
+3. Confirm sqlite path permissions.
+4. Check model downloads/cache paths and disk space.
+
+### TTS does not play
+
+1. `curl http://localhost:8001/health`.
+2. `uv run python core/speak.py --devices`.
+3. Set `MIOTTS_DEVICE` or default PulseAudio/PipeWire sink.
+4. Test `uv run python core/speak.py --wait "test"`.
+
+### ASR does not transcribe
+
+1. Confirm microphone device and permissions.
+2. Verify `ASR_MODEL` can be downloaded or exists in cache.
+3. Lower/raise `LISTEN_VAD_THRESHOLD` based on false negatives/positives.
+4. Test in a quiet room before testing noisy environments.
+
+### WebUI does not load
+
+1. Check terminal URL and port (`AIKO_HTTP_PORT`, default 8787).
+2. Check WebSocket port (`AIKO_WS_PORT`, default 8765).
+3. Open browser devtools for static asset or WebSocket errors.
+4. Confirm `webui/static/assets/Aiko.vrm` exists.
+
+### Agent tools behave incorrectly
+
+1. Re-run tool schema listing.
+2. Test the underlying `core.toolkit.*` function directly.
+3. Check workspace path caps and safe-path failures.
+4. Inspect final-answer verification logs for rejected unsupported claims.

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,33 @@
+# Aiko-chan Test Suites
+
+This directory organizes the industrial test plan described in [`docs/TESTS.md`](../docs/TESTS.md). The current files are suite specifications/checklists; executable tests should be added under the matching suite as the codebase becomes more automated.
+
+| Directory | Purpose | Typical trigger |
+|---|---|---|
+| `unit/` | Pure Python functions and safety helpers. | Every code change. |
+| `integration/` | Local service boundaries: LLM, SearXNG, MioTTS, ASR, sqlite-vec, WebUI. | Adapter/config/dependency changes. |
+| `system/` | Full user journeys through TUI, WebUI, voice, and agentic mode. | Release candidate. |
+| `load/` | Concurrent users, queue pressure, large memory DBs, long prompts. | Demo/field hardening. |
+| `error/` | Fault injection and graceful degradation. | Release candidate and incident fixes. |
+| `performance/` | Latency/resource measurements. | Model, hardware, or dependency changes. |
+| `stability/` | Soak, restart, reconnect, leak checks. | Long-running deployments. |
+| `functionality/` | Phase/feature acceptance. | Feature completion. |
+
+## Naming Convention for Future Executable Tests
+
+- Python unit tests: `tests/unit/test_<module>_<behavior>.py`
+- Integration tests: `tests/integration/test_<service>_<contract>.py`
+- Scenario scripts: `tests/system/<scenario>.md` or `tests/system/<scenario>.py`
+- Artifacts/logs: keep outside git, e.g. `workspace/test-runs/<date>/`
+
+## Minimum Metadata for Manual Test Runs
+
+Capture the following with every G3+ run:
+
+- git commit SHA;
+- hardware target and OS;
+- model names/quantization;
+- relevant `.env` values with secrets redacted;
+- commands executed;
+- pass/fail result;
+- logs, screenshots, or measurements.

--- a/tests/error/README.md
+++ b/tests/error/README.md
@@ -1,0 +1,19 @@
+# Error Injection Test Suite
+
+Verify graceful degradation and clear troubleshooting output.
+
+## Faults to Inject
+
+- LLM server down/wrong model/timeout;
+- SearXNG down or returning no results;
+- MioTTS down or audio device invalid;
+- ASR model missing, microphone unavailable, noisy input;
+- sqlite path unwritable, corrupt DB copy, disk full;
+- corrupt `workspace/schedule.json`;
+- WebSocket invalid JSON/binary frames;
+- path traversal attempts in workspace and repo tools;
+- absent GitHub reflection credentials.
+
+## Expected Behavior
+
+Aiko should not crash, should not leak secrets, should explain partial failure honestly, and should remain usable in reduced-capability mode where possible.

--- a/tests/functionality/README.md
+++ b/tests/functionality/README.md
@@ -1,0 +1,16 @@
+# Functionality Test Suite
+
+Feature and phase acceptance criteria.
+
+## Phase Coverage
+
+- Phase 1: local LLM, persona, memory, web search.
+- Phase 1.5: curses TUI, streaming, commands, TTS toggle.
+- Phase 2: ASR, VAD, TTS, barge-in.
+- Phase 2.5: agent tools, skill registry, schedules, photo/repo workflows, final-answer verification.
+- Phase 3: VRM avatar, expressions, visemes, WebSocket bridge.
+- Phase 4+: roadmap features should remain marked roadmap-facing until implemented.
+
+## Evidence
+
+For user-visible features, capture terminal output, browser screenshots when UI changes are visible, generated files, and logs.

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,20 @@
+# Integration Test Suite
+
+Validate contracts between Aiko and local services.
+
+## Boundaries
+
+- OpenAI-compatible LLM at `LLM_BASE_URL`.
+- SearXNG search at `SEARXNG_URL`.
+- MioTTS synthesis at `MIOTTS_API_URL`.
+- SenseVoice/Silero ASR/VAD initialization.
+- sqlite-vec + fastembed persistent memory.
+- WebUI HTTP/WebSocket bridge.
+- schedule runner and `workspace/schedule.json`.
+
+## Required Evidence
+
+- service health output;
+- request/response shape;
+- timeout behavior;
+- controlled failure behavior when the service is stopped or misconfigured.

--- a/tests/load/README.md
+++ b/tests/load/README.md
@@ -1,0 +1,17 @@
+# Load Test Suite
+
+Stress queues, services, and resource limits.
+
+## Targets
+
+- sequential and concurrent text turns;
+- long prompts near context limits;
+- large sqlite memory DB sizes: 100, 1,000, 10,000 memories;
+- repeated `/web`, `/memory`, `/reset`, `/voice`, `/listen` commands;
+- repeated WebSocket reconnects;
+- rapid schedule create/cancel loops;
+- repeated ASR/TTS turns and barge-in attempts.
+
+## Metrics
+
+Capture latency percentiles, RSS memory, CPU/GPU usage, DB size, thread count, and error rate.

--- a/tests/performance/README.md
+++ b/tests/performance/README.md
@@ -1,0 +1,21 @@
+# Performance Test Suite
+
+Measure latency and throughput against hardware-specific baselines.
+
+## Metrics
+
+- boot to chat-ready;
+- boot to voice-ready;
+- first-token latency;
+- full short-turn latency;
+- memory recall latency at multiple DB sizes;
+- `/web` latency;
+- ASR finalization after silence;
+- TTS first-audio latency;
+- barge-in reaction time;
+- WebUI token-display lag;
+- RSS growth over idle and active windows.
+
+## Tools
+
+Use `/usr/bin/time -v`, `ps`, `jtop` on Jetson, `nvidia-smi` on desktop NVIDIA, browser devtools, and Aiko logs.

--- a/tests/stability/README.md
+++ b/tests/stability/README.md
@@ -1,0 +1,16 @@
+# Stability Test Suite
+
+Long-running and recovery-focused tests.
+
+## Soak Runs
+
+- 8-hour text idle;
+- 100-turn mixed conversation;
+- 2-hour intermittent voice session;
+- 8-hour WebUI connected browser session;
+- scheduler due-job overnight run;
+- service restart recovery for LLM, SearXNG, MioTTS, and browser reconnects.
+
+## Failure Conditions
+
+Unbounded memory growth, stuck audio devices, unrecoverable WebSocket reconnect loops, corrupted memory/schedule files, or hung shutdowns fail the suite.

--- a/tests/system/README.md
+++ b/tests/system/README.md
@@ -1,0 +1,16 @@
+# System Test Suite
+
+Exercise complete user journeys.
+
+## Core Scenarios
+
+- text-only baseline: `uv run python main.py --text`;
+- curses full voice: `uv run python main.py`;
+- browser WebUI text: `uv run python main.py --webui --text`;
+- browser WebUI voice: `uv run python main.py --webui`;
+- agentic planning/workspace/scheduling/photo/repo workflows;
+- restart and memory recall journey.
+
+## Acceptance
+
+A scenario passes only if the process exits cleanly, expected artifacts are created in approved locations, and no uncaught traceback appears.

--- a/tests/unit/README.md
+++ b/tests/unit/README.md
@@ -1,0 +1,21 @@
+# Unit Test Suite
+
+Focus on deterministic functions that do not require live external services.
+
+## Priority Areas
+
+- CLI parsing and voice-command fuzzy matching in `main.py`.
+- TTS text sanitization and chunk splitting in `core/speak.py`.
+- stream sentence splitting in `core/think.py`.
+- memory decay scoring and FTS query sanitization in `core/forget.py` and `core/memorize.py`.
+- schedule calculation and legacy migration in `core/schedule.py`.
+- safe path handling in `core/toolkit/common.py`, `planning.py`, and `architecture.py`.
+- agent tool schema validation and failure classification in `core/agentic.py`.
+
+## Suggested First Automation Targets
+
+1. `test_voice_command_matching.py`
+2. `test_sanitize_for_tts.py`
+3. `test_schedule_calculate_next_due.py`
+4. `test_toolkit_safe_paths.py`
+5. `test_agentic_schema_dispatch.py`


### PR DESCRIPTION
### Motivation
- Provide an optional browser WebUI with VRM avatar and microphone bridge alongside the existing curses TUI to enable richer remote interactions.
- Migrate the chat runtime from an Ollama-specific client to an OpenAI-compatible local endpoint (`LLM_BASE_URL` / `LLM_MODEL`) for broader local LLM support (e.g. `llama-server`).
- Activate Phase 2.5 agentic workflows: tool registry, skill documents, scheduling/reminders, and a ReAct-style task loop to support repeatable workflows.
- Improve release readiness by adding a structured industrial test plan and suite scaffolding to validate integration, performance, and stability on constrained hardware. 

### Description
- README and docs updated to document default `--tui` behavior, optional `--webui` flag, new environment variables (`LLM_BASE_URL`, `LLM_MODEL`, `ROUTE_*`, etc.), and runtime expectations for MioTTS/SenseVoice/SeaxNG.
- Added a `webui/` backend (`webui/aiko_web.py`) and `webui/static/` assets to serve the browser UI, WebSocket bridge, VRM avatar, and microphone frame handling.
- Core runtime notes and architecture docs updated: `core/think.py` now targets an OpenAI-compatible client path, `core/agentic.py` and `core/toolkit/` are highlighted for agentic execution, and scheduling/schedule runner capabilities expanded.
- Project layout and tooling adjustments: new `tests/` directory with unit/integration/system/load/error/performance/stability/functionality suites and companion `tests/*/README.md` files, plus updated docs (`docs/TESTS.md`, `docs/INSTALL.md`, `docs/ARCHITECTURE.md`, `docs/HISTORY.md`) to reflect the feature and env migrations.
- Minor fixes and renames across the tree (e.g. `aurora_forecast_watch` spelling, `main.py` CLI flag docs, notes about archived Ollama-specific settings). 

### Testing
- No automated tests were executed as part of this change; the PR adds a detailed industrial test plan and scaffolding under `tests/` intended for future automation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d725ae140832c867881a48a008c1b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project docs to reflect the current runtime, setup, and configuration, including WebUI, voice, agent workflows, scheduling, and new environment settings.
  * Expanded architecture, history, install, and README details with clearer launch options and current service expectations.

* **Tests**
  * Added a full test suite structure and guidance for unit, integration, system, load, performance, stability, functionality, and error-injection coverage.
  * Introduced a comprehensive test plan with acceptance criteria and evidence requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->