### PR TITLE
Improve archived gesture animations

### DIFF
--- a/archive/gesture.js
+++ b/archive/gesture.js
@@ -1,268 +1,216 @@
 // gesture.js
+// Natural, loop-friendly gesture poses for archive/test-3d-model.html.
+// Each exported gesture accepts the tester ctx and writes target rotations.
+
 export function blend(from, to, t) {
   return from + (to - from) * t;
 }
 
-export function hairBrush(ctx) {
-  const {
-    side,
-    intensity,
-    t,
-    strokeSpeed = 0.9,
-    io,
-    REST,
-    head,
-    lUA,
-    lLA,
-    lH,
-    rUA,
-    rLA,
-    rH
-  } = ctx;
+const TAU = Math.PI * 2;
+const clamp01 = v => Math.max(0, Math.min(1, v));
+const ease = v => v * v * (3 - 2 * v);
+function wave(t, speed = 1, phase = 0) {
+  return Math.sin(t * speed + phase);
+}
 
+function holdCycle(t, speed = 0.35, hold = 0.42) {
+  const c = (t * speed) % 1;
+  if (c < 0.22) return ease(c / 0.22);
+  if (c < 0.22 + hold) return 1;
+  return ease(1 - (c - 0.22 - hold) / (0.78 - hold));
+}
+
+function strokeCycle(t, speed = 1, downPortion = 0.72) {
+  const c = (t * speed) % 1;
+  const v = c < downPortion ? c / downPortion : 1 - (c - downPortion) / (1 - downPortion);
+  return ease(clamp01(v));
+}
+
+function sideBones(ctx, side = ctx.side) {
   const left = side < 0;
-  const sign = left ? -1 : 1;
+  return {
+    s: left ? -1 : 1,
+    UA: left ? ctx.lUA : ctx.rUA,
+    LA: left ? ctx.lLA : ctx.rLA,
+    H: left ? ctx.lH : ctx.rH,
+    restUA: left ? ctx.REST.leftUpperArm : ctx.REST.rightUpperArm,
+    restLA: left ? ctx.REST.leftLowerArm : ctx.REST.rightLowerArm,
+    restH: left ? ctx.REST.leftHand : ctx.REST.rightHand,
+    ioUA: left ? ctx.io.lUA : ctx.io.rUA,
+    ioLA: left ? ctx.io.lLA : ctx.io.rLA,
+    ioH: left ? ctx.io.lH : ctx.io.rH,
+  };
+}
 
-  const UA = left ? lUA : rUA;
-  const LA = left ? lLA : rLA;
-  const H  = left ? lH  : rH;
+function poseArm(ctx, side, upper = {}, lower = {}, hand = {}) {
+  const b = sideBones(ctx, side);
+  const set = (bone, rest, io, vals) => {
+    if (!bone) return;
+    for (const axis of ['x', 'y', 'z']) {
+      if (vals[axis] !== undefined) bone.rotation[axis] = blend((rest[axis] ?? 0) + (io[axis] ?? 0), vals[axis], 1);
+    }
+  };
+  set(b.UA, b.restUA, b.ioUA, upper);
+  set(b.LA, b.restLA, b.ioLA, lower);
+  set(b.H, b.restH, b.ioH, hand);
+}
 
-  const restUA = left ? REST.leftUpperArm : REST.rightUpperArm;
-  const restLA = left ? REST.leftLowerArm : REST.rightLowerArm;
-  const restH  = left ? REST.leftHand : REST.rightHand;
-
-  const ioUA = left ? io.lUA : io.rUA;
-  const ioLA = left ? io.lLA : io.rLA;
-  const ioH  = left ? io.lH  : io.rH;
-
-  // --------------------------------------------------
-  // Brush cycle
-  // 0.0 = temple
-  // 0.7 = shoulder
-  // 1.0 = quick return
-  // --------------------------------------------------
-
-  const cycle = (t * strokeSpeed) % 1;
-
-  let brush;
-
-  if (cycle < 0.75) {
-    // slow downward stroke
-    brush = cycle / 0.75;
-  } else {
-    // quick lift
-    brush = 1 - (cycle - 0.75) / 0.25;
-  }
-
-  // smooth easing
-  brush = brush * brush * (3 - 2 * brush);
-
-  // --------------------------------------------------
-  // Upper arm
-  // --------------------------------------------------
-
-  if (UA) {
-
-    UA.rotation.z = blend(
-      restUA.z + ioUA.z,
-      sign * (0.93 + brush * 0.05) * intensity,
-      1
-    );
-
-    UA.rotation.x = blend(
-      restUA.x + ioUA.x,
-      -(0.55 - brush * 0.05) * intensity,
-      1
-    );
-  }
-
-  // --------------------------------------------------
-  // Lower arm
-  // Most of the movement
-  // --------------------------------------------------
-
-  if (LA) {
-
-    LA.rotation.x = blend(
-      restLA.x + ioLA.x,
-      -(1.35 - brush * 0.55) * intensity,
-      1
-    );
-
-    LA.rotation.z = blend(
-      restLA.z + ioLA.z,
-      sign * 0.16 * intensity,
-      1
-    );
-  }
-
-  // --------------------------------------------------
-  // Wrist
-  // --------------------------------------------------
-
-  if (H) {
-
-    H.rotation.y = blend(
-      restH.y + ioH.y,
-      -sign * (0.55 - brush * 0.18) * intensity,
-      1
-    );
-
-    H.rotation.x = blend(
-      restH.x + ioH.x,
-      -(0.30 + brush * 0.15) * intensity,
-      1
-    );
-
-    H.rotation.z = blend(
-      (restH.z ?? 0) + (ioH.z ?? 0),
-      sign * (0.20 + brush * 0.08) * intensity,
-      1
-    );
-  }
-
-  // --------------------------------------------------
-  // Head
-  // --------------------------------------------------
-
+function look(ctx, { x, y, z, neckX, neckY, neckZ }, amount) {
+  if (neckX === undefined && x !== undefined) neckX = x * 0.45;
+  if (neckY === undefined && y !== undefined) neckY = y * 0.45;
+  if (neckZ === undefined && z !== undefined) neckZ = z * 0.45;
+  const { head, neck, io } = ctx;
   if (head) {
-
-    head.rotation.z = blend(
-      io.head.z,
-      -sign * 0.08 * intensity,
-      1
-    );
-
-    head.rotation.y = blend(
-      io.head.y,
-      sign * (0.04 + brush * 0.02) * intensity,
-      1
-    );
-
-    head.rotation.x = blend(
-      io.head.x,
-      -0.03 * intensity,
-      1
-    );
+    if (x !== undefined) head.rotation.x = blend(io.head.x, x, amount);
+    if (y !== undefined) head.rotation.y = blend(io.head.y, y, amount);
+    if (z !== undefined) head.rotation.z = blend(io.head.z, z, amount);
+  }
+  if (neck) {
+    if (neckX !== undefined) neck.rotation.x = blend(io.neck?.x ?? 0, neckX, amount);
+    if (neckY !== undefined) neck.rotation.y = blend(io.neck?.y ?? 0, neckY, amount);
+    if (neckZ !== undefined) neck.rotation.z = blend(io.neck?.z ?? 0, neckZ, amount);
   }
 }
 
+export function idleBreathing(ctx) {
+  const { t, intensity = 1, head, neck, io } = ctx;
+  const a = intensity;
+  look(ctx, {
+    x: io.head.x + wave(t, 0.53) * 0.018 * a,
+    y: io.head.y + wave(t, 0.31) * 0.055 * a + wave(t, 0.97, 1.2) * 0.012 * a,
+    z: io.head.z + wave(t, 0.27, 1.1) * 0.025 * a,
+  }, 1);
+  if (neck) neck.rotation.x += wave(t, 0.71) * 0.008 * a;
+  const armSway = wave(t, 0.42) * 0.03 * a;
+  poseArm(ctx, -1, { x: ctx.REST.leftUpperArm.x + wave(t, 0.49) * 0.02 * a, z: ctx.REST.leftUpperArm.z + armSway }, { x: ctx.REST.leftLowerArm.x + wave(t, 0.67) * 0.014 * a }, { y: ctx.REST.leftHand.y + wave(t, 0.58) * 0.018 * a });
+  poseArm(ctx, 1, { x: ctx.REST.rightUpperArm.x + wave(t, 0.47, 1.1) * 0.02 * a, z: ctx.REST.rightUpperArm.z + armSway }, { x: ctx.REST.rightLowerArm.x + wave(t, 0.63, 0.8) * 0.014 * a }, { y: ctx.REST.rightHand.y + wave(t, 0.54, 1.4) * 0.018 * a });
+}
+
+export function lookAround(ctx) {
+  const { t, intensity = 1, side } = ctx;
+  const a = holdCycle(t, 0.18, 0.5) * intensity;
+  look(ctx, { x: -0.015 * a + wave(t, 0.7) * 0.018, y: side * (0.18 + 0.05 * wave(t, 0.8)) * a, z: -side * 0.035 * a }, 1);
+}
+
+export function meetGaze(ctx) {
+  const a = holdCycle(ctx.t, 0.24, 0.56) * ctx.intensity;
+  look(ctx, { x: 0.02, y: 0, z: 0, neckX: 0.006, neckY: 0, neckZ: 0 }, a);
+}
+
+export function curiousTilt(ctx) {
+  const a = holdCycle(ctx.t, 0.28, 0.46) * ctx.intensity;
+  look(ctx, { x: -0.035 * a, y: ctx.side * 0.055 * a, z: ctx.side * 0.16 * a }, 1);
+}
+
+export function headNod(ctx) {
+  const n = Math.sin((ctx.t * (ctx.strokeSpeed ?? 1.2)) % 1 * TAU * 1.5) * ctx.intensity;
+  look(ctx, { x: n * 0.11, y: 0, z: ctx.side * 0.012 }, 1);
+}
+
+export function hairBrush(ctx) {
+  const { t, intensity = 1, strokeSpeed = 0.9, side } = ctx;
+  const b = strokeCycle(t, strokeSpeed, 0.76);
+  const a = holdCycle(t, 0.23, 0.5) * intensity;
+  poseArm(ctx, side,
+    { x: -0.48 * a, z: side * (0.82 + b * 0.08) * a },
+    { x: -(1.18 - b * 0.45) * a, z: side * 0.18 * a },
+    { x: -(0.20 + b * 0.18) * a, y: -side * (0.50 - b * 0.16) * a, z: side * (0.16 + b * 0.10) * a }
+  );
+  look(ctx, { x: -0.025 * a, y: side * (0.035 + b * 0.025) * a, z: -side * 0.075 * a }, 1);
+}
+
 export function lookAtHand(ctx) {
-  const {
-    side,
-    intensity,
-    io,
-    REST,
-    head,
-    neck,
-    lUA,
-    lLA,
-    lH,
-    rUA,
-    rLA,
-    rH
-  } = ctx;
+  const a = holdCycle(ctx.t, 0.25, 0.46) * ctx.intensity;
+  poseArm(ctx, ctx.side, { x: -0.42 * a, z: ctx.side * 0.68 * a }, { x: -0.92 * a, z: ctx.side * 0.14 * a }, { x: 0.18 * a, y: -ctx.side * 0.38 * a, z: ctx.side * 0.08 * wave(ctx.t, 3) * a });
+  look(ctx, { x: -0.08 * a, y: ctx.side * 0.18 * a, z: -ctx.side * 0.025 * a }, 1);
+}
 
-  const s = side < 0 ? -1 : 1;
+export function fingerPlay(ctx) {
+  const a = holdCycle(ctx.t, 0.3, 0.5) * ctx.intensity;
+  poseArm(ctx, ctx.side, { x: -0.16 * a, z: ctx.side * 0.18 * a }, { x: -0.42 * a, z: ctx.side * 0.06 * a }, { x: 0.04 * wave(ctx.t, 5.2) * a, y: -ctx.side * 0.28 * a, z: ctx.side * 0.16 * wave(ctx.t, 7.1) * a });
+  look(ctx, { x: 0.055 * a, y: ctx.side * 0.11 * a, z: ctx.side * 0.02 * a }, 1);
+}
 
-  if (s < 0) {
-    if (lUA) {
-      lUA.rotation.x = blend(
-        REST.leftUpperArm.x + io.lUA.x,
-        -0.45 * intensity,
-        1
-      );
-      lUA.rotation.z = blend(
-        REST.leftUpperArm.z + io.lUA.z,
-        -0.70 * intensity,
-        1
-      );
-    }
-    if (lLA) {
-      lLA.rotation.x = blend(
-        REST.leftLowerArm.x + io.lLA.x,
-        -0.95 * intensity,
-        1
-      );
-      lLA.rotation.z = blend(
-        REST.leftLowerArm.z + io.lLA.z,
-        -0.15 * intensity,
-        1
-      );
-    }
-    if (lH) {
-      lH.rotation.x = blend(
-        REST.leftHand.x + io.lH.x,
-        0.25 * intensity,
-        1
-      );
-      lH.rotation.y = blend(
-        REST.leftHand.y + io.lH.y,
-        0.45 * intensity,
-        1
-      );
-    }
-  } else {
-    if (rUA) {
-      rUA.rotation.x = blend(
-        REST.rightUpperArm.x + io.rUA.x,
-        -0.45 * intensity,
-        1
-      );
-      rUA.rotation.z = blend(
-        REST.rightUpperArm.z + io.rUA.z,
-        0.70 * intensity,
-        1
-      );
-    }
-    if (rLA) {
-      rLA.rotation.x = blend(
-        REST.rightLowerArm.x + io.rLA.x,
-        -0.95 * intensity,
-        1
-      );
-      rLA.rotation.z = blend(
-        REST.rightLowerArm.z + io.rLA.z,
-        0.15 * intensity,
-        1
-      );
-    }
-    if (rH) {
-      rH.rotation.x = blend(
-        REST.rightHand.x + io.rH.x,
-        0.25 * intensity,
-        1
-      );
-      rH.rotation.y = blend(
-        REST.rightHand.y + io.rH.y,
-        -0.45 * intensity,
-        1
-      );
-    }
-  }
+export function raiseHand(ctx) {
+  const a = holdCycle(ctx.t, 0.23, 0.44) * ctx.intensity;
+  const flutter = wave(ctx.t, 8.5) * 0.10 * a;
+  poseArm(ctx, ctx.side, { x: -0.72 * a, z: ctx.side * 0.44 * a }, { x: -0.86 * a, z: ctx.side * 0.10 * a }, { x: 0.10 * a, y: -ctx.side * 0.22 * a, z: ctx.side * flutter });
+  look(ctx, { x: -0.025 * a, y: ctx.side * 0.10 * a, z: -ctx.side * 0.018 * a }, 1);
+}
 
-  if (head) {
-    head.rotation.y = blend(
-      io.head.y,
-      s * 0.18 * intensity,
-      1
-    );
-    head.rotation.x = blend(
-      io.head.x,
-      -0.10 * intensity,
-      1
-    );
-  }
-  if (neck) {
-    neck.rotation.y = blend(
-      io.neck.y,
-      s * 0.10 * intensity,
-      1
-    );
-    neck.rotation.x = blend(
-      io.neck.x,
-      -0.06 * intensity,
-      1
-    );
-  }
+export function chinTouch(ctx) {
+  const a = holdCycle(ctx.t, 0.22, 0.55) * ctx.intensity;
+  poseArm(ctx, ctx.side, { x: -0.55 * a, z: ctx.side * 0.58 * a }, { x: -1.02 * a, z: ctx.side * 0.10 * a }, { x: -0.18 * a, y: -ctx.side * 0.20 * a, z: ctx.side * 0.06 * a });
+  look(ctx, { x: 0.055 * a, y: -ctx.side * 0.035 * a, z: ctx.side * 0.045 * a }, 1);
+}
+
+export function touchCollar(ctx) {
+  const a = holdCycle(ctx.t, 0.28, 0.42) * ctx.intensity;
+  poseArm(ctx, ctx.side, { x: -0.46 * a, z: ctx.side * 0.44 * a }, { x: -0.82 * a, z: ctx.side * 0.18 * a }, { x: 0.12 * a, y: -ctx.side * 0.24 * a, z: ctx.side * 0.05 * wave(ctx.t, 4) * a });
+  look(ctx, { x: -0.035 * a, y: ctx.side * 0.08 * a, z: -ctx.side * 0.03 * a }, 1);
+}
+
+export function wristFlick(ctx) {
+  const a = holdCycle(ctx.t, 0.55, 0.15) * ctx.intensity;
+  poseArm(ctx, ctx.side, { z: ctx.side * 0.16 * a }, { y: -ctx.side * 0.34 * a }, { y: -ctx.side * 0.25 * a, z: ctx.side * 0.48 * wave(ctx.t, 11) * a });
+  look(ctx, { y: ctx.side * 0.06 * a, z: -ctx.side * 0.015 * a }, 1);
+}
+
+export function shoulderRoll(ctx) {
+  const r = Math.sin((ctx.t * 0.55) % 1 * TAU) * ctx.intensity;
+  poseArm(ctx, ctx.side, { x: -0.20 * r, y: ctx.side * 0.10 * r, z: ctx.side * 0.14 * r }, {}, {});
+  look(ctx, { x: -0.02 * Math.abs(r), z: -ctx.side * 0.045 * r }, 1);
+}
+
+export function handOnHip(ctx) {
+  const a = holdCycle(ctx.t, 0.21, 0.58) * ctx.intensity;
+  poseArm(ctx, ctx.side, { x: -0.18 * a, z: ctx.side * 0.58 * a }, { x: -0.18 * a, z: ctx.side * 0.34 * a }, { y: -ctx.side * 0.12 * a, z: ctx.side * 0.22 * a });
+  look(ctx, { y: -ctx.side * 0.05 * a, z: ctx.side * 0.025 * a }, 1);
+}
+
+export function adjustSleeve(ctx) {
+  const a = holdCycle(ctx.t, 0.32, 0.34) * ctx.intensity;
+  const workingSide = -ctx.side;
+  poseArm(ctx, workingSide, { x: -0.30 * a, z: workingSide * 0.36 * a }, { x: -0.54 * a, y: -workingSide * 0.35 * a }, { x: -0.16 * a, z: workingSide * (0.12 + 0.08 * wave(ctx.t, 9)) * a });
+  look(ctx, { x: 0.04 * a, y: workingSide * 0.08 * a }, 1);
+}
+
+export function brushShoulder(ctx) {
+  const a = holdCycle(ctx.t, 0.35, 0.25) * ctx.intensity;
+  const workingSide = -ctx.side;
+  const brush = wave(ctx.t, 9.5) * a;
+  poseArm(ctx, workingSide, { x: -0.28 * a, z: workingSide * 0.24 * a }, { x: -0.45 * a }, { z: workingSide * 0.26 * brush, y: -workingSide * 0.12 * a });
+  look(ctx, { y: -workingSide * 0.08 * a, z: workingSide * 0.025 * a }, 1);
+}
+
+export function stretchArm(ctx) {
+  const a = holdCycle(ctx.t, 0.18, 0.42) * ctx.intensity;
+  poseArm(ctx, ctx.side, { x: -0.82 * a, z: ctx.side * 0.30 * a }, { x: -0.32 * a, z: ctx.side * 0.04 * a }, { x: 0.18 * a, y: -ctx.side * 0.10 * a });
+  look(ctx, { x: -0.04 * a, y: ctx.side * 0.12 * a, z: -ctx.side * 0.025 * a }, 1);
+}
+
+export function stretchNeck(ctx) {
+  const a = holdCycle(ctx.t, 0.2, 0.5) * ctx.intensity;
+  look(ctx, { x: -0.10 * a, y: -ctx.side * 0.04 * a, z: ctx.side * 0.08 * a }, 1);
+}
+
+export function shiftWeight(ctx) {
+  const a = Math.sin((ctx.t * 0.22) % 1 * Math.PI) * ctx.intensity;
+  look(ctx, { x: 0.005, y: -ctx.side * 0.025 * a, z: ctx.side * 0.04 * a }, 1);
+  poseArm(ctx, -1, { z: ctx.REST.leftUpperArm.z - ctx.side * 0.035 * a }, {}, {});
+  poseArm(ctx, 1, { z: ctx.REST.rightUpperArm.z - ctx.side * 0.035 * a }, {}, {});
+}
+
+export function sway(ctx) {
+  const s = wave(ctx.t, 0.8) * ctx.intensity;
+  look(ctx, { x: 0.01 * wave(ctx.t, 1.1), y: 0.035 * s, z: -0.045 * s }, 1);
+  poseArm(ctx, -1, { z: ctx.REST.leftUpperArm.z - 0.045 * s }, { x: ctx.REST.leftLowerArm.x + 0.018 * s }, {});
+  poseArm(ctx, 1, { z: ctx.REST.rightUpperArm.z - 0.045 * s }, { x: ctx.REST.rightLowerArm.x - 0.018 * s }, {});
+}
+
+export function crossArms(ctx) {
+  const a = holdCycle(ctx.t, 0.17, 0.5) * ctx.intensity;
+  poseArm(ctx, -1, { x: -0.16 * a, z: -0.34 * a }, { x: -0.36 * a, z: -0.25 * a }, { z: -0.10 * a });
+  poseArm(ctx, 1, { x: -0.16 * a, z: 0.34 * a }, { x: -0.36 * a, z: 0.25 * a }, { z: 0.10 * a });
+  look(ctx, { x: 0.035 * a, y: ctx.side * 0.025 * a }, 1);
 }


### PR DESCRIPTION
### Motivation
- Replace the existing simplistic idle/gesture logic with more natural, loop-friendly motions and make the poses easier to tune.
- Centralize shared timing and easing behavior so multiple gestures blend cleanly with the idle base.
- Provide a richer set of small, believable interactions (hair, sleeve, collar, hips, cross-arms, etc.) for the HTML gesture tester.

### Description
- Rewrote `archive/gesture.js` and added shared helpers and constants (`TAU`, `ease`, `clamp01`, `wave`, `holdCycle`, `strokeCycle`) for consistent timing and easing.
- Introduced `sideBones`, `poseArm`, and `look` utilities to make gestures side-aware and to unify head/neck follow-through and arm posing.
- Replaced scattered per-gesture code with a fuller library of exports including `idleBreathing`, `lookAround`, `meetGaze`, `hairBrush`, `lookAtHand`, `fingerPlay`, `raiseHand`, `chinTouch`, `touchCollar`, `wristFlick`, `shoulderRoll`, `handOnHip`, `adjustSleeve`, `brushShoulder`, `stretchArm`, `stretchNeck`, `shiftWeight`, `sway`, and `crossArms`.
- Smoothed gesture loops and timing by using hold/stroke cycles, subtle head/neck offsets, and small per-gesture wave/pulse variations.

### Testing
- Performed a syntax/module check with `node --input-type=module --check < archive/gesture.js` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dbf059ad8832ca866dd348ab97dcd)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded character gesture and idle animation options, including looking around, nodding, hand-to-face motions, stretching, shifting weight, and crossing arms.
  * Improved arm and head movement behavior for more natural-looking gestures.

* **Bug Fixes**
  * Refined existing gestures like brushing hair and looking at a hand for smoother, more consistent motion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->