### PR TITLE
Memory & routing overhaul: Harrier embeddings, monthly consolidation, routing and latency telemetry

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,11 +9,6 @@ USER_ID=OppaAI                                  # your user ID stored with memor
 # ── LLM — llama.cpp ───────────────────────────────────────────────────────────
 LLM_BASE_URL=http://localhost:8080/v1                   # llama-server OpenAI-compatible endpoint (launch with --jinja for Ministral's chat template)
 LLM_MODEL=ministral                                     # main chat LLM — must match /v1/models id/alias
-EMBED_MODEL=ferrisS/harrier-oss-v1-270m-fastembed       # embedding model for vector search
-EMBED_DIMS=640                                          # dimension of embedding model
-EMBED_QUERY_INSTRUCT="Retrieve relevant memories that answer the query"
-EMBED_BATCH_SIZE=64
-
 LLM_TIMEOUT=120                                         # seconds before an LLM call times out (stream + fallback)
 LLM_MAX_TOKENS=280                                      # base max_tokens per chat reply (aliased as BASE_PREDICT)
 CONTEXT_WINDOW_TURNS=8                                  # past turns sent as context (each turn = 2 messages)
@@ -31,6 +26,13 @@ REASONING_SCALE=3                                       # think+answer token mul
 # FASTEMBED_CACHE_PATH must also survive reboots — /tmp is wiped on restart.
 SQLITE_MEMORY_PATH=/home/oppa-ai/.aiko/memory.db        # sqlite-vec DB (persistent storage)
 FASTEMBED_CACHE_PATH=/home/oppa-ai/.cache/fastembed     # fastembed model cache (not /tmp)
+EMBED_MODEL=ferrisS/harrier-oss-v1-270m-fastembed       # fastembed model for memory + semantic routing
+EMBED_DIMS=640                                          # vector dimensions; must match model and memories_vec schema
+EMBED_REGISTER_CUSTOM_MODEL=auto                        # auto = try add_custom_model and continue if already registered; 1 = require; 0 = skip
+EMBED_MODEL_FILE=model_quantized.onnx                   # ONNX filename inside custom fastembed repo
+EMBED_MODEL_DATA_FILE=model_quantized.onnx_data         # external ONNX data file inside custom fastembed repo (blank if none)
+EMBED_QUERY_INSTRUCT="Retrieve relevant memories that answer the query"  # harrier query-side instruction; documents/memories stay unprefixed
+EMBED_BATCH_SIZE=64                                     # batch size for archive/migrate_embeddings.py re-embedding
 MEMORY_EXTRACT_MIN_CHARS=80                             # skip trivial turns (greetings, "ok")
 MEMORY_RECALL_LIMIT=5                                   # memories injected into context per turn
 
@@ -39,9 +41,21 @@ MEMORY_RECALL_LIMIT=5                                   # memories injected into
 # FORGET_ACCESS_COUNT_CAP=255                   # max access count — uint8 cap (default 255)
 # FORGET_BOOST_AMOUNT=2                         # access_count boost for salient memories (default 2)
 FORGET_CLEANUP_THRESHOLD=0.1                    # prune more aggressively — default 0.05
-FORGET_GRACE_PERIOD_DAYS=7                      # shorter new-memory protection — default 14
+FORGET_GRACE_PERIOD_DAYS=31                     # keep at least one full month of detailed memories before cleanup
 DREAM_MERGE_THRESHOLD=0.88                      # merge more duplicates — default 0.92
-# DREAM_HOUR=3                                  # run consolidation at 3 AM when idle
+DREAM_RUN_AFTER_HOUR=0                         # daily dream/reflection can run any time after this local hour
+DREAM_RUN_AFTER_MINUTE=0                       # daily dream/reflection minute within DREAM_RUN_AFTER_HOUR
+DREAM_POLL_SECONDS=300                         # how often the scheduler checks for a missed daily run
+DREAM_STATE_PATH=/home/oppa-ai/.aiko/dream_state.json  # stores last successful daily dream date
+MONTHLY_CONSOLIDATION_ENABLED=1                 # consolidate older memories into a pinned monthly summary
+MONTHLY_CONSOLIDATION_SOURCE=experience         # experience = summarize raw daily JSONL turns; memory = summarize vector facts
+MONTHLY_CONSOLIDATION_KEEP_MONTHS=1             # keep the most recent full month as detailed memories
+MONTHLY_CONSOLIDATION_CHUNK_TURNS=40            # experience turns per monthly summary chunk
+MONTHLY_CONSOLIDATION_CHUNK_MEMS=25             # memory facts per fallback summary chunk
+MONTHLY_CONSOLIDATION_DELETE_ORIGINALS=1        # delete unpinned detailed memories after pinned monthly summary is saved
+MONTHLY_CONSOLIDATION_DELETE_DAILY_SUMMARIES=1  # replace older pinned daily summaries with the monthly pinned summary
+MONTHLY_CONSOLIDATION_MIN_MEMS=5                # skip memory fallback months with fewer memories than this
+MONTHLY_CONSOLIDATION_STATE_PATH=/home/oppa-ai/.aiko/monthly_consolidation_state.json
 DREAM_BOOST_AMOUNT=2
 
 # ── Async Memory Write Timing ────────────────────────────────────────────────
@@ -52,6 +66,10 @@ MEMORY_WRITE_IDLE_GRACE=3.0                     # seconds of idle chat required 
 MEMORY_WRITE_MAX_WAIT=45.0                      # max seconds memory writer waits before forcing the write anyway
 MEMORY_SEARCH_CACHE_SIZE=128
 MEMORY_SEARCH_CACHE_TTL=20.0
+MEMORY_RANK_RECENCY_WEIGHT=0.004                 # small retrieval boost for recent memories after semantic/FTS RRF
+MEMORY_RANK_RECENCY_HALF_LIFE_DAYS=30            # recency boost halves every N days
+MEMORY_RANK_ACCESS_WEIGHT=0.002                  # small boost for frequently recalled memories
+MEMORY_RANK_PINNED_WEIGHT=0.002                  # small boost for pinned/special memories
 MEMORY_CONTEXT_FACT_CHARS=220
 MEMORY_CONTEXT_TOTAL_CHARS=1200
 MEMORY_LIFECYCLE_BATCH_SIZE=500
@@ -59,6 +77,7 @@ WRITE_DEDUP_THRESHOLD=0.95
 
 # ── Output Pacing ─────────────────────────────────────────────────────────────
 EMIT_DELAY=0.012                                # delay (sec) between word emits to TUI callback — sync with TTS pacing
+AIKO_LATENCY_LOG=1                              # log per-turn timing: voice-end→submit, first token, TTS start, full turn
 
 # ── Logging ───────────────────────────────────────────────────────────────────
 # DEBUG floods the terminal — use INFO for normal operation.
@@ -68,7 +87,7 @@ LOG_LEVEL=INFO                                  # DEBUG | INFO | WARNING | ERROR
 
 # ── TTS — MioTTS ──────────────────────────────────────────────────────────────
 # MioTTS runs as an external server — start it before launching Aiko.
-# Backend: Ollama serves the MioTTS GGUF model via OpenAI-compatible API.
+# Backend: OpenAI-compatible local server serves the MioTTS GGUF model.
 # Frontend: run_server.py (in ~/MioTTS-Inference) wraps it as a synthesis API.
 # speak.py POSTs text here and plays back the returned WAV.
 MIOTTS_API_URL=http://localhost:8001            # MioTTS synthesis API (run_server.py)
@@ -131,14 +150,15 @@ USER_REFERENCE_IMAGE = os.getenv("OPPAAI_REFERENCE_IMAGE", "")    # Reference im
 # REFLECT_MAX_MEMS=20                           # max memories to include in reflection
 # REFLECT_TAGS=daily-reflection,ai-journal,aiko # Hugo front matter tags for posts
 
-# ── Intent Routing (chat vs agentic) ─────────────────────────────────────────
-# Controls whether a turn goes to normal chat() or the agentic tool loop.
-ROUTE_ENABLED=1                                 # 0 = always chat, never auto-route to agentic
-ROUTE_MODE=semantic                             # semantic (embedding-based, default) | llm | chat
-#ROUTER_MODEL=smollm2:135m-instruct-q8_0        # separate agentic routing model if mode set to "llm" (unset = use LLM_MODEL)          
-ROUTE_SEMANTIC_THRESHOLD=0.65                   # cosine-similarity cutoff to trigger agentic mode (# lower = more agentic triggers, higher = safer chat fallback)
-ROUTE_MIN_GAP=0.10
-SEARCH_SEMANTIC_THRESHOLD=0.65
+# ── Intent Routing (chat vs agentic/search) ─────────────────────────────────
+# ROUTE_MODE=semantic is fastest: one local embedding and cached example vectors.
+# ROUTE_MODE=llm is slower but can resolve context/pronouns through ROUTER_MODEL.
+ROUTE_ENABLED=1                                 # 0 = always chat, never auto-route to agentic/search
+ROUTE_MODE=semantic                             # semantic | semantic_only | llm | chat
+ROUTER_MODEL=ministral                          # LLM used only for routing when ROUTE_MODE=llm or semantic fallback; can be a tiny model
+ROUTE_SEMANTIC_THRESHOLD=0.65                   # higher = fewer agentic triggers; lower = more eager agentic mode
+ROUTE_MIN_GAP=0.10                              # best-vs-second semantic score gap required before routing agentic
+SEARCH_SEMANTIC_THRESHOLD=0.65                  # higher = fewer automatic web searches from normal chat
 
 # ── Scheduling ──────────────────────────────────────────────────────────────
 TIMEZONE=America/Vancouver                      # IANA tz name used for scheduling/reminders (e.g. America/Vancouver, UTC)
@@ -147,16 +167,15 @@ SCHEDULE_PATH=workspace/schedule.json           # Path to the persistent schedul
 SCHEDULE_POLL_SECONDS=15                        # How often (seconds) the scheduler checks for due jobs
 
 # ── Agent ───────────────────────────────────────────────────────────────────
-MAX_AGENT_ITER=10                               # Max tool call steps per agentic task
-AGENT_MAX_TOKENS=1024                           # Output tokens per agent LLM call (separate from chat)
+MAX_AGENT_ITER=6                                # Max tool-call steps allowed per task
+AGENT_MAX_TOKENS=512                            # Max output tokens per agent step (separate from chat)
 AGENT_MEMORY_DRAIN_TIMEOUT=0.25                 # Seconds to wait for memory queue before agent starts
 AGENT_MEMORY_RECALL_LIMIT=2                     # Memories injected into agent context (keep low)
 SEARXNG_MAX_RESULTS=3                           # Search results returned per query (less = fewer tokens)
 AGENT_VERIFY_FINAL=1                            # Whether to verify the final answer before returning it
 AGENT_VERIFY_LLM=0                              # Whether verification uses an LLM call
-MAX_AGENT_ITER=6                                # Max tool-call steps allowed per task
-AGENT_MAX_TOKENS=512                            # Max output tokens per agent step
 AGENT_MAX_FINAL_REPAIRS=1                       # Max retries to repair a bad final answer
+AGENT_VERIFY_MIN_SCORE=0.70                     # LLM verifier scores below this fail even if pass=true
 AGENT_TOOL_RETRY_BACKOFF=0.2                    # Delay (seconds) before retrying a failed tool call
 # ── Tools ───────────────────────────────────────────────────────────────────
 MAX_WRITE_CHARS=20000                           # Max characters allowed when saving a note/draft to disk

--- a/.env.example
+++ b/.env.example
@@ -55,6 +55,7 @@ MONTHLY_CONSOLIDATION_CHUNK_MEMS=25             # memory facts per fallback summ
 MONTHLY_CONSOLIDATION_DELETE_ORIGINALS=1        # delete unpinned detailed memories after pinned monthly summary is saved
 MONTHLY_CONSOLIDATION_DELETE_DAILY_SUMMARIES=1  # replace older pinned daily summaries with the monthly pinned summary
 MONTHLY_CONSOLIDATION_MIN_MEMS=5                # skip memory fallback months with fewer memories than this
+MONTHLY_CONSOLIDATION_LLM_TIMEOUT=120              # seconds before monthly summary LLM calls time out
 MONTHLY_CONSOLIDATION_STATE_PATH=/home/oppa-ai/.aiko/monthly_consolidation_state.json
 DREAM_BOOST_AMOUNT=2
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Phase 2 voice is implemented, and Phase 2.5 agentic workflows are now active. Th
 ASR and TTS run through the local machine by default. WebUI microphone streaming exists in the frontend/backend bridge, but full remote voice-device polish is still experimental.
 
 > Known Issues:
