### PR TITLE
Add viseme callbacks, karaoke-synced streamed TTS, and WebUI mouth animation

### DIFF
--- a/core/speak.py
+++ b/core/speak.py
@@ -27,6 +27,7 @@ import time
 import threading
 import argparse
 import unicodedata
+import queue
 
 try:
     from dotenv import load_dotenv
@@ -206,10 +207,18 @@ class AikoSpeak:
             self._sd = _sd                 # eagerly loaded to avoid curses fd conflict
         self._token_buf: list[str] = []        # accumulate feed() tokens
         self._stream_chunks: list[str] = []
+        self._stream_queue = None
         self._stream_thread = None
+        self._stream_on_word = None
         self._streaming_active = False
         self._first_audio_callback = None
         self._first_audio_fired = threading.Event()
+
+        # When enabled, streamed TTS drives the UI token callback word-by-word
+        # against real WAV duration, instead of letting LLM tokens paint early.
+        self.karaoke_text = os.getenv("AIKO_KARAOKE_TEXT", "0").lower() in {
+            "1", "true", "yes", "on",
+        }
 
         # ── remote audio sink (WebUI) ────────────────────────────────────
         # If set, _play_wav_bytes() also hands each synthesized WAV chunk to
@@ -217,6 +226,7 @@ class AikoSpeak:
         # connected browser can play it — needed for remote/WAN use where
         # nobody's in the room to hear the Jetson's own speaker.
         self._audio_sink = None
+        self._viseme_sink = None
         # When True (default), local sounddevice playback still happens even
         # if a remote sink is set — fine on LAN where you might be near the
         # robot. Set False to silence the Jetson's own speaker entirely once
@@ -251,6 +261,36 @@ class AikoSpeak:
             voice.set_audio_sink(web.broadcast_audio_bytes)
         """
         self._audio_sink = callback
+
+    def set_viseme_sink(self, callback) -> None:
+        """
+        Register a callback(viseme: str, weight: float) -> None invoked during
+        TTS playback so a remote avatar can lip-sync to the synthesized voice.
+        """
+        self._viseme_sink = callback
+
+    def _emit_viseme(self, viseme: str, weight: float = 1.0) -> None:
+        if self._viseme_sink is None:
+            return
+        try:
+            self._viseme_sink(viseme, weight)
+        except Exception as e:
+            log.error("[speak] viseme sink error: %s", e)
+
+    def _viseme_for_word(self, word: str) -> str:
+        lowered = word.lower()
+        for char in lowered:
+            if char in "aあかがさざただなはばぱまやゃらわ":
+                return "A"
+            if char in "iいきぎしじちぢにひびぴみり":
+                return "I"
+            if char in "uうくぐすずつづぬふぶぷむゆゅる":
+                return "U"
+            if char in "eえけげせぜてでねへべぺめれ":
+                return "E"
+            if char in "oおこごそぞとどのほぼぽもよょろを":
+                return "O"
+        return "A"
 
     def warmup(self) -> bool:
         """Health-check the MioTTS server — called from wakeup.py during boot."""
@@ -396,7 +436,42 @@ class AikoSpeak:
         finally:
             self._playing.clear()
 
-    def _emit_words_timed(self, text: str, duration: float, on_word) -> None:
+    def _speech_stream_worker(self, chunk_queue, on_word=None) -> None:
+        """
+        Synthesize and play streamed sentence chunks as soon as they arrive.
+
+        The LLM/UI stream still owns text display; this worker only handles
+        sentence-level TTS so voice can start before the full answer is done.
+        """
+        self._playing.set()
+        try:
+            while not self._stop_flag.is_set():
+                chunk = chunk_queue.get()
+                if chunk is None:
+                    break
+                clean = sanitize_for_tts(chunk)
+                if not clean:
+                    continue
+                for piece in self._chunk_text(clean):
+                    if self._stop_flag.is_set():
+                        break
+                    wav = self._synthesize(piece)
+                    if not wav:
+                        continue
+                    if on_word or self._viseme_sink is not None:
+                        duration = self._wav_duration(wav)
+                        play_thread = threading.Thread(
+                            target=self._play_wav_bytes, args=(wav,), daemon=True
+                        )
+                        play_thread.start()
+                        self._emit_words_timed(piece, duration, on_word)
+                        play_thread.join()
+                    else:
+                        self._play_wav_bytes(wav)
+        finally:
+            self._playing.clear()
+
+    def _emit_words_timed(self, text: str, duration: float, on_word=None) -> None:
         """
         Call on_word() for each word in `text`, paced so the words land
         roughly across `duration` seconds — the real audio length of this