-> - TTS via MioTTS sometimes cannot inference proper voice output due to memory constraint (May switch MioTTS model and even BGE 1.5 embedding model to the smallest param ones to squeeze out a bit more RAM)
+> - TTS via MioTTS sometimes cannot inference proper voice output due to memory constraint (MioTTS and embedding models are still tuned for Jetson memory pressure; Harrier replaced BGE for better semantic separation at 640d)
 > - Time latency between ASR voice input ends to beginning of TTS voice output are still over 5 sec for normal chats. Need to figure out how to do proper synchronized text and speech streaming to save a couple seconds.
 > - ASR may have transcribing errors that output wrong text or even wrong language, especially when accent is present in speaker's voice or when using low quality microphone.
 > - Barge-in haven't been fully tested and may cause some runtime issues that needed to conduct more testing and debugging.
@@ -84,7 +84,7 @@ flowchart TD
 | Interface | full-screen curses TUI in `tui/`; optional browser WebUI in `webui/` |
 | Chat model | llama.cpp or any OpenAI-compatible local server via `openai.OpenAI` |
 | Long-term memory | custom sqlite-vec backend (no server required) |
-| Embeddings | fastembed `BAAI/bge-base-en-v1.5` |
+| Embeddings | fastembed `ferrisS/harrier-oss-v1-270m-fastembed` |
 | Memory lifecycle | Ebbinghaus-style decay, pinned memories, nightly `dream()` consolidation |
 | Web search | local SearXNG instance through `core/toolkit/web.py` |
 | TTS | external MioTTS HTTP server |
@@ -113,7 +113,7 @@ uv run python main.py            # curses TUI, full voice if services are availa
 
 ```bash
 uv run python main.py --webui    # browser WebUI + VRM frontend
-uv run python main.py --text      # keyboard input, no ASR/TTS
+uv run python main.py --text      # keyboard input, ASR/TTS toggled off but loaded
 uv run python main.py --debug     # show memory hits each turn
 uv run python main.py --clear-mem # wipe all memories and exit
 ```

--- a/archive/migrate_embeddings.py
+++ b/archive/migrate_embeddings.py
@@ -20,8 +20,8 @@ Usage:
 
 Defaults pulled from environment (.env if python-dotenv is installed):
     DB:    $SQLITE_MEMORY_PATH  (~/.aiko/memory.db)
-    MODEL: $EMBED_MODEL         (BAAI/bge-base-en-v1.5)
-    DIMS:  $EMBED_DIMS          (768)
+    MODEL: $EMBED_MODEL         (ferrisS/harrier-oss-v1-270m-fastembed in .env.example)
+    DIMS:  $EMBED_DIMS          (640 for harrier-oss-v1-270m)
 """
 
 import argparse
@@ -52,8 +52,8 @@ except ImportError:
 
 # ── defaults ──────────────────────────────────────────────────────────────────
 DEFAULT_DB    = os.getenv("SQLITE_MEMORY_PATH", str(Path.home() / ".aiko" / "memory.db"))
-DEFAULT_MODEL = os.getenv("EMBED_MODEL", "BAAI/bge-base-en-v1.5")
-DEFAULT_DIMS  = int(os.getenv("EMBED_DIMS", "768"))
+DEFAULT_MODEL = os.getenv("EMBED_MODEL", "ferrisS/harrier-oss-v1-270m-fastembed")
+DEFAULT_DIMS  = int(os.getenv("EMBED_DIMS", "640"))
 FASTEMBED_CACHE = os.getenv("FASTEMBED_CACHE_PATH")
 BATCH_SIZE    = int(os.getenv("EMBED_BATCH_SIZE", "64"))   # memories per embedding batch — tune down if OOM on Jetson
 
@@ -90,11 +90,10 @@ def register_custom_model(model_id: str, dims: int) -> None:
     try:
         TextEmbedding.add_custom_model(
             model=model_id,
-            # NOTE: verify against the model card / config_sentence_transformers.json
-            # for the actual repo — harrier-oss-v1 uses LAST-TOKEN pooling, not mean.
-            # If fastembed's PoolingType has no last-token option and the ONNX
-            # export doesn't bake pooling into the graph itself, embeddings will
-            # be silently degraded. Confirm before trusting migrated vectors.
+            # The ferrisS fastembed package documents MEAN pooling for its
+            # custom TextEmbedding registration. The upstream sentence-
+            # transformers model card uses last-token pooling, but that is not
+            # the fastembed package's documented loading contract.
             pooling=PoolingType.MEAN,
             normalization=True,
             sources=ModelSource(hf=model_id),

--- a/core/agentic.py
+++ b/core/agentic.py
@@ -42,13 +42,14 @@ log = get_logger(__name__)
 
 MAX_AGENT_ITER = int(os.getenv("MAX_AGENT_ITER", 8))
 AGENT_MAX_TOKENS = int(os.getenv("AGENT_MAX_TOKENS", os.getenv("LLM_MAX_TOKENS", 512)))
-AGENT_MEMORY_DRAIN_TIMEOUT = float(os.getenv("MEMORY_AGENT_DRAIN_TIMEOUT", 0.25))
+AGENT_MEMORY_DRAIN_TIMEOUT = float(os.getenv("AGENT_MEMORY_DRAIN_TIMEOUT", os.getenv("MEMORY_AGENT_DRAIN_TIMEOUT", 0.25)))
 AGENT_MEMORY_RECALL_LIMIT = int(os.getenv("AGENT_MEMORY_RECALL_LIMIT", min(int(os.getenv("MEMORY_RECALL_LIMIT", 3)), 2)))
 AGENT_NOTE_MAX_CHARS = int(os.getenv("AGENT_NOTE_MAX_CHARS", 1500))
 AGENT_TOOL_RESULT_MAX_CHARS = int(os.getenv("AGENT_TOOL_RESULT_MAX_CHARS", 3000))
 AGENT_VERIFY_FINAL = os.getenv("AGENT_VERIFY_FINAL", "1").lower() in {"1", "true", "yes", "on"}
 AGENT_VERIFY_LLM = os.getenv("AGENT_VERIFY_LLM", "1").lower() in {"1", "true", "yes", "on"}
 AGENT_MAX_FINAL_REPAIRS = int(os.getenv("AGENT_MAX_FINAL_REPAIRS", 2))
+AGENT_VERIFY_MIN_SCORE = float(os.getenv("AGENT_VERIFY_MIN_SCORE", "0.70"))
 AGENT_TOOL_RETRY_BACKOFF = float(os.getenv("AGENT_TOOL_RETRY_BACKOFF", 0.4))
 
 _ERROR_PREFIX_RE = re.compile(r"^\[(?P<label>[^\]:]+)(?::\s*(?P<detail>.*))?\]$", re.DOTALL)
@@ -450,8 +451,17 @@ def execute_tool_with_policy(name: str, args: dict, state: TaskState) -> ToolRes
     return last
 
 
+def _coerce_verifier_bool(value) -> bool:
+    """Parse verifier booleans without treating non-empty strings as True."""
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in {"true", "yes", "1", "pass", "passed"}
+    return bool(value)
+
+
 def _verify_final_answer(owner, user_input: str, answer: str, state: TaskState) -> VerificationResult:
-    """Check answer completeness and faithfulness before Aiko speaks it."""
+    """Check answer completeness and evidence support before Aiko speaks it."""
     issues: list[str] = []
     stripped = (answer or "").strip()
     lowered = stripped.lower()
@@ -478,11 +488,15 @@ def _verify_final_answer(owner, user_input: str, answer: str, state: TaskState) 
         return VerificationResult(ok=not issues, feedback="\n".join(issues) or "Verified by deterministic checks.", score=0.0 if issues else 1.0)
 
     prompt = (
-        "You are Aiko's verifier. Check whether the candidate answer is accurate, complete, "
-        "and supported by the task ledger. Return ONLY compact JSON with keys: "
-        "pass (boolean), score (0-1), feedback (string). Do not add markdown.\n\n"
+        "You are Aiko's final-answer verifier. This is NOT just a JSON schema check. "
+        "Judge whether the candidate answer is accurate, complete, and supported by "
+        "the task ledger/tool evidence. Do not use outside knowledge to bless facts that "
+        "are missing from the ledger. Fail answers that invent unsupported details, hide "
+        "tool failures, imply external actions that were not performed, omit required paths "
+        "or confirmations, or do not answer the user's request. Return ONLY compact JSON "
+        "with keys: pass (boolean), score (0-1), feedback (string). Do not add markdown.\n\n"
         f"User request:\n{user_input}\n\n"
-        f"Task ledger:\n{state.summary()}\n\n"
+        f"Task ledger/tool evidence:\n{state.summary()}\n\n"
         f"Candidate answer:\n{stripped}"
     )
     try:
@@ -496,9 +510,13 @@ def _verify_final_answer(owner, user_input: str, answer: str, state: TaskState) 
         raw = (resp.choices[0].message.content or "").strip()
         match = re.search(r"\{.*\}", raw, flags=re.DOTALL)
         data = json.loads(match.group(0) if match else raw)
-        ok = bool(data.get("pass"))
+        ok = _coerce_verifier_bool(data.get("pass"))
         score = float(data.get("score", 1.0 if ok else 0.0))
         feedback = str(data.get("feedback") or ("Verifier passed." if ok else "Verifier failed."))
+        if score < AGENT_VERIFY_MIN_SCORE:
+            ok = False
+            if feedback == "Verifier passed.":
+                feedback = f"Verifier score {score:.2f} below threshold {AGENT_VERIFY_MIN_SCORE:.2f}."
         return VerificationResult(ok=ok, feedback=feedback, score=score)
     except Exception as e:
         log.warning("Agent verifier failed; falling back to deterministic pass: %s", e)

--- a/core/agentic.py
+++ b/core/agentic.py
@@ -9,6 +9,7 @@ history, and memory queue ownership stay in core/think.py.
 from __future__ import annotations
 
 import json
+import math
 import os
 import re
 import time
@@ -511,8 +512,18 @@ def _verify_final_answer(owner, user_input: str, answer: str, state: TaskState) 
         match = re.search(r"\{.*\}", raw, flags=re.DOTALL)
         data = json.loads(match.group(0) if match else raw)
         ok = _coerce_verifier_bool(data.get("pass"))
-        score = float(data.get("score", 1.0 if ok else 0.0))
+        raw_score = data.get("score", 1.0 if ok else 0.0)
         feedback = str(data.get("feedback") or ("Verifier passed." if ok else "Verifier failed."))
+        try:
+            score = float(raw_score)
+        except (TypeError, ValueError):
+            score = 0.0
+            ok = False
+            feedback = "Verifier returned an invalid score."
+        if not math.isfinite(score) or score < 0.0 or score > 1.0:
+            ok = False
+            feedback = f"Verifier returned an out-of-range score: {raw_score!r}."
+            score = 0.0
         if score < AGENT_VERIFY_MIN_SCORE:
             ok = False
             if feedback == "Verifier passed.":

--- a/core/dream.py
+++ b/core/dream.py
@@ -1,27 +1,30 @@
 """
 core/dream.py
-Schedules Aiko's nightly dream() consolidation pass at 00:00 local time.
+Schedules Aiko's daily dream() consolidation pass after the configured local time.
 
 Usage — call start() once during Aiko startup (e.g. in UI):
     from core.dream import start as start_dream_scheduler
     start_dream_scheduler(memorize_instance)
 
-The scheduler runs in a background daemon thread and fires dream() at midnight.
+The scheduler runs in a background daemon thread and fires once per local date after the daily window opens; missed runs fire on the next boot after that window.
 It does NOT block startup or conversation flow.
 
  VRAM safety:
      dream() does zero LLM calls — only sqlite-vec ops and memory deletes.
-     No Ollama contention. Safe to fire even if a conversation is mid-flight,
+     No LLM-server contention. Safe to fire even if a conversation is mid-flight,
      though a _dream_lock flag is checked to avoid overlapping passes.
 """
 
 from datetime import datetime, timedelta, timezone
+import json
 import os
 import threading
 import time
+from pathlib import Path
 
 from core.log import get_logger
 from core.reflect import generate_and_post
+from core.monthly import maybe_run_monthly_consolidation
 
 log = get_logger(__name__)
 
@@ -29,65 +32,85 @@ log = get_logger(__name__)
 # fires twice due to a suspend/resume cycle).
 _dream_lock = threading.Lock()
 
+_DREAM_STATE_PATH = Path(os.getenv("DREAM_STATE_PATH", str(Path.home() / ".aiko" / "dream_state.json")))
+_DREAM_POLL_SECONDS = max(60, int(os.getenv("DREAM_POLL_SECONDS", "300")))
+_DREAM_RUN_AFTER_HOUR = int(os.getenv("DREAM_RUN_AFTER_HOUR", "0"))
+_DREAM_RUN_AFTER_MINUTE = int(os.getenv("DREAM_RUN_AFTER_MINUTE", "0"))
 
-def _seconds_until_midnight() -> float:
-    """Seconds from now until the next local 00:00:00."""
-    now       = datetime.now()
-    tomorrow  = (now + timedelta(days=1)).replace(hour=0, minute=0, second=0, microsecond=0)
-    return max((tomorrow - now).total_seconds(), 0.0)
+
+def _load_last_run_date() -> str | None:
+    try:
+        data = json.loads(_DREAM_STATE_PATH.read_text(encoding="utf-8"))
+        return data.get("last_run_date")
+    except Exception:
+        return None
+
+
+def _save_last_run_date(day: str) -> None:
+    _DREAM_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _DREAM_STATE_PATH.write_text(json.dumps({"last_run_date": day}, ensure_ascii=False), encoding="utf-8")
+
+
+def _after_daily_window(now: datetime) -> bool:
+    return (now.hour, now.minute) >= (_DREAM_RUN_AFTER_HOUR, _DREAM_RUN_AFTER_MINUTE)
+
+
+def _run_dream_once(memorize, run_day: str) -> None:
+    if not _dream_lock.acquire(blocking=False):
+        log.warning("Pass already running — skipping.")
+        return
+
+    try:
+        log.info("Firing dream() for %s at %s", run_day, datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
+        result = memorize.dream()
+        log.info(f"Pass complete: {result}")
+
+        # anchor: yesterday 00:00 UTC
+        yesterday_start = (datetime.now(timezone.utc) - timedelta(days=1)).replace(
+            hour=0, minute=0, second=0, microsecond=0
+        )
+
+        # get yesterday's memories first, sorted newest-first
+        memories = memorize.get_since(yesterday_start)
+
+        # backfill with older memories if yesterday was quiet
+        if len(memories) < int(os.getenv("REFLECT_MAX_MEMS", 20)):
+            seen_ids  = {m["id"] for m in memories}
+            all_mems  = sorted(
+                memorize.get_all(),
+                key=lambda m: m.get("created_at", ""),
+                reverse=True,
+            )
+            for m in all_mems:
+                if m["id"] not in seen_ids:
+                    memories.append(m)
+                if len(memories) >= int(os.getenv("REFLECT_MAX_MEMS", 20)):
+                    break
+
+        generate_and_post(memories, date=yesterday_start, memorize=memorize)
+        _save_last_run_date(run_day)
+    except Exception as e:
+        log.error(f"dream() raised: {e}")
+    finally:
+        _dream_lock.release()
+
 
 def _dream_loop(memorize) -> None:
-    """
-    Background loop: sleep until midnight, fire dream(), repeat.
-    Runs as a daemon thread — exits automatically when the main process ends.
-    """
+    """Run once per local date after the configured daily window opens."""
     while True:
-        wait = _seconds_until_midnight()
-        log.info(f"Next consolidation pass in {wait / 3600:.1f}h (at midnight).")
-        time.sleep(wait)
-
-        if not _dream_lock.acquire(blocking=False):
-            log.warning("Pass already running — skipping.")
-            # Sleep a bit to avoid tight loop if something is wrong
-            time.sleep(60)
-            continue
-
-        try:
-            log.info(f"Firing dream() at {datetime.now().strftime('%Y-%m-%d %H:%M:%S')}")
-            result = memorize.dream()
-            log.info(f"Pass complete: {result}")
-            
-            # anchor: yesterday 00:00 UTC
-            yesterday_start = (datetime.now(timezone.utc) - timedelta(days=1)).replace(
-                hour=0, minute=0, second=0, microsecond=0
-            )
-            
-            # get yesterday's memories first, sorted newest-first
-            memories = memorize.get_since(yesterday_start)
-            
-            # backfill with older memories if yesterday was quiet
-            if len(memories) < int(os.getenv("REFLECT_MAX_MEMS", 20)):
-                seen_ids  = {m["id"] for m in memories}
-                all_mems  = sorted(
-                    memorize.get_all(),
-                    key=lambda m: m.get("created_at", ""),
-                    reverse=True,
-                )
-                for m in all_mems:
-                    if m["id"] not in seen_ids:
-                        memories.append(m)
-                    if len(memories) >= int(os.getenv("REFLECT_MAX_MEMS", 20)):
-                        break
-            
-            generate_and_post(memories, date=yesterday_start, memorize=memorize)
-        except Exception as e:
-            log.error(f"dream() raised: {e}")
-        finally:
-            _dream_lock.release()
-
-        # Sleep 90 seconds after firing so we don't re-trigger at 00:00:00
-        # on the same second due to scheduler drift.
-        time.sleep(90)
+        now = datetime.now()
+        today = now.date().isoformat()
+        last_run = _load_last_run_date()
+        if _after_daily_window(now) and last_run != today:
+            _run_dream_once(memorize, today)
+        if _after_daily_window(now):
+            try:
+                monthly = maybe_run_monthly_consolidation(memorize, now=now)
+                if monthly.get("ran"):
+                    log.info("Monthly consolidation result: %s", monthly)
+            except Exception as e:
+                log.error("monthly consolidation raised: %s", e)
+        time.sleep(_DREAM_POLL_SECONDS)
 
 def start(memorize) -> threading.Thread:
     """
@@ -105,5 +128,9 @@ def start(memorize) -> threading.Thread:
         name="dream-scheduler",
     )
     t.start()
-    log.info("Started — will consolidate memories nightly at midnight.")
+    log.info(
+        "Started — will consolidate once daily after %02d:%02d; missed runs fire on next boot.",
+        _DREAM_RUN_AFTER_HOUR,
+        _DREAM_RUN_AFTER_MINUTE,
+    )
     return t

--- a/core/dream.py
+++ b/core/dream.py
@@ -10,9 +10,10 @@ The scheduler runs in a background daemon thread and fires once per local date a
 It does NOT block startup or conversation flow.
 
  VRAM safety:
-     dream() does zero LLM calls — only sqlite-vec ops and memory deletes.
-     No LLM-server contention. Safe to fire even if a conversation is mid-flight,
-     though a _dream_lock flag is checked to avoid overlapping passes.
+     memorize.dream() itself does zero LLM calls — only sqlite-vec ops and memory deletes.
+     This scheduler also runs reflection/monthly consolidation, which may call the LLM;
+     avoid configuring the window during expected active conversation time.
+     A _dream_lock flag is checked to avoid overlapping passes.
 """
 
 from datetime import datetime, timedelta, timezone

--- a/core/listen.py
+++ b/core/listen.py
@@ -348,14 +348,26 @@ class AikoListen:
             wait_fn()
 
         _cb(status_callback, "__LISTENING__")
+        listen_started_at = time.monotonic()
         audio = self._record(status_callback, chunk_source=chunk_source)
+        recording_stopped_at = time.monotonic()
         if audio is None:
             _cb(status_callback, "__IDLE__")
-            return "", {"verified": None, "speaker_score": None}
+            return "", {
+                "verified": None,
+                "speaker_score": None,
+                "listen_started_at": listen_started_at,
+                "recording_stopped_at": recording_stopped_at,
+            }
 
         _cb(status_callback, "__TRANSCRIBING__")
 
-        info = {"verified": None, "speaker_score": None}
+        info = {
+            "verified": None,
+            "speaker_score": None,
+            "listen_started_at": listen_started_at,
+            "recording_stopped_at": recording_stopped_at,
+        }
         if self.speaker_verify_active():
             result_box: dict = {}
 

--- a/core/memorize.py
+++ b/core/memorize.py
@@ -79,18 +79,26 @@ log = get_logger(__name__)
 # ── boot labels ───────────────────────────────────────────────────────────────
 
 BOOT_LABELS = {
-    'mem_sqlite':  'Opening sqlite-vec memory store...',
+    'mem_sqlite_vec':  'Opening sqlite-vec memory store...',
     'mem_cleanup': 'Running memory cleanup...',
     'mem_ready':   'Memory backend ready',
 }
 
 # ── constants ─────────────────────────────────────────────────────────────────
 
-EMBED_MODEL = os.getenv("EMBED_MODEL", "BAAI/bge-base-en-v1.5")
-EMBED_DIMS  = os.getenv("EMBED_DIMS", 768)
+EMBED_MODEL = os.getenv("EMBED_MODEL", "ferrisS/harrier-oss-v1-270m-fastembed")
+EMBED_DIMS  = int(os.getenv("EMBED_DIMS", "640"))
+EMBED_QUERY_INSTRUCT = os.getenv("EMBED_QUERY_INSTRUCT", "Retrieve relevant memories that answer the query").strip()
+EMBED_MODEL_FILE = os.getenv("EMBED_MODEL_FILE", "model_quantized.onnx")
+EMBED_MODEL_DATA_FILE = os.getenv("EMBED_MODEL_DATA_FILE", "model_quantized.onnx_data").strip()
+EMBED_REGISTER_CUSTOM_MODEL = os.getenv("EMBED_REGISTER_CUSTOM_MODEL", "auto").strip().lower()
 RRF_K       = 60          # standard RRF constant — dampens outlier ranks
 KNN_LIMIT   = 20          # candidates fetched before RRF re-rank
 FTS_LIMIT   = 20          # candidates fetched before RRF re-rank
+MEMORY_RANK_RECENCY_WEIGHT = float(os.getenv("MEMORY_RANK_RECENCY_WEIGHT", "0.004"))
+MEMORY_RANK_RECENCY_HALF_LIFE_DAYS = float(os.getenv("MEMORY_RANK_RECENCY_HALF_LIFE_DAYS", "30"))
+MEMORY_RANK_ACCESS_WEIGHT = float(os.getenv("MEMORY_RANK_ACCESS_WEIGHT", "0.002"))
+MEMORY_RANK_PINNED_WEIGHT = float(os.getenv("MEMORY_RANK_PINNED_WEIGHT", "0.002"))
 SEARCH_CACHE_SIZE = int(os.getenv("MEMORY_SEARCH_CACHE_SIZE", 128))
 SEARCH_CACHE_TTL  = float(os.getenv("MEMORY_SEARCH_CACHE_TTL", 20.0))
 MEMORY_CONTEXT_FACT_CHARS  = int(os.getenv("MEMORY_CONTEXT_FACT_CHARS", 220))
@@ -390,17 +398,26 @@ class _MemoryBackend:
         self._client   = OpenAI(base_url=self._llm_base, api_key="not-needed")
       
         from fastembed.common.model_description import ModelSource, PoolingType
-        
-        # Before constructing the embedder:
-        TextEmbedding.add_custom_model(
-            model=EMBED_MODEL,
-            pooling=PoolingType.MEAN,
-            normalization=True,
-            sources=ModelSource(hf=EMBED_MODEL),
-            dim=EMBED_DIMS,
-            model_file="model_quantized.onnx",
-            additional_files=["model_quantized.onnx_data"],
-        )
+
+        # Register community ONNX packages that fastembed does not ship
+        # natively. Harrier's fastembed conversion documents MEAN pooling in
+        # its custom-model example, despite the base SentenceTransformers model
+        # card using last-token pooling internally.
+        if EMBED_REGISTER_CUSTOM_MODEL not in {"0", "false", "no", "off"}:
+            try:
+                TextEmbedding.add_custom_model(
+                    model=EMBED_MODEL,
+                    pooling=PoolingType.MEAN,
+                    normalization=True,
+                    sources=ModelSource(hf=EMBED_MODEL),
+                    dim=EMBED_DIMS,
+                    model_file=EMBED_MODEL_FILE,
+                    additional_files=[EMBED_MODEL_DATA_FILE] if EMBED_MODEL_DATA_FILE else [],
+                )
+            except Exception as e:
+                if EMBED_REGISTER_CUSTOM_MODEL in {"1", "true", "yes", "on"}:
+                    raise
+                log.debug("Custom embedding model registration skipped: %s", e)
         self._embedder = TextEmbedding(
             model_name=EMBED_MODEL,
             cache_dir=fastembed_cache,
@@ -424,13 +441,21 @@ class _MemoryBackend:
 
     # ── embedding ─────────────────────────────────────────────────────────────
 
-    def _embed(self, text: str) -> list[float]:
-        """Embed a single string with fastembed. Returns a plain float list."""
-        return list(self._embedder.embed([text]))[0].tolist()
+    def _format_query_text(self, text: str) -> str:
+        """Apply query-side instruction prefix for instruct embedding models."""
+        if not EMBED_QUERY_INSTRUCT:
+            return text
+        return f"Instruct: {EMBED_QUERY_INSTRUCT}\nQuery: {text}"
 
-    def _embed_batch(self, texts: list[str]) -> list[list[float]]:
+    def _embed(self, text: str, *, query: bool = False) -> list[float]:
+        """Embed a single string with fastembed. Returns a plain float list."""
+        embed_text = self._format_query_text(text) if query else text
+        return list(self._embedder.embed([embed_text]))[0].tolist()
+
+    def _embed_batch(self, texts: list[str], *, query: bool = False) -> list[list[float]]:
         """Embed multiple strings in a single batched fastembed call."""
-        return [v.tolist() for v in self._embedder.embed(texts)]
+        embed_texts = [self._format_query_text(t) for t in texts] if query else texts
+        return [v.tolist() for v in self._embedder.embed(embed_texts)]
 
     # ── extraction ────────────────────────────────────────────────────────────
 
@@ -596,6 +621,34 @@ class _MemoryBackend:
 
         return ids
 
+    def add_raw(self, memory: str, user_id: str, *, pinned: bool = False) -> str | None:
+        """Persist one already-curated memory string without LLM extraction."""
+        text = (memory or "").strip()
+        if not text:
+            return None
+        mem_id = str(uuid.uuid4())
+        now = datetime.now(timezone.utc).isoformat()
+        try:
+            vector = self._embed(text)
+            self._conn.execute(
+                """
+                INSERT INTO memories
+                    (id, user_id, memory, created_at, access_count, last_accessed_at, pinned)
+                VALUES (?, ?, ?, ?, 0, 'never', ?)
+                """,
+                (mem_id, user_id, text, now, 1 if pinned else 0),
+            )
+            self._conn.execute(
+                "INSERT INTO memories_vec(id, embedding) VALUES (?, ?)",
+                (mem_id, sqlite_vec.serialize_float32(vector)),
+            )
+            self._conn.commit()
+            return mem_id
+        except Exception as e:
+            log.warning("Failed to insert raw memory %r: %s", mem_id, e)
+            self._conn.rollback()
+            return None
+
     # ── read ──────────────────────────────────────────────────────────────────
 
     def search(self, query: str, user_id: str, limit: int = 5) -> list[dict]:
@@ -607,7 +660,7 @@ class _MemoryBackend:
         3. RRF: score = 1/(k+rank_knn) + 1/(k+rank_fts)
         4. Return top `limit` by RRF score as payload dicts
         """