@@ -413,7 +488,10 @@ class AikoSpeak:
         if duration <= 0:
             # couldn't determine audio length — just emit immediately
             for i, word in enumerate(words):
-                on_word(word if i == 0 else " " + word)
+                self._emit_viseme(self._viseme_for_word(word), 0.85)
+                if on_word:
+                    on_word(word if i == 0 else " " + word)
+            self._emit_viseme("A", 0.0)
             return
 
         # Keep a small lead-in so the first word appears when audio begins,
@@ -438,8 +516,11 @@ class AikoSpeak:
             sleep_time = (start + elapsed) - time.monotonic()
             if sleep_time > 0:
                 time.sleep(sleep_time)
-            on_word(word if i == 0 else " " + word)
+            self._emit_viseme(self._viseme_for_word(word), 0.85)
+            if on_word:
+                on_word(word if i == 0 else " " + word)
             elapsed += usable_duration * (weight / total)
+        self._emit_viseme("A", 0.0)
 
     def _speak_thread_synced(self, text: str, on_word=None) -> None:
         """
@@ -565,42 +646,45 @@ class AikoSpeak:
         t = threading.Thread(target=self._speak_thread, args=(text,), daemon=True)
         t.start()
 
-    def start_speech_stream(self) -> None:
-        """Start collecting streamed text for one complete TTS playback."""
+    def start_speech_stream(self, on_word=None) -> None:
+        """Start sentence-level TTS playback for one streamed response."""
         self.stop()
         self._first_audio_fired.clear()
         with self._lock:
             self._stream_chunks = []
+            self._stream_queue = queue.Queue()
+            self._stream_on_word = on_word
             self._streaming_active = True
             self._stop_flag.clear()
+            self._stream_thread = threading.Thread(
+                target=self._speech_stream_worker,
+                args=(self._stream_queue, self._stream_on_word),
+                daemon=True,
+            )
+            self._stream_thread.start()
 
     def feed_speech_stream(self, text: str) -> None:
-        """Buffer streamed text until the full response is ready to speak."""
+        """Queue a completed streamed sentence/chunk for immediate TTS."""
         if not text:
             return
         with self._lock:
             if self._streaming_active:
                 self._stream_chunks.append(text)
+                if self._stream_queue is not None:
+                    self._stream_queue.put(text)
 
     def stop_speech_stream(self) -> None:
-        """Finish the stream and play the complete buffered response."""
+        """Finish the current sentence-level TTS stream."""
         with self._lock:
             if not self._streaming_active:
                 return
             self._streaming_active = False
-            text = " ".join(chunk.strip() for chunk in self._stream_chunks if chunk.strip())
             self._stream_chunks = []
-
-        clean = sanitize_for_tts(text)
-        if not clean or self._stop_flag.is_set():
-            return
-        self._first_audio_fired.clear()
-        self._playing.set()
-        self._stop_flag.clear()
-        self._stream_thread = threading.Thread(
-            target=self._speak_thread, args=(clean,), daemon=True
-        )
-        self._stream_thread.start()
+            self._stream_on_word = None
+            stream_queue = self._stream_queue
+            self._stream_queue = None
+        if stream_queue is not None:
+            stream_queue.put(None)
 
     def is_playing(self) -> bool:
         return self._playing.is_set()
@@ -627,6 +711,11 @@ class AikoSpeak:
         with self._lock:
             self._streaming_active = False
             self._stream_chunks = []
+            self._stream_on_word = None
+            stream_queue = self._stream_queue
+            self._stream_queue = None
+        if stream_queue is not None:
+            stream_queue.put(None)
 
         try:
             sd = self._load_sd()

--- a/core/speak.py
+++ b/core/speak.py
@@ -451,12 +451,16 @@ class AikoSpeak:
                     break
                 clean = sanitize_for_tts(chunk)
                 if not clean:
+                    if on_word:
+                        self._emit_words_timed(chunk, 0.0, on_word)
                     continue
                 for piece in self._chunk_text(clean):
                     if self._stop_flag.is_set():
                         break
                     wav = self._synthesize(piece)
                     if not wav:
+                        if on_word:
+                            self._emit_words_timed(piece, 0.0, on_word)
                         continue
                     if on_word or self._viseme_sink is not None:
                         duration = self._wav_duration(wav)
@@ -520,6 +524,10 @@ class AikoSpeak:
             if on_word:
                 on_word(word if i == 0 else " " + word)
             elapsed += usable_duration * (weight / total)
+        remaining = (start + usable_duration) - time.monotonic()
+        while remaining > 0 and not self._stop_flag.is_set():
+            time.sleep(min(0.05, remaining))
+            remaining = (start + usable_duration) - time.monotonic()
         self._emit_viseme("A", 0.0)
 
     def _speak_thread_synced(self, text: str, on_word=None) -> None:

--- a/core/think.py
+++ b/core/think.py
@@ -598,8 +598,11 @@ class AikoThink:
         max_tokens = _BASE_PREDICT * _REASONING_SCALE if self._reasoning else _BASE_PREDICT
         all_messages = [{"role": "system", "content": system}] + messages if system else messages
 
+        karaoke_text = bool(
+            self._speak and token_callback and getattr(self._speak, "karaoke_text", False)
+        )
         if self._speak:
-            self._speak.start_speech_stream()
+            self._speak.start_speech_stream(token_callback if karaoke_text else None)
 
         sentence_buffer = ""
         stream_success = False
@@ -621,7 +624,7 @@ class AikoThink:
                 delta = chunk.choices[0].delta if chunk.choices else None
                 token = (delta.content or "") if delta else ""
                 
-                if token_callback and token:
+                if token_callback and token and not karaoke_text:
                     token_callback(token)
                 
                 full_response.append(token)

--- a/core/think.py
+++ b/core/think.py
@@ -600,6 +600,7 @@ class AikoThink:
 
         karaoke_text = bool(
             self._speak and token_callback and getattr(self._speak, "karaoke_text", False)
+            and not self._reasoning
         )
         if self._speak:
             self._speak.start_speech_stream(token_callback if karaoke_text else None)

--- a/main.py
+++ b/main.py
@@ -236,6 +236,13 @@ def _run_session(tui, args):
     speak    = result.speak
     listen   = result.listen
 
+    if speak and hasattr(tui, "broadcast_audio_bytes"):
+        speak.set_audio_sink(tui.broadcast_audio_bytes)
+        if hasattr(tui, "set_viseme"):
+            speak.set_viseme_sink(tui.set_viseme)
+        if os.getenv("AIKO_WEBUI_LOCAL_PLAYBACK", "1").lower() in {"0", "false", "no", "off"}:
+            speak.local_playback = False
+
     # ── transition to chat ────────────────────────────────────────────────────
 
     spin_stop.set()
@@ -541,10 +548,10 @@ def _run_session(tui, args):
 
         think.route(user_input, token_callback=token_cb)
         current_latency["assistant_done_at"] = time.monotonic()
-        tui.stream_commit()
-        tui._draw()
         if speak and tts_enabled:
             speak.wait()
+        tui.stream_commit()
+        tui._draw()
         current_latency["turn_done_at"] = time.monotonic()
         _update_latency_stats(current_latency)
         _log_latency(current_latency)

--- a/webui/static/aiko-vrm.js
+++ b/webui/static/aiko-vrm.js
@@ -859,6 +859,16 @@ loader.load(VRM_URL,
 
 // ── expression / viseme API (called by WS handler) ───────────────────────────
 const VISEME = { A: 'aa', I: 'ih', U: 'ou', E: 'ee', O: 'oh' };
+let activeViseme = 'aa';
+let mouthOpen = 0;
+
+function applyMouthShape(weight = mouthOpen) {
+  const w = Math.max(0, Math.min(1, weight));
+  ['aa', 'ih', 'ou', 'ee', 'oh'].forEach(k => exprTargets[k] = 0);
+  exprTargets[activeViseme] = w;
+  mouthOpen = w;
+  if (w > 0.03) lastVisemeAt = performance.now();
+}
 
 window.aikoSetExpression = (name, intensity = 1.0) => {
   for (const k of Object.keys(exprTargets)) if (k !== 'blink') exprTargets[k] = 0;
@@ -875,14 +885,23 @@ window.aikoSetExpression = (name, intensity = 1.0) => {
 };
 
 window.aikoSetViseme = (viseme, weight = 1.0) => {
-  const v = VISEME[viseme] ?? viseme;
-  ['aa', 'ih', 'ou', 'ee', 'oh'].forEach(k => exprTargets[k] = 0);
-  exprTargets[v] = weight;
-  lastVisemeAt = performance.now();
+  activeViseme = VISEME[viseme] ?? viseme;
+  applyMouthShape(mouthOpen);
   const dot = document.getElementById('speak-dot');
   const lbl = document.getElementById('speak-label');
-  dot.className = 'dot speak';
+  dot.className = mouthOpen > 0.03 ? 'dot speak' : 'dot';
   lbl.textContent = viseme;
-  clearTimeout(window._vt);
-  window._vt = setTimeout(() => { dot.className = 'dot'; lbl.textContent = 'idle'; }, 300);
+};
+
+window.aikoSetMouthOpen = (weight = 0) => {
+  applyMouthShape(weight);
+  const dot = document.getElementById('speak-dot');
+  const lbl = document.getElementById('speak-label');
+  if (mouthOpen > 0.03) {
+    dot.className = 'dot speak';
+    lbl.textContent = activeViseme;
+  } else {
+    dot.className = 'dot';
+    lbl.textContent = 'idle';
+  }
 };

--- a/webui/static/aiko-vrm.js
+++ b/webui/static/aiko-vrm.js
@@ -889,8 +889,9 @@ window.aikoSetViseme = (viseme, weight = 1.0) => {
   applyMouthShape(mouthOpen);
   const dot = document.getElementById('speak-dot');
   const lbl = document.getElementById('speak-label');
-  dot.className = mouthOpen > 0.03 ? 'dot speak' : 'dot';
-  lbl.textContent = viseme;
+  const speaking = mouthOpen > 0.03;
+  dot.className = speaking ? 'dot speak' : 'dot';
+  lbl.textContent = speaking ? activeViseme : 'idle';
 };
 
 window.aikoSetMouthOpen = (weight = 0) => {

--- a/webui/static/index.html
+++ b/webui/static/index.html
@@ -459,10 +459,64 @@
     let ttsContext = null;
     let ttsQueue   = [];
     let ttsPlaying = false;
+    let ttsAnalyser = null;
+    let ttsAnalyserData = null;
+    let ttsAnalyserConnected = false;
+    let ttsMouthLoop = false;
+    let ttsMouthLevel = 0;
 
     function getTtsContext() {
       if (!ttsContext) ttsContext = new AudioContext();
       return ttsContext;
+    }
+
+    function getTtsAnalyser() {
+      const ctx = getTtsContext();
+      if (!ttsAnalyser) {
+        ttsAnalyser = ctx.createAnalyser();
+        ttsAnalyser.fftSize = 1024;
+        ttsAnalyser.smoothingTimeConstant = 0.35;
+        ttsAnalyserData = new Float32Array(ttsAnalyser.fftSize);
+      }
+      if (!ttsAnalyserConnected) {
+        ttsAnalyser.connect(ctx.destination);
+        ttsAnalyserConnected = true;
+      }
+      return ttsAnalyser;
+    }
+
+    function startMouthAnalyserLoop() {
+      if (ttsMouthLoop) return;
+      ttsMouthLoop = true;
+      const tick = () => {
+        if (!ttsMouthLoop) return;
+        let target = 0;
+        if (ttsPlaying && ttsAnalyser && ttsAnalyserData) {
+          ttsAnalyser.getFloatTimeDomainData(ttsAnalyserData);
+          let sum = 0;
+          for (let i = 0; i < ttsAnalyserData.length; i++) {
+            const v = ttsAnalyserData[i];
+            sum += v * v;
+          }
+          const rms = Math.sqrt(sum / ttsAnalyserData.length);
+          target = Math.max(0, Math.min(1, (rms - 0.012) * 9.5));
+        }
+
+        // Fast attack, slower release. Pauses from punctuation naturally drop
+        // the analyser RMS, closing the mouth instead of racing ahead of audio.
+        const coeff = target > ttsMouthLevel ? 0.65 : 0.28;
+        ttsMouthLevel += (target - ttsMouthLevel) * coeff;
+        if (window.aikoSetMouthOpen) window.aikoSetMouthOpen(ttsMouthLevel);
+
+        if (!ttsPlaying && ttsMouthLevel < 0.01) {
+          ttsMouthLoop = false;
+          ttsMouthLevel = 0;
+          if (window.aikoSetMouthOpen) window.aikoSetMouthOpen(0);
+          return;
+        }
+        requestAnimationFrame(tick);
+      };
+      requestAnimationFrame(tick);
     }
 
     async function enqueueTtsAudio(arrayBuffer) {
@@ -477,11 +531,13 @@
       try {
         const ctx         = getTtsContext();
         const audioBuffer = await ctx.decodeAudioData(buf.slice(0));
+        const analyser    = getTtsAnalyser();
         const src         = ctx.createBufferSource();
         src.buffer        = audioBuffer;
-        src.connect(ctx.destination);
+        src.connect(analyser);
         src.onended       = playNextTts;
         src.start();
+        startMouthAnalyserLoop();
       } catch (err) {
         console.error('[tts] decode/play failed:', err);
         playNextTts();


### PR DESCRIPTION
### Motivation
- Enable sentence-level streamed TTS so voice can start playing before the LLM finishes and pace on-screen word emission to the actual audio (karaoke-style). 
- Expose viseme events and a mouth-open signal so remote WebUI avatars can lip-sync to local TTS playback. 
- Route audio to the WebUI when present and optionally disable local playback for remote usage.

### Description
- `core/speak.py`: added a queue-based `_speech_stream_worker`, `start_speech_stream`/`feed_speech_stream`/`stop_speech_stream` lifecycle using a `queue.Queue`, `set_viseme_sink`, `_emit_viseme`, `_viseme_for_word`, and a `karaoke_text` flag driven by `AIKO_KARAOKE_TEXT` to optionally have streamed TTS drive per-word callbacks; integrated viseme emission into `_emit_words_timed` and ensured proper thread/queue teardown. 
- `core/think.py`: conditional passing of the token callback into `start_speech_stream` only when `karaoke_text` mode is enabled to avoid double-emitting tokens to the TUI while still allowing word-timed callbacks when requested. 
- `main.py`: wire the TUI's `broadcast_audio_bytes` and `set_viseme` handlers into `speak` via `set_audio_sink` and `set_viseme_sink`, and allow disabling local playback via `AIKO_WEBUI_LOCAL_PLAYBACK`. 
- `webui/static/aiko-vrm.js` and `webui/static/index.html`: added viseme and mouth-open APIs (`aikoSetViseme`, `aikoSetMouthOpen`) and client-side audio analyser logic to drive smooth mouth-open animation from decoded TTS audio, plus housekeeping for viseme state and UI indicators.

### Testing
- Ran the repository test suite with `pytest` and the static WebUI smoke playback (decode/play path) locally; the automated tests completed without failures. 
- Exercised the streamed TTS path in a local integration smoke test to verify sentence-level playback, on-word callbacks, and viseme events reached the WebUI; the smoke check passed. 
- Performed a lint/format check to ensure no syntax or static issues were introduced and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42c3fd1a5c832cb91311ba34a1d3c8)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added more natural avatar lip-sync during speech, with mouth movement driven by live audio playback and word-level viseme updates.
  * Speech can now animate progressively while text is being spoken, instead of waiting for the full response to finish.

* **Bug Fixes**
  * Improved timing so speech, avatar animation, and on-screen updates stay better aligned during streaming playback.
  * Reduced the chance of the avatar snapping back to idle too early while speech is still active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->