-        vector = self._embed(query)
+        vector = self._embed(query, query=True)
 
         knn_rows = _sqlite_knn_search(self._conn, vector, user_id, KNN_LIMIT)
         rank_knn = {row["id"]: i + 1 for i, row in enumerate(knn_rows)}
@@ -635,7 +688,24 @@ class _MemoryBackend:
         if not all_ids:
             return []
 
-        def rrf(mem_id: str) -> float:
+        placeholders = ",".join("?" * len(all_ids))
+        rows = self._conn.execute(
+            f"SELECT * FROM memories WHERE id IN ({placeholders})",
+            list(all_ids),
+        ).fetchall()
+        row_by_id = {row["id"]: row for row in rows}
+
+        def _recency_score(created_at: str) -> float:
+            try:
+                created = datetime.fromisoformat((created_at or "").replace("Z", "+00:00"))
+                if created.tzinfo is None:
+                    created = created.replace(tzinfo=timezone.utc)
+                age_days = max(0.0, (datetime.now(timezone.utc) - created).total_seconds() / 86400)
+                return 0.5 ** (age_days / max(MEMORY_RANK_RECENCY_HALF_LIFE_DAYS, 1e-6))
+            except Exception:
+                return 0.0
+
+        def final_score(mem_id: str) -> float:
             knn = rank_knn.get(mem_id, 0)
             fts = rank_fts.get(mem_id, 0)
             score = 0.0
@@ -643,18 +713,18 @@ class _MemoryBackend:
                 score += 1.0 / (RRF_K + knn)
             if fts:
                 score += 1.0 / (RRF_K + fts)
+
+            row = row_by_id.get(mem_id)
+            if row is not None:
+                score += MEMORY_RANK_RECENCY_WEIGHT * _recency_score(row["created_at"])
+                score += MEMORY_RANK_ACCESS_WEIGHT * min(int(row["access_count"] or 0), ACCESS_COUNT_CAP) / max(ACCESS_COUNT_CAP, 1)
+                if int(row["pinned"] or 0):
+                    score += MEMORY_RANK_PINNED_WEIGHT
             return score
 
-        ranked = sorted(all_ids, key=rrf, reverse=True)[:limit]
-
-        placeholders = ",".join("?" * len(ranked))
-        rows = self._conn.execute(
-            f"SELECT * FROM memories WHERE id IN ({placeholders})",
-            ranked,
-        ).fetchall()
-
-        order       = {mid: i for i, mid in enumerate(ranked)}
-        rows_sorted = sorted(rows, key=lambda r: order.get(r["id"], 999))
+        ranked = sorted(all_ids, key=final_score, reverse=True)[:limit]
+        order = {mid: i for i, mid in enumerate(ranked)}
+        rows_sorted = sorted((row_by_id[mid] for mid in ranked if mid in row_by_id), key=lambda r: order.get(r["id"], 999))
 
         return [dict(r) for r in rows_sorted]
 
@@ -700,6 +770,18 @@ class _MemoryBackend:
             ORDER BY created_at DESC
             """,
             (user_id, since.isoformat()),
+        ).fetchall()
+        return [dict(r) for r in rows]
+
+    def get_between(self, start: datetime, end: datetime, user_id: str = USER_ID) -> list[dict]:
+        """Return memories created in [start, end), oldest first."""
+        rows = self._conn.execute(
+            """
+            SELECT * FROM memories
+            WHERE user_id = ? AND created_at >= ? AND created_at < ?
+            ORDER BY created_at ASC
+            """,
+            (user_id, start.isoformat(), end.isoformat()),
         ).fetchall()
         return [dict(r) for r in rows]
 
@@ -1303,9 +1385,24 @@ class AikoMemorize:
         """Return all stored memories for a user."""
         return self._mem.get_all(user_id=user_id)
 
+    def add_raw(self, memory: str, user_id: str = USER_ID, *, pinned: bool = False, metadata: Optional[dict] = None) -> str | None:
+        """Persist one already-curated memory string without LLM extraction."""
+        # metadata is accepted for call-site clarity; the current schema stores
+        # only the curated text plus pinned flag.
+        return self._mem.add_raw(memory, user_id=user_id, pinned=pinned)
+
     def get_since(self, since: datetime, user_id: str = USER_ID) -> list[dict]:
         """Return memories created on or after `since`, newest first."""
         return self._mem.get_since(since, user_id=user_id)
+
+    def get_between(self, start: datetime, end: datetime, user_id: str = USER_ID) -> list[dict]:
+        """Return memories created in [start, end), oldest first."""
+        return self._mem.get_between(start, end, user_id=user_id)
+
+    def delete(self, memory_id: str) -> None:
+        """Delete one memory from the store and clear search cache."""
+        self._mem.delete(memory_id)
+        self._clear_search_cache()
 
     def clear(self, user_id: str = USER_ID) -> None:
         """Wipe all memories for a user. Use carefully."""
@@ -1323,9 +1420,13 @@ class AikoMemorize:
         """Retrieve the raw embedding vector for a single memory."""
         return _sqlite_get_vector(self._conn, mem_id)
 
-    def embed_text(self, text: str) -> list[float]:
+    def embed_text(self, text: str, *, query: bool = False) -> list[float]:
         """Embed one text string with the configured memory embedding model."""
-        return self._mem._embed(text)
+        return self._mem._embed(text, query=query)
+
+    def embed_texts(self, texts: list[str], *, query: bool = False) -> list[list[float]]:
+        """Embed multiple strings with the configured memory embedding model."""
+        return self._mem._embed_batch(texts, query=query)
 
     def _is_pinned(self, mem_id: str) -> bool:
         """Return True if memories.pinned == 1 for this id."""

--- a/core/memorize.py
+++ b/core/memorize.py
@@ -71,7 +71,7 @@ import sqlite_vec
 from openai import OpenAI
 from fastembed import TextEmbedding
 
-from core.forget import compute_weighted_score, should_cleanup, CLEANUP_THRESHOLD
+from core.forget import ACCESS_COUNT_CAP, compute_weighted_score, should_cleanup, CLEANUP_THRESHOLD
 from core.log import get_logger
 
 log = get_logger(__name__)
@@ -1389,7 +1389,10 @@ class AikoMemorize:
         """Persist one already-curated memory string without LLM extraction."""
         # metadata is accepted for call-site clarity; the current schema stores
         # only the curated text plus pinned flag.
-        return self._mem.add_raw(memory, user_id=user_id, pinned=pinned)
+        mem_id = self._mem.add_raw(memory, user_id=user_id, pinned=pinned)
+        if mem_id:
+            self._clear_search_cache()
+        return mem_id
 
     def get_since(self, since: datetime, user_id: str = USER_ID) -> list[dict]:
         """Return memories created on or after `since`, newest first."""

--- a/core/monthly.py
+++ b/core/monthly.py
@@ -33,6 +33,7 @@ MONTHLY_CONSOLIDATION_DELETE_DAILY_SUMMARIES = os.getenv("MONTHLY_CONSOLIDATION_
 MONTHLY_CONSOLIDATION_STATE_PATH = Path(os.getenv("MONTHLY_CONSOLIDATION_STATE_PATH", str(Path.home() / ".aiko" / "monthly_consolidation_state.json")))
 LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://localhost:8080/v1")
 LLM_MODEL = os.getenv("REFLECT_MODEL", os.getenv("LLM_MODEL", "ministral"))
+MONTHLY_CONSOLIDATION_LLM_TIMEOUT = float(os.getenv("MONTHLY_CONSOLIDATION_LLM_TIMEOUT", os.getenv("LLM_TIMEOUT", "120")))
 
 
 def _add_months(dt: datetime, months: int) -> datetime:
@@ -64,7 +65,7 @@ def _save_state(state: dict) -> None:
 
 
 def _chat(prompt: str, max_tokens: int = 700) -> str:
-    client = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed")
+    client = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed", timeout=MONTHLY_CONSOLIDATION_LLM_TIMEOUT)
     resp = client.chat.completions.create(
         model=LLM_MODEL,
         messages=[{"role": "user", "content": prompt}],

--- a/core/monthly.py
+++ b/core/monthly.py
@@ -1,0 +1,200 @@
+"""
+Monthly memory consolidation.
+
+Runs on/after the first day of a month and consolidates the month before the
+most recent full month. Example: on July 1, keep June intact and summarize May.
+The summary is inserted as a pinned raw memory, then unpinned detailed memories
+from the consolidated month can be deleted to reduce vector DB size.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+from openai import OpenAI
+
+from core.experience import load_chat_turns
+from core.log import get_logger
+
+log = get_logger(__name__)
+
+MONTHLY_CONSOLIDATION_ENABLED = os.getenv("MONTHLY_CONSOLIDATION_ENABLED", "1").lower() in {"1", "true", "yes", "on"}
+MONTHLY_CONSOLIDATION_KEEP_MONTHS = max(1, int(os.getenv("MONTHLY_CONSOLIDATION_KEEP_MONTHS", "1")))
+MONTHLY_CONSOLIDATION_SOURCE = os.getenv("MONTHLY_CONSOLIDATION_SOURCE", "experience").strip().lower()
+MONTHLY_CONSOLIDATION_CHUNK_MEMS = max(5, int(os.getenv("MONTHLY_CONSOLIDATION_CHUNK_MEMS", "25")))
+MONTHLY_CONSOLIDATION_CHUNK_TURNS = max(10, int(os.getenv("MONTHLY_CONSOLIDATION_CHUNK_TURNS", "40")))
+MONTHLY_CONSOLIDATION_MAX_INPUT_CHARS = max(1000, int(os.getenv("MONTHLY_CONSOLIDATION_MAX_INPUT_CHARS", "6000")))
+MONTHLY_CONSOLIDATION_MIN_MEMS = max(1, int(os.getenv("MONTHLY_CONSOLIDATION_MIN_MEMS", "5")))
+MONTHLY_CONSOLIDATION_DELETE_ORIGINALS = os.getenv("MONTHLY_CONSOLIDATION_DELETE_ORIGINALS", "1").lower() in {"1", "true", "yes", "on"}
+MONTHLY_CONSOLIDATION_DELETE_DAILY_SUMMARIES = os.getenv("MONTHLY_CONSOLIDATION_DELETE_DAILY_SUMMARIES", "1").lower() in {"1", "true", "yes", "on"}
+MONTHLY_CONSOLIDATION_STATE_PATH = Path(os.getenv("MONTHLY_CONSOLIDATION_STATE_PATH", str(Path.home() / ".aiko" / "monthly_consolidation_state.json")))
+LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://localhost:8080/v1")
+LLM_MODEL = os.getenv("REFLECT_MODEL", os.getenv("LLM_MODEL", "ministral"))
+
+
+def _add_months(dt: datetime, months: int) -> datetime:
+    month_index = dt.month - 1 + months
+    year = dt.year + month_index // 12
+    month = month_index % 12 + 1
+    return dt.replace(year=year, month=month, day=1, hour=0, minute=0, second=0, microsecond=0)
+
+
+def target_month_for(now: datetime) -> tuple[datetime, datetime, str]:
+    """Return (start, end, key) for the month ready to consolidate."""
+    local_first = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+    target_end = _add_months(local_first, -MONTHLY_CONSOLIDATION_KEEP_MONTHS)
+    target_start = _add_months(target_end, -1)
+    key = target_start.strftime("%Y-%m")
+    return target_start, target_end, key
+
+
+def _load_state() -> dict:
+    try:
+        return json.loads(MONTHLY_CONSOLIDATION_STATE_PATH.read_text(encoding="utf-8"))
+    except Exception:
+        return {}
+
+
+def _save_state(state: dict) -> None:
+    MONTHLY_CONSOLIDATION_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
+    MONTHLY_CONSOLIDATION_STATE_PATH.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+
+
+def _chat(prompt: str, max_tokens: int = 700) -> str:
+    client = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed")
+    resp = client.chat.completions.create(
+        model=LLM_MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        stream=False,
+        max_tokens=max_tokens,
+        temperature=0.1,
+    )
+    return (resp.choices[0].message.content or "").strip()
+
+
+def _bounded_lines(items: list[str]) -> str:
+    lines: list[str] = []
+    total = 0
+    for line in items:
+        if total + len(line) > MONTHLY_CONSOLIDATION_MAX_INPUT_CHARS:
+            break
+        lines.append(line)
+        total += len(line) + 1
+    return "\n".join(lines)
+
+
+def _memory_lines(memories: list[dict]) -> str:
+    return _bounded_lines([
+        f"- {m.get('created_at', '')}: {(m.get('memory') or m.get('text') or '').strip()}"
+        for m in memories
+        if (m.get("memory") or m.get("text") or "").strip()
+    ])
+
+
+def _turn_lines(turns: list[dict]) -> str:
+    return _bounded_lines([
+        f"- {t.get('created_at', '')}\n  User: {(t.get('user') or '').strip()}\n  Aiko: {(t.get('assistant') or '').strip()}"
+        for t in turns
+        if (t.get("user") or t.get("assistant"))
+    ])
+
+
+def _summarize_memory_chunk(month_key: str, memories: list[dict], idx: int, total: int) -> str:
+    prompt = (
+        "Summarize these long-term memory facts for Aiko's monthly memory consolidation. "
+        "Keep stable preferences, identity facts, projects, deadlines, relationships, and recurring patterns. "
+        "Drop trivial chatter, duplicates, and implementation details about the memory system. "
+        "Use compact bullet points only. Do not invent facts.\n\n"
+        f"Month: {month_key}\nChunk: {idx}/{total}\n\n"
+        f"Memories:\n{_memory_lines(memories)}"
+    )
+    return _chat(prompt, max_tokens=500)
+
+
+def _summarize_turn_chunk(month_key: str, turns: list[dict], idx: int, total: int) -> str:
+    prompt = (
+        "Summarize these raw Aiko/Oppa daily experience turns for monthly consolidation. "
+        "Keep stable facts, preferences, projects, emotional beats, deadlines, repeated themes, and important events. "
+        "Drop filler, greetings, transient wording, and duplicate details. Do not invent facts. "
+        "Use compact bullet points only.\n\n"
+        f"Month: {month_key}\nChunk: {idx}/{total}\n\n"
+        f"Experience turns:\n{_turn_lines(turns)}"
+    )
+    return _chat(prompt, max_tokens=550)
+
+
+def _final_summary(month_key: str, chunk_summaries: list[str]) -> str:
+    prompt = (
+        "Merge these chunk summaries into ONE durable pinned memory for Aiko. "
+        "Write concise bullet points grouped by theme. Preserve only facts worth keeping long-term. "
+        "Do not mention vectors, databases, consolidation, chunks, or internal processes. "
+        "Do not invent facts.\n\n"
+        f"Month: {month_key}\n\n"
+        + "\n\n".join(f"Chunk summary {i+1}:\n{s}" for i, s in enumerate(chunk_summaries))
+    )
+    return _chat(prompt, max_tokens=900)
+
+
+def maybe_run_monthly_consolidation(memorize, now: datetime | None = None) -> dict:
+    """Run monthly consolidation if enabled, due, and not already done."""
+    if not MONTHLY_CONSOLIDATION_ENABLED:
+        return {"ran": False, "reason": "disabled"}
+    now = now or datetime.now()
+    if now.day != 1:
+        return {"ran": False, "reason": "not_first_day"}
+
+    start, end, month_key = target_month_for(now)
+    state = _load_state()
+    if state.get("last_consolidated_month") == month_key:
+        return {"ran": False, "reason": "already_done", "month": month_key}
+
+    start_utc = start.replace(tzinfo=timezone.utc)
+    end_utc = end.replace(tzinfo=timezone.utc)
+    memories = memorize.get_between(start_utc, end_utc)
+    turns = load_chat_turns(start_utc, end_utc) if MONTHLY_CONSOLIDATION_SOURCE == "experience" else []
+
+    if turns:
+        chunks = [turns[i:i + MONTHLY_CONSOLIDATION_CHUNK_TURNS] for i in range(0, len(turns), MONTHLY_CONSOLIDATION_CHUNK_TURNS)]
+        chunk_summaries = [_summarize_turn_chunk(month_key, chunk, i + 1, len(chunks)) for i, chunk in enumerate(chunks)]
+        source_count = len(turns)
+        source = "experience"
+    else:
+        if len(memories) < MONTHLY_CONSOLIDATION_MIN_MEMS:
+            state["last_consolidated_month"] = month_key
+            _save_state(state)
+            return {"ran": False, "reason": "too_few_memories", "month": month_key, "count": len(memories)}
+        chunks = [memories[i:i + MONTHLY_CONSOLIDATION_CHUNK_MEMS] for i in range(0, len(memories), MONTHLY_CONSOLIDATION_CHUNK_MEMS)]
+        chunk_summaries = [_summarize_memory_chunk(month_key, chunk, i + 1, len(chunks)) for i, chunk in enumerate(chunks)]
+        source_count = len(memories)
+        source = "memory"
+    summary = _final_summary(month_key, chunk_summaries)
+    if not summary:
+        return {"ran": False, "reason": "empty_summary", "month": month_key, "count": source_count, "source": source}
+
+    summary_text = f"Monthly memory summary for {month_key}:\n{summary}"
+    summary_id = memorize.add_raw(summary_text, pinned=True)
+    if not summary_id:
+        return {"ran": False, "reason": "summary_insert_failed", "month": month_key, "count": len(memories)}
+
+    deleted = 0
+    daily_deleted = 0
+    if MONTHLY_CONSOLIDATION_DELETE_ORIGINALS:
+        for memory in memories:
+            mem_id = memory.get("id")
+            text = (memory.get("memory") or "")
+            is_daily_summary = text.startswith("Daily experience summary for ")
+            if mem_id and not memorize._is_pinned(mem_id):
+                memorize.delete(mem_id)
+                deleted += 1
+            elif mem_id and is_daily_summary and MONTHLY_CONSOLIDATION_DELETE_DAILY_SUMMARIES:
+                memorize.delete(mem_id)
+                daily_deleted += 1
+
+    state["last_consolidated_month"] = month_key
+    state["last_summary_id"] = summary_id
+    _save_state(state)
+    log.info("Monthly consolidation complete: month=%s source=%s count=%s deleted=%s daily_deleted=%s summary_id=%s", month_key, source, source_count, deleted, daily_deleted, summary_id)
+    return {"ran": True, "month": month_key, "source": source, "count": source_count, "deleted": deleted, "daily_deleted": daily_deleted, "summary_id": summary_id}

--- a/core/reflect.py
+++ b/core/reflect.py
@@ -432,14 +432,14 @@ def generate_and_post(
             "pinned":          False,
         }
 
-    # Step 4: pin daily summary to persistent memory
+    # Step 4: pin daily summary to persistent memory. Store a raw curated
+    # summary with a stable prefix so monthly consolidation can replace older
+    # daily summaries without relying on another extraction pass.
     pinned = False
     if memorize is not None:
         try:
-            pinned = bool(memorize.pin([
-                {"role": "user", "content": f"Pin Aiko's daily experience summary for {date.strftime('%Y-%m-%d')}."},
-                {"role": "assistant", "content": f"Daily experience summary for {date.strftime('%Y-%m-%d')}: {prose}"},
-            ]))
+            daily_text = f"Daily experience summary for {date.strftime('%Y-%m-%d')}: {prose}"
+            pinned = bool(memorize.add_raw(daily_text, pinned=True))
         except Exception as e:
             log.error(f"Daily summary pin failed: {e}")
 

--- a/core/speak.py
+++ b/core/speak.py
@@ -208,6 +208,8 @@ class AikoSpeak:
         self._stream_chunks: list[str] = []
         self._stream_thread = None
         self._streaming_active = False
+        self._first_audio_callback = None
+        self._first_audio_fired = threading.Event()
 
         # ── remote audio sink (WebUI) ────────────────────────────────────
         # If set, _play_wav_bytes() also hands each synthesized WAV chunk to
@@ -223,6 +225,22 @@ class AikoSpeak:
 
         if not silent:
             log.info(f"[speak] MioTTS ready | url: {MIOTTS_API_URL} | preset: {MIOTTS_PRESET}")
+
+    def set_first_audio_callback(self, callback) -> None:
+        """Register a callback invoked when the next utterance starts playback."""
+        self._first_audio_callback = callback
+        self._first_audio_fired.clear()
+
+    def _notify_first_audio_start(self) -> None:
+        if self._first_audio_fired.is_set():
+            return
+        self._first_audio_fired.set()
+        callback = self._first_audio_callback
+        if callback is not None:
+            try:
+                callback()
+            except Exception as e:
+                log.warning("[speak] first-audio callback failed: %s", e)
 
     def set_audio_sink(self, callback) -> None:
         """
@@ -311,6 +329,8 @@ class AikoSpeak:
         used to cause is_playing() to flicker false between chunks, and
         could wipe a stop() request that landed between chunks.
         """
+        self._notify_first_audio_start()
+
         if self._audio_sink is not None:
             try:
                 self._audio_sink(wav_bytes)
@@ -487,6 +507,7 @@ class AikoSpeak:
         if not clean:
             return False
         self.stop()
+        self._first_audio_fired.clear()
         self._playing.set()
         t = threading.Thread(target=self._speak_thread, args=(clean,), daemon=True)
         t.start()
@@ -505,6 +526,7 @@ class AikoSpeak:
         if not clean:
             return False
         self.stop()
+        self._first_audio_fired.clear()
         self._playing.set()
         t = threading.Thread(
             target=self._speak_thread_synced, args=(clean, on_word), daemon=True
@@ -524,6 +546,7 @@ class AikoSpeak:
         if not text:
             return
         self.stop()
+        self._first_audio_fired.clear()
         self._playing.set()
         t = threading.Thread(target=self._speak_thread, args=(text,), daemon=True)
         t.start()
@@ -537,6 +560,7 @@ class AikoSpeak:
         if not text:
             return
         self.stop()
+        self._first_audio_fired.clear()
         self._playing.set()
         t = threading.Thread(target=self._speak_thread, args=(text,), daemon=True)
         t.start()
@@ -544,6 +568,7 @@ class AikoSpeak:
     def start_speech_stream(self) -> None:
         """Start collecting streamed text for one complete TTS playback."""
         self.stop()
+        self._first_audio_fired.clear()
         with self._lock:
             self._stream_chunks = []
             self._streaming_active = True
@@ -569,6 +594,7 @@ class AikoSpeak:
         clean = sanitize_for_tts(text)
         if not clean or self._stop_flag.is_set():
             return
+        self._first_audio_fired.clear()
         self._playing.set()
         self._stop_flag.clear()
         self._stream_thread = threading.Thread(

--- a/core/think.py
+++ b/core/think.py
@@ -69,7 +69,7 @@ _ROUTE_ENABLED = os.getenv("ROUTE_ENABLED", "1").lower() in {"1", "true", "yes",
 _ROUTE_MODE = os.getenv("ROUTE_MODE", "semantic").strip().lower()
 _SEMANTIC_ROUTE_THRESHOLD = float(os.getenv("ROUTE_SEMANTIC_THRESHOLD", "0.36"))
 _SEMANTIC_SEARCH_THRESHOLD = float(os.getenv("SEARCH_SEMANTIC_THRESHOLD", "0.36"))
-_SEMANTIC_ROUTE_MIN_GAP = float(os.getenv("ROUTE_MIN_GAP", "0.03"))
+_SEMANTIC_ROUTE_MIN_GAP = float(os.getenv("ROUTE_MIN_GAP", "0.10"))
 
 _PERSONA_PATH = Path(__file__).resolve().parent.parent / "persona" / "soul.md"
 _USER_PATH = Path(__file__).resolve().parent.parent / "persona" / "user.md"
@@ -277,7 +277,7 @@ class AikoThink:
             raw_scores = example_vectors @ query_vector
 
             scores: dict[str, float] = {}
-            for label, score in zip(labels, raw_scores):
+            for label, score in zip(labels, raw_scores, strict=True):
                 scores[label] = max(scores.get(label, 0.0), float(score))
 
             best_label = max(scores, key=scores.get)
@@ -289,6 +289,8 @@ class AikoThink:
 
             if best_score >= _SEMANTIC_ROUTE_THRESHOLD and (best_score - second_score) >= _SEMANTIC_ROUTE_MIN_GAP:
                 return best_label
+            if best_score >= _SEMANTIC_ROUTE_THRESHOLD and _ROUTE_MODE != "semantic_only":
+                return self._classify_agent_intent(user_input)
             return "chat"
         except Exception as e:
             log.warning("Semantic intent routing failed: %s", e)
@@ -344,7 +346,7 @@ class AikoThink:
                     "Aiko's own codebase/repository. Reply one label only.\n"
                     f"Message: {user_input!r}"
                 )}],
-                stream=False, max_tokens=8, temperature=0.0,
+                stream=False, max_tokens=8, temperature=0.0, timeout=LLM_TIMEOUT,
             )
             label = (resp.choices[0].message.content or "chat").strip().lower()
             label = re.sub(r"[^a-z_].*$", "", label)
@@ -675,7 +677,7 @@ class AikoThink:
                     f'If data, resolve pronouns into a search query.\n'
                     f'Reply EXACTLY:\ndata|<search query>\nor:\nsocial|none'
                 )}],
-                stream=False, max_tokens=32, temperature=0.0,
+                stream=False, max_tokens=32, temperature=0.0, timeout=LLM_TIMEOUT,
             )
             answer = resp.choices[0].message.content.strip()
             label, _, rest = answer.partition("|")

--- a/core/think.py
+++ b/core/think.py
@@ -27,6 +27,8 @@ import threading
 import time
 import unicodedata
 
+import numpy as np
+
 from core.memorize import AikoMemorize
 from core.speak    import AikoSpeak
 from core.tools    import deep_search
@@ -67,6 +69,7 @@ _ROUTE_ENABLED = os.getenv("ROUTE_ENABLED", "1").lower() in {"1", "true", "yes",
 _ROUTE_MODE = os.getenv("ROUTE_MODE", "semantic").strip().lower()
 _SEMANTIC_ROUTE_THRESHOLD = float(os.getenv("ROUTE_SEMANTIC_THRESHOLD", "0.36"))
 _SEMANTIC_SEARCH_THRESHOLD = float(os.getenv("SEARCH_SEMANTIC_THRESHOLD", "0.36"))
+_SEMANTIC_ROUTE_MIN_GAP = float(os.getenv("ROUTE_MIN_GAP", "0.03"))
 
 _PERSONA_PATH = Path(__file__).resolve().parent.parent / "persona" / "soul.md"
 _USER_PATH = Path(__file__).resolve().parent.parent / "persona" / "user.md"
@@ -183,7 +186,8 @@ _SEMANTIC_SEARCH_EXAMPLES: dict[str, tuple[str, ...]] = {
 class AikoThink:
     def __init__(self, memorize: AikoMemorize, speak: AikoSpeak | None = None) -> None:
         self._client    = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed")
-        self._llm_model = ROUTER_MODEL
+        self._llm_model = LLM_MODEL
+        self._router_model = ROUTER_MODEL
         self._memorize  = memorize
         self._speak     = speak
         self._persona   = _load_persona()
@@ -191,7 +195,7 @@ class AikoThink:
         self._history_lock = threading.Lock()
         self._pending_search_query: str | None = None
         self._route_chat_classified: str | None = None
-        self._semantic_example_cache: dict[int, tuple[list[str], list[list[float]]]] = {}
+        self._semantic_example_cache: dict[int, tuple[list[str], np.ndarray]] = {}
         self._semantic_example_cache_lock = threading.RLock()
         self._active_turn = threading.Event()
         self._reasoning = False
@@ -248,34 +252,42 @@ class AikoThink:
         return self._semantic_agent_intent(user_input)
 
     @staticmethod
-    def _cosine_similarity(a: list[float], b: list[float]) -> float:
-        denom_a = sum(x * x for x in a) ** 0.5
-        denom_b = sum(x * x for x in b) ** 0.5
-        if not denom_a or not denom_b:
-            return 0.0
-        return sum(x * y for x, y in zip(a, b)) / (denom_a * denom_b)
+    def _normalized_vector(vector: list[float]) -> np.ndarray:
+        """Return one L2-normalized float32 embedding vector for cosine scoring."""
+        arr = np.asarray(vector, dtype=np.float32)
+        norm = float(np.linalg.norm(arr))
+        if norm <= 1e-12:
+            return arr
+        return arr / norm
+
+    @staticmethod
+    def _normalized_matrix(vectors: list[list[float]]) -> np.ndarray:
+        """Return row-wise L2-normalized float32 embeddings for vectorized cosine."""
+        matrix = np.asarray(vectors, dtype=np.float32)
+        if matrix.size == 0:
+            return matrix.reshape(0, 0)
+        norms = np.linalg.norm(matrix, axis=1, keepdims=True)
+        return matrix / np.clip(norms, 1e-12, None)
 
     def _semantic_agent_intent(self, user_input: str) -> str:
         """Classify agentic intent by embedding similarity to route examples."""
         try:
-            query_vector = self._memorize.embed_text(user_input)
+            query_vector = self._normalized_vector(self._memorize.embed_text(user_input, query=True))
             labels, example_vectors = self._semantic_example_vectors(_SEMANTIC_ROUTE_EXAMPLES)
-            
+            raw_scores = example_vectors @ query_vector
+
             scores: dict[str, float] = {}
-            for label, vector in zip(labels, example_vectors):
-                s = self._cosine_similarity(query_vector, vector)
-                if s > scores.get(label, 0.0):
-                    scores[label] = s
-            
+            for label, score in zip(labels, raw_scores):
+                scores[label] = max(scores.get(label, 0.0), float(score))
+
             best_label = max(scores, key=scores.get)
             best_score = scores[best_label]
             sorted_scores = sorted(scores.values(), reverse=True)
             second_score = sorted_scores[1] if len(sorted_scores) > 1 else 0.0
-            
-            MIN_GAP = float(os.getenv("ROUTE_MIN_GAP", "0.03"))
+
             log.debug("[route] best=%s score=%.3f gap=%.3f for: %r", best_label, best_score, best_score - second_score, user_input)
-            
-            if best_score >= _SEMANTIC_ROUTE_THRESHOLD and (best_score - second_score) >= MIN_GAP:
+
+            if best_score >= _SEMANTIC_ROUTE_THRESHOLD and (best_score - second_score) >= _SEMANTIC_ROUTE_MIN_GAP:
                 return best_label
             return "chat"
         except Exception as e:
@@ -286,18 +298,15 @@ class AikoThink:
 
     def _semantic_best_label(self, user_input: str, examples_by_label: dict[str, tuple[str, ...]]) -> tuple[str, float]:
         """Return the closest semantic label and cosine score for a prompt."""
-        query_vector = self._memorize.embed_text(user_input)
+        query_vector = self._normalized_vector(self._memorize.embed_text(user_input, query=True))
         labels, example_vectors = self._semantic_example_vectors(examples_by_label)
-        best_label = "chat"
-        best_score = 0.0
-        for label, vector in zip(labels, example_vectors):
-            score = self._cosine_similarity(query_vector, vector)
-            if score > best_score:
-                best_label = label
-                best_score = score
-        return best_label, best_score
+        if example_vectors.size == 0:
+            return "chat", 0.0
+        raw_scores = example_vectors @ query_vector
+        best_idx = int(np.argmax(raw_scores))
+        return labels[best_idx], float(raw_scores[best_idx])
 
-    def _semantic_example_vectors(self, examples_by_label: dict[str, tuple[str, ...]]) -> tuple[list[str], list[list[float]]]:
+    def _semantic_example_vectors(self, examples_by_label: dict[str, tuple[str, ...]]) -> tuple[list[str], np.ndarray]:
         """Return cached embeddings for a static semantic example corpus."""
         cache_key = id(examples_by_label)
         cache = getattr(self, "_semantic_example_cache", None)
@@ -318,7 +327,7 @@ class AikoThink:
                 labels.extend([label] * len(examples))
                 prompts.extend(examples)
 
-            vectors = [self._memorize.embed_text(text) for text in prompts]
+            vectors = self._normalized_matrix(self._memorize.embed_texts(prompts))
             cached = (labels, vectors)
             cache[cache_key] = cached
             return cached
@@ -327,7 +336,7 @@ class AikoThink:
         """Ask the local model for a compact route label when keywords miss."""
         try:
             resp = self._client.chat.completions.create(
-                model=self._llm_model,
+                model=self._router_model,
                 messages=[{"role": "user", "content": (
                     "Route message. Labels: chat, research, planning, writing, coding, "
                     "architecture, decision, reminder, ongoing_task. "
@@ -659,7 +668,7 @@ class AikoThink:
 
         try:
             resp = self._client.chat.completions.create(
-                model=self._llm_model,
+                model=self._router_model,
                 messages=[{"role": "user", "content": (
                     f'{context_block}Message: "{user_input}"\n\n'
                     f'Is this asking for factual external data, or conversational?\n'

--- a/core/wakeup.py
+++ b/core/wakeup.py
@@ -24,8 +24,8 @@ Usage:
     )
     think    = result.think
     memorize = result.memorize
-    speak    = result.speak    # None in text mode
-    listen   = result.listen   # None in text mode
+    speak    = result.speak
+    listen   = result.listen
 """
 
 import threading
@@ -46,8 +46,8 @@ class BootResult:
     """Holds all live subsystem references produced during boot."""
     think:    object          # AikoThink
     memorize: object          # AikoMemorize
-    speak:    object | None   # AikoSpeak  — None in text mode
-    listen:   object | None   # AikoListen — None in text mode
+    speak:    object          # AikoSpeak
+    listen:   object          # AikoListen
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
@@ -75,7 +75,7 @@ class AikoWakeup:
     so the TUI can register display text before boot begins.
 
     Args:
-        text_mode: When True, TTS and ASR subsystems are skipped entirely.
+        text_mode: Legacy flag. The CLI now keeps voice subsystems loadable so /voice and /listen can toggle them at runtime.
     """
 
     ALL_BOOT_LABELS: dict[str, str] = {
@@ -98,7 +98,7 @@ class AikoWakeup:
         Execute full boot sequence and return live subsystem references.
 
         Parallel phase: AikoThink + AikoMemorize boot concurrently.
-        Sequential phase: TTS warmup → ASR staged init (or skip both).
+        Sequential phase: TTS warmup → ASR staged init.
         Barge-in monitor started as the final ASR step so Silero is already
         warm and the VAD thread costs nothing before the first turn.
 
@@ -117,7 +117,7 @@ class AikoWakeup:
             from core.speak import AikoSpeak
             from core.think import AikoThink
 
-        speak     = AikoSpeak(silent=True) if not self._text_mode else None
+        speak     = AikoSpeak(silent=True)
         memorize  = [None]
         think_ref = [None]
         mem_ready = threading.Event()
@@ -163,38 +163,32 @@ class AikoWakeup:
 
         # ── voice subsystems ──────────────────────────────────────────────────
 
-        listen = None
+        # TTS
+        on_loading('speak_miotts')
+        speak.warmup()
+        on_done('speak_miotts')
+        on_loading('speak_ready')
+        on_done('speak_ready')
 
-        if not self._text_mode:
-            # TTS
-            on_loading('speak_miotts')
-            speak.warmup()
-            on_done('speak_miotts')
-            on_loading('speak_ready')
-            on_done('speak_ready')
+        # ASR — staged so each step reports independently
+        from core.listen import AikoListen
+        listen = AikoListen()
 
-            # ASR — staged so each step reports independently
-            from core.listen import AikoListen
-            listen = AikoListen()
+        on_loading('listen_asr')
+        listen.load_asr()
+        on_done('listen_asr')
 
-            on_loading('listen_asr')
-            listen.load_asr()
-            on_done('listen_asr')
+        on_loading('listen_silero')
+        listen.load_vad()              # also kicks off warmup thread
+        on_done('listen_silero')
 
-            on_loading('listen_silero')
-            listen.load_vad()              # also kicks off warmup thread
-            on_done('listen_silero')
+        on_loading('listen_warmup')
+        listen.join_warmup()
+        on_done('listen_warmup')
 
-            on_loading('listen_warmup')
-            listen.join_warmup()
-            on_done('listen_warmup')
-
-            on_loading('listen_ready')
-            listen.start_barge_in_monitor()   # VAD daemon — costs ~0 CPU at idle
-            on_done('listen_ready')
-        else:
-            on_skip('speak_skip')
-            on_skip('listen_skip')
+        on_loading('listen_ready')
+        listen.start_barge_in_monitor()   # VAD daemon — costs ~0 CPU at idle
+        on_done('listen_ready')
 
         return BootResult(
             think    = think_ref[0],

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -93,15 +93,12 @@ sequenceDiagram
         Memory-->>Wakeup: ready
     end
     Wakeup->>Think: inject Memory reference
-    alt voice mode
-        Wakeup->>Speak: warm TTS client
-        Speak-->>Wakeup: ready
-        Wakeup->>Listen: initialize ASR + VAD + barge-in monitor
-        Listen-->>Wakeup: ready
-    else --text mode
-        Wakeup-->>Main: skip Speak and Listen
-    end
-    Wakeup-->>Main: BootResult(think, memorize, speak?, listen?)
+    Wakeup->>Speak: warm TTS client
+    Speak-->>Wakeup: ready
+    Wakeup->>Listen: initialize ASR + VAD + barge-in monitor
+    Listen-->>Wakeup: ready
+    Wakeup-->>Main: BootResult(think, memorize, speak, listen)
+    Note over Main: --text/--no-asr only change initial toggles; /voice and /listen can enable loaded subsystems.
     Main->>UI: status_finish + first draw
     Main->>Main: enter shared input loop
 ```

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -142,6 +142,9 @@ Major additions:
 - initial `wildlife_photo`, `aiko_architect`, `coding_tutor`, `japanese_tutor`, and `aurora_forecast_watch` skill projects
 - local scheduling/reminder infrastructure using `workspace/schedule.json`
 - final-answer verification/repair safeguards in the agentic loop
+- monthly memory consolidation for older full months, using chunked daily experience turns first and memory facts as fallback so the LLM never needs an entire month in one context window
+- routing decision upgrade: keyword-only task detection was replaced by a dual path — fast semantic exemplar routing by default, with optional LLM routing/fallback for context-heavy cases
+- embedding decision upgrade: BGE v1.5 was replaced by Harrier OSS v1 270M fastembed because BGE is aging and produced compressed route-example cosine bands, while Harrier gives a newer 640-dimensional retrieval model with query-instruction support and better expected semantic separation
 
 Lessons learned:
 
@@ -150,6 +153,7 @@ Lessons learned:
 - `core/tools.py` remains useful as a stable public facade even when implementations move into `core/toolkit/`.
 - The browser WebUI can share the TUI contract, but remote voice-device UX still needs polishing.
 - Environment-variable migrations need docs: `LLM_*` and `ROUTE_*` are now the current names for chat runtime/routing.
+- Aiko is still a single orchestrated agentic loop today; semantic routing, optional LLM routing, tools, and skills are components, not separate autonomous agents.
 
 ---
 

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -163,7 +163,7 @@ uv run python core/speak.py --devices
 uv run python core/speak.py --wait "Hello, I'm Aiko."
 ```
 
-If you do not need voice, run Aiko with `--text`; wakeup will skip TTS and ASR.
+If you do not need voice initially, run Aiko with `--text`; TTS and ASR still load so `/voice` and `/listen` can toggle them on later without restarting.
 
 ---
 
@@ -185,7 +185,8 @@ LLM_MAX_TOKENS=280
 # Memory
 SQLITE_MEMORY_PATH=/home/oppa-ai/.aiko/memory.db
 FASTEMBED_CACHE_PATH=/home/oppa-ai/.cache/fastembed
-EMBED_MODEL=BAAI/bge-base-en-v1.5
+EMBED_MODEL=ferrisS/harrier-oss-v1-270m-fastembed
+EMBED_DIMS=640
 MEMORY_RECALL_LIMIT=5
 
 # Web search
@@ -282,10 +283,10 @@ uv run python main.py
 # Browser WebUI + VRM frontend
 uv run python main.py --webui
 
-# Keyboard-only, skips ASR and TTS
+# Keyboard-first, ASR/TTS loaded but initially toggled off
 uv run python main.py --text
 
-# Keyboard input but keep TTS available
+# Keyboard input, TTS on and ASR loaded but toggled off
 uv run python main.py --no-asr
 
 # Debug memory hits each turn

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -65,7 +65,9 @@ Aiko-chan is built in phases. Each phase is a self-contained capability layer th
 | Feature | Status |
 |---|---|
 | **Memory backend rewrite — sqlite-vec + fastembed (custom, no server)** | ✅ Done |
+| Embedding model migration — BGE v1.5 → Harrier OSS v1 270M fastembed for newer 640d vectors and better expected semantic separation | ✅ Done |
 | KNN + FTS5 + RRF memory retrieval | ✅ Done |
+| Monthly memory consolidation — older full months summarized into pinned durable memories | ✅ Done |
 | Microphone capture via PulseAudio `parec` | ✅ Done |
 | ASR via SenseVoice + sherpa-onnx | ✅ Done |
 | Voice Activity Detection via Silero VAD | ✅ Done |
@@ -109,6 +111,7 @@ Aiko-chan is built in phases. Each phase is a self-contained capability layer th
 | Toolkit set Agentic-focused tool modules | ✅ Done |
 | Agentic skill workflow registry | ✅ Done |
 | Skill-context retrieval in agentic mode | ✅ Done |
+| Dual-path agentic routing — semantic exemplar route by default, optional LLM router/fallback instead of keyword-only dispatch | ✅ Done |
 | Initial wildlife-photo and Aiko-architecture skills | ✅ Done |
 | Safer code-edit/review workflow for self-improvement | 🔲 Planned |
 | Optional MCP wrappers for stable long-running tools | 🔲 Planned |

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -77,7 +77,7 @@ Run before any phase suite.
 
 ### 1.1 Boot and launch modes
 
-- [ ] `uv run python main.py --text` starts without loading ASR/TTS and reaches the first input prompt.
+- [ ] `uv run python main.py --text` starts with ASR/TTS loaded but initially toggled off, and reaches the first input prompt.
 - [ ] `uv run python main.py --text --debug` starts and prints memory recall/debug information per turn.
 - [ ] `uv run python main.py --clear-mem` wipes the configured memory DB and exits without entering chat.
 - [ ] Launch fails gracefully with a clear error if `LLM_BASE_URL` is unavailable; no traceback-only user experience.
@@ -218,7 +218,7 @@ Run before any phase suite.
 - [ ] `uv run python main.py` starts full voice mode without `--text` and reaches ready state.
 - [ ] Staged boot reports ASR model loading, Silero VAD loading, optional speaker verification, ASR warmup, TTS readiness, and microphone readiness.
 - [ ] First-use Hugging Face model download is tested once; cached/offline boot is tested with `HF_HUB_OFFLINE=1`.
-- [ ] ASR/TTS disabled modes are correct: `--text` skips both, `--no-asr` keeps keyboard input with TTS.
+- [ ] ASR/TTS initial-toggle modes are correct: `--text` starts with both off but loadable via `/voice` and `/listen`; `--no-asr` starts with keyboard input and TTS on.
 - [ ] Missing microphone, missing `parec`, invalid ASR model, and missing HF cache produce actionable errors.
 - [ ] Resource usage during boot stays within Jetson limits and does not trigger OOM killer.
 

--- a/main.py
+++ b/main.py
@@ -5,7 +5,8 @@ Aiko-chan CLI — entry point and session orchestrator.
 
 Usage:
     python main.py               # full voice — ASR (SenseVoice + Silero VAD) + TTS (MioTTS)
-    python main.py --text        # keyboard input + no TTS
+    python main.py --text        # keyboard input + TTS/ASR loaded but toggled off
+    python main.py --no-asr      # keyboard input + TTS on, ASR loaded but toggled off
     python main.py               # browser WebUI (default)
     python main.py --tui         # curses TUI
     python main.py --debug       # show memory debug info each turn
@@ -56,6 +57,7 @@ from webui.aiko_web import AikoWeb
 AI_NAME = os.getenv("AI_NAME", "Aiko")
 USER_ID = os.getenv("USER_ID", "")
 STREAM_DRAW_INTERVAL = float(os.getenv("AIKO_STREAM_DRAW_INTERVAL", "0.05"))
+LATENCY_LOG_ENABLED = os.getenv("AIKO_LATENCY_LOG", "1").lower() in {"1", "true", "yes", "on"}
 
 
 # ── voice command map ─────────────────────────────────────────────────────────
@@ -145,9 +147,9 @@ def parse_args():
     """Parse and return the CLI argument namespace for Aiko-chan's launch options."""
     p = argparse.ArgumentParser(description="Aiko-chan CLI")
     p.add_argument("--text",      action="store_true",
-                   help="keyboard input + no TTS  (default: ASR + TTS)")
+                   help="keyboard input + TTS/ASR initially off; both subsystems still load for /voice and /listen toggles")
     p.add_argument("--no-asr",    action="store_true",
-                   help="keyboard input but keep TTS")
+                   help="keyboard input but keep TTS on; ASR still loads for /listen")
     p.add_argument("--debug",     action="store_true",
                    help="show memory hits each turn")
     p.add_argument("--tui",       action="store_true",
@@ -195,6 +197,13 @@ def _run_session(tui, args):
 
     def token_cb(token):
         nonlocal last_stream_draw
+        if token:
+            _latency_mark("first_token_at")
+            if not token.startswith("__"):
+                _latency_mark("first_assistant_token_at")
+        if token.startswith("__THINKING__") or token.startswith("__TOOL__:"):
+            if current_latency is not None:
+                current_latency["mode"] = "agentic"
         if token.startswith("__SEARCHING__:"):
             query = token.split(":", 1)[1]
             tui.add_message('sys', f'Searching: {query}...')
@@ -214,7 +223,9 @@ def _run_session(tui, args):
 
     # ── boot all subsystems via wakeup ────────────────────────────────────────
 
-    result = AikoWakeup(text_mode=args.text).boot(
+    # Load voice subsystems even when initially toggled off so /voice and
+    # /listen can turn them on without a second boot-time model load.
+    result = AikoWakeup(text_mode=False).boot(
         on_loading = tui.step_loading,
         on_done    = tui.step_done,
         on_skip    = tui.step_skip,
@@ -234,6 +245,53 @@ def _run_session(tui, args):
 
     tts_enabled = not args.text
     asr_enabled = not args.text and not args.no_asr
+    if hasattr(tui, "_stats"):
+        tui._stats['tts_on'] = tts_enabled
+        tui._stats['asr_on'] = asr_enabled
+
+    current_latency: dict | None = None
+
+    def _latency_mark(name: str) -> None:
+        if current_latency is not None and name not in current_latency:
+            current_latency[name] = time.monotonic()
+
+    if speak is not None and hasattr(speak, "set_first_audio_callback"):
+        speak.set_first_audio_callback(lambda: _latency_mark("first_audio_at"))
+
+    def _latency_seconds(timing: dict, start: str, end: str) -> float | None:
+        if timing.get(start) is None or timing.get(end) is None:
+            return None
+        return max(0.0, timing[end] - timing[start])
+
+    def _fmt_latency(value: float | None) -> str:
+        return "n/a" if value is None else f"{value:.3f}s"
+
+    def _log_latency(timing: dict) -> None:
+        if not LATENCY_LOG_ENABLED:
+            return
+        mode = timing.get("mode", "text")
+        parts = {
+            "voice_end_to_submit": _latency_seconds(timing, "voice_recording_stopped_at", "submitted_at"),
+            "submit_to_first_token": _latency_seconds(timing, "submitted_at", "first_assistant_token_at"),
+            "submit_to_assistant_done": _latency_seconds(timing, "submitted_at", "assistant_done_at"),
+            "assistant_done_to_first_audio": _latency_seconds(timing, "assistant_done_at", "first_audio_at"),
+            "voice_end_to_first_audio": _latency_seconds(timing, "voice_recording_stopped_at", "first_audio_at"),
+            "submit_to_first_audio": _latency_seconds(timing, "submitted_at", "first_audio_at"),
+            "submit_to_turn_done": _latency_seconds(timing, "submitted_at", "turn_done_at"),
+        }
+        log.info(
+            "[latency] mode=%s voice_end→submit=%s submit→first_token=%s "
+            "submit→assistant_done=%s assistant_done→first_audio=%s "
+            "voice_end→first_audio=%s submit→first_audio=%s submit→turn_done=%s",
+            mode,
+            _fmt_latency(parts["voice_end_to_submit"]),
+            _fmt_latency(parts["submit_to_first_token"]),
+            _fmt_latency(parts["submit_to_assistant_done"]),
+            _fmt_latency(parts["assistant_done_to_first_audio"]),
+            _fmt_latency(parts["voice_end_to_first_audio"]),
+            _fmt_latency(parts["submit_to_first_audio"]),
+            _fmt_latency(parts["submit_to_turn_done"]),
+        )
 
     # ── shutdown helper ───────────────────────────────────────────────────────
 
@@ -247,6 +305,7 @@ def _run_session(tui, args):
 
     while True:
         try:
+            voice_info = None
             if listen and asr_enabled:
                 result = tui.get_voice_input(
                     listen,
@@ -254,6 +313,7 @@ def _run_session(tui, args):
                     wait_fn = None,
                 )
                 user_input = result[0] if isinstance(result, tuple) else result
+                voice_info = result[1] if isinstance(result, tuple) and len(result) > 1 and isinstance(result[1], dict) else None
             else:
                 result = tui.get_input()
                 user_input = result[0] if isinstance(result, tuple) else result
@@ -375,7 +435,7 @@ def _run_session(tui, args):
 
             elif cmd == '/voice':
                 if speak is None:
-                    tui.add_message('sys', 'TTS unavailable — started in --text mode.')
+                    tui.add_message('sys', 'TTS unavailable — voice subsystem did not load.')
                 else:
                     tts_enabled = not tts_enabled
                     think.set_speak(speak if tts_enabled else None)
@@ -385,7 +445,7 @@ def _run_session(tui, args):
 
             elif cmd == '/listen':
                 if listen is None:
-                    tui.add_message('sys', 'ASR unavailable — started in --text mode.')
+                    tui.add_message('sys', 'ASR unavailable — voice subsystem did not load.')
                 else:
                     asr_enabled = not asr_enabled
                     tui._stats['asr_on'] = asr_enabled
@@ -456,15 +516,27 @@ def _run_session(tui, args):
                     tui.add_message('sys',
                         f'  → {m.get("memory") or m.get("text") or m}')
 
+        current_latency = {
+            "mode": "voice" if (listen and asr_enabled and voice_info) else "text",
+            "submitted_at": time.monotonic(),
+        }
+        if voice_info:
+            current_latency["listen_started_at"] = voice_info.get("listen_started_at")
+            current_latency["voice_recording_stopped_at"] = voice_info.get("recording_stopped_at")
+
         tui.add_message('you', user_input)
         tui.turn_start()
         tui._draw()
 
         think.route(user_input, token_callback=token_cb)
+        current_latency["assistant_done_at"] = time.monotonic()
         tui.stream_commit()
         tui._draw()
         if speak and tts_enabled:
             speak.wait()
+        current_latency["turn_done_at"] = time.monotonic()
+        _log_latency(current_latency)
+        current_latency = None
 
 
 # ═════════════════════════════════════════════════════════════════════════════

--- a/tui/tui.py
+++ b/tui/tui.py
@@ -41,6 +41,8 @@ from core.health import _ram_used_str, _db_size_str, _fmt_uptime
 
 LLM_BASE_URL  = os.getenv("LLM_BASE_URL", "unknown")
 LLM_MODEL     = os.getenv("LLM_MODEL", "unknown")
+EMBED_MODEL   = os.getenv("EMBED_MODEL", "unknown")
+EMBED_DIMS    = os.getenv("EMBED_DIMS", "?")
 ASR_MODEL     = os.getenv("ASR_MODEL", os.getenv("ASR_MODE", "csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17"))
 MIOTTS_MODEL  = os.getenv("MIOTTS_MODEL", "MioTTS 0.4B")
 SEARXNG_URL   = os.getenv("SEARXNG_URL",   "localhost:8080")
@@ -115,11 +117,11 @@ def _art_attr(palette_idx: int) -> int:
 ARCH_SECTIONS = [
     ("MEMORY SYSTEMS", [
         ("Long-term store", "SQLite-vec DB"),
-        ("Embedding model", "BGE-base-en-v1.5  (768d)"),
+        ("Embedding model", f"{EMBED_MODEL}  ({EMBED_DIMS}d)"),
         ("Short-term ctx",  f"Rolling {os.getenv('CONTEXT_WINDOW_TURNS', '20')}-turn window"),
     ]),
     ("COGNITION", [
-        ("Inference engine", "Ollama  (local, offline)"),
+        ("Inference engine", "llama.cpp  (OpenAI-compatible)"),
         ("Active model",     LLM_MODEL),
         ("Web search",       SEARXNG_URL),
     ]),
@@ -134,10 +136,10 @@ ARCH_ROWS = sum(1 + len(items) for _, items in ARCH_SECTIONS) + 2
 db_path = os.getenv("SQLITE_MEMORY_PATH", str(Path.home() / ".aiko" / "memory.db"))
 
 INIT_STEPS = {
-    'think_start':      ('Inference Engine', f'Spawning Ollama worker  ·  {LLM_MODEL}'),
+    'think_start':      ('Inference Engine', f'Spawning llama.cpp client  ·  {LLM_MODEL}'),
     'think_warmup':     ('Model Warm-up',    'Loading weights, running prefill pass …'),
     'mem_sqlite_vec':   ('Vector Database',  f'Connecting to SQLite-vec  ·  {db_path}'),
-    'mem_embed':        ('Embedding Model',  'Loading BGE-base-en-v1.5  ·  768-dim vectors'),
+    'mem_embed':        ('Embedding Model',  f'Loading {EMBED_MODEL}  ·  {EMBED_DIMS}-dim vectors'),
     'mem_cleanup':      ('Memory Lifecycle', 'Pruning decayed memories …'),
     'mem_ready':        ('Memory Cortex',    'OppaAI custom-build  ·  long-term recall online'),
     'speak_miotts':     ('TTS Engine',       f'Initializing MioTTS  ·  {os.getenv("MIOTTS_PRESET", "jp_female")}'),

--- a/webui/aiko_web.py
+++ b/webui/aiko_web.py
@@ -388,11 +388,12 @@ class AikoWeb:
             except queue.Empty:
                 self._push_vitals()
 
-    def get_voice_input(self, listen, speak=None, wait_fn=None) -> str:
+    def get_voice_input(self, listen, speak=None, wait_fn=None):
         """
         Capture a voice utterance via the browser's microphone and return the
-        transcript. Tells the browser to start streaming raw PCM mic frames
-        over the WebSocket (binary frames), feeds them into the same VAD/ASR
+        same (text, info) shape as AikoTUI.get_voice_input(). Tells the browser
+        to start streaming raw PCM mic frames over the WebSocket (binary frames),
+        feeds them into the same VAD/ASR
         pipeline used locally (via chunk_source), and stops the browser mic
         once the utterance is captured or the turn times out.
         """
@@ -454,8 +455,8 @@ class AikoWeb:
         self._broadcast({"type": "voice", "status": "idle"})
         raw = result_holder[0]
         if isinstance(raw, tuple):
-            raw = raw[0]
-        return raw or ""
+            return raw
+        return (raw or "", {})
 
     # ------------------------------------------------------------------
     # spin loop  (called during init phase — just keeps vitals ticking)


### PR DESCRIPTION
### Motivation
- Replace the aging BGE embedding path with a local Harrier fastembed conversion for better retrieval separation and smaller vectors on constrained hardware.
- Improve long-term memory lifecycle by adding monthly consolidation to reduce vector DB size while keeping durable summaries pinned.
- Make intent routing faster and more robust by using vectorized, normalized exemplar embeddings and a separate LLM router fallback option.
- Add runtime telemetry and audio timing hooks to measure and reduce voice turn latency.

### Description
- Environment and docs: expanded `.env.example`, `README.md`, and install/docs to document `EMBED_MODEL`, new embedding registration options, monthly consolidation flags, routing modes (`ROUTE_MODE`/`ROUTER_MODEL`) and latency logging via `AIKO_LATENCY_LOG`.
- Embeddings & memory: switched defaults to `ferrisS/harrier-oss-v1-270m-fastembed` (640d), added query-side instruction support, optional custom ONNX registration (`EMBED_REGISTER_CUSTOM_MODEL`), batched embedding APIs, `add_raw`, `get_between`, and improved dedupe/registration handling in `core/memorize.py` and `archive/migrate_embeddings.py`.
- Retrieval scoring: fused KNN+FTS5 RRF now includes small recency/access/pinned boosts (`MEMORY_RANK_*`) and L2-normalized vectors for stable cosine scoring.
- Monthly consolidation: added `core/monthly.py` to summarize an older full month into a pinned summary, optionally delete originals, and persist consolidation state; integrated into `core/dream.py` scheduler to run after a configurable daily window.
- Routing & think: `core/think.py` now normalizes embeddings with `numpy`, caches exemplar matrices as `ndarray`, computes fast vectorized cosine scores, supports separate `ROUTER_MODEL` for LLM routing, and tightened routing thresholds.
- Agent verifier & policy: `core/agentic.py` parses verifier booleans strictly, enforces a configurable `AGENT_VERIFY_MIN_SCORE`, and improves verifier prompt and fallback behavior.
- Voice & telemetry: `core/speak.py` exposes `set_first_audio_callback` and fires it on first audio chunk to allow timing marks; `core/listen.py` returns listen timestamps in ASR info; `main.py` and `core/wakeup.py` now load voice subsystems even when initially toggled off and added per-turn latency logging and marks.
- Boot and TUI: `core/wakeup.py`, `main.py`, and `tui/tui.py` updated to reflect new defaults, boot labels, and embedding/TTS/ASR status rendering.

### Testing
- Ran environment/import smoke check: `uv run python -c "import sqlite_vec, fastembed, sherpa_onnx, silero_vad, sounddevice, websockets; print('OK')"` and it completed successfully.
- Exercised memory backend instantiation: `uv run python -c "from core.memorize import AikoMemorize; m=AikoMemorize(silent=True); print(len(m.get_all()))"` and the call returned without error.
- Performed embedding registration dry-run: `python archive/migrate_embeddings.py --dry-run` to verify `fastembed` can register the custom model, which completed successfully.
- Boot smoke: started the app in keyboard-first mode to exercise `AikoWakeup` and the new boot path via `uv run python main.py --text --debug`; the wakeup sequence and latency hooks executed as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ec3161f3c832c99a0b979d3b0fea8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added monthly memory consolidation and richer memory scheduling controls.
  * Improved voice startup so TTS/ASR load even in text-first mode and can be enabled later.
  * Added latency logging, first-audio callbacks, and expanded intent routing controls.

* **Bug Fixes**
  * Improved memory search ranking for more relevant results.
  * Better final-answer verification to reduce low-confidence outputs.

* **Documentation**
  * Updated setup, architecture, roadmap, and history notes to match the latest behavior and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->