### PR TITLE
Add Threads token refresh support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -246,6 +246,10 @@ X_ACCOUNT_USERNAME=<Your X Username>       # optional sanity label for the conne
 # Image posts require a public image_url; local draft images are not enough.
 THREADS_USER_ID=<Your Thread user ID>           # Threads user id from Meta/Threads API
 THREADS_ACCESS_TOKEN=                           # long-lived Threads user access token
+THREADS_ACCESS_TOKEN_EXPIRES_AT=                # ISO UTC expiry, e.g. 2026-08-29T00:00:00+00:00
+THREADS_REFRESH_WINDOW_DAYS=55                  # refresh token when <= this many days remain
+THREADS_REFRESH_PERSIST_ENV=0                   # 1 = auto-write refreshed token back to THREADS_TOKEN_ENV_PATH
+THREADS_TOKEN_ENV_PATH=.env                     # env file updated by --persist-env / auto-persist
 THREADS_API_BASE=https://graph.threads.net/v1.0 # official Threads API base URL
 THREADS_PUBLISH_DELAY_SECONDS=5                 # wait between container create and publish
 WEEKLY_SOCIAL_IMAGE_URL=                   # optional public URL for the generated weekly image before Threads posting

--- a/core/social.py
+++ b/core/social.py
@@ -24,12 +24,13 @@ import mimetypes
 import os
 import re
 import shutil
+import tempfile
 import time
 import webbrowser
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, Mapping
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 import requests
@@ -63,6 +64,9 @@ LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://localhost:8080/v1")
 _LLM_CLIENT = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed")
 
 MAX_POST_CHARS = int(os.getenv("WEEKLY_SOCIAL_MAX_CHARS", "260"))
+
+THREADS_REFRESH_WINDOW_DAYS = int(os.getenv("THREADS_REFRESH_WINDOW_DAYS", "55"))
+THREADS_TOKEN_ENV_PATH = os.getenv("THREADS_TOKEN_ENV_PATH", ".env")
 
 _WEEKDAYS = {
     "monday": 0, "mon": 0,
@@ -384,10 +388,131 @@ def _post_x_via_aisa(text: str, image_path: Path | None) -> dict[str, Any]:
         return {"ok": False, "provider": "x", "error": str(e)}
 
 
-def _post_threads(text: str, image_url: str | None) -> dict[str, Any]:
+def _threads_config() -> tuple[str, str, str]:
     token = os.getenv("THREADS_ACCESS_TOKEN", "").strip()
     user_id = os.getenv("THREADS_USER_ID", "").strip()
     base = os.getenv("THREADS_API_BASE", "https://graph.threads.net/v1.0").rstrip("/")
+    return token, user_id, base
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    value = os.getenv(name)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
+def _token_seconds_remaining(expires_at: str | None = None) -> int | None:
+    raw = (expires_at or os.getenv("THREADS_ACCESS_TOKEN_EXPIRES_AT", "")).strip()
+    if not raw:
+        return None
+    try:
+        expiry = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError:
+        log.warning("Invalid THREADS_ACCESS_TOKEN_EXPIRES_AT: %s", raw)
+        return None
+    if expiry.tzinfo is None:
+        expiry = expiry.replace(tzinfo=timezone.utc)
+    return int((expiry.astimezone(timezone.utc) - datetime.now(timezone.utc)).total_seconds())
+
+
+def _write_env_values(env_path: str | Path, values: Mapping[str, str]) -> None:
+    path = Path(env_path).expanduser().resolve()
+    lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+    remaining = dict(values)
+    updated: list[str] = []
+    for line in lines:
+        stripped = line.lstrip()
+        if not stripped or stripped.startswith("#") or "=" not in line:
+            updated.append(line)
+            continue
+        key = line.split("=", 1)[0].strip().removeprefix("export ").strip()
+        if key in remaining:
+            updated.append(f"{key}={remaining.pop(key)}")
+        else:
+            updated.append(line)
+    for key, value in remaining.items():
+        updated.append(f"{key}={value}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=f".{path.name}.", dir=str(path.parent), text=True)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as tmp:
+            tmp.write("\n".join(updated).rstrip() + "\n")
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            os.unlink(tmp_name)
+
+
+def refresh_threads_token(
+    *,
+    token: str | None = None,
+    persist_env: bool = False,
+    env_path: str | Path | None = None,
+) -> dict[str, Any]:
+    """Refresh an unexpired long-lived Threads token and optionally persist it to an env file."""
+    current_token = (token or os.getenv("THREADS_ACCESS_TOKEN", "")).strip()
+    base = os.getenv("THREADS_API_BASE", "https://graph.threads.net/v1.0").rstrip("/")
+    if not current_token:
+        return {"ok": False, "provider": "threads", "error": "THREADS_ACCESS_TOKEN not set"}
+
+    try:
+        resp = requests.get(
+            f"{base}/refresh_access_token",
+            params={"grant_type": "th_refresh_token", "access_token": current_token},
+            timeout=120,
+        )
+        try:
+            payload: Any = resp.json()
+        except ValueError:
+            payload = {"raw": resp.text[:2000]}
+        ok = 200 <= resp.status_code < 300 and isinstance(payload, dict) and bool(payload.get("access_token"))
+        result: dict[str, Any] = {"ok": ok, "provider": "threads", "status_code": resp.status_code, "response": payload}
+        if not ok:
+            return result
+
+        new_token = str(payload["access_token"])
+        expires_in = int(payload.get("expires_in") or 0)
+        if expires_in > 0:
+            expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+            result["expires_at"] = expires_at.isoformat()
+            result["expires_in"] = expires_in
+        if persist_env:
+            values = {"THREADS_ACCESS_TOKEN": new_token}
+            if result.get("expires_at"):
+                values["THREADS_ACCESS_TOKEN_EXPIRES_AT"] = str(result["expires_at"])
+            _write_env_values(env_path or THREADS_TOKEN_ENV_PATH, values)
+            result["env_updated"] = str(Path(env_path or THREADS_TOKEN_ENV_PATH).expanduser().resolve())
+        os.environ["THREADS_ACCESS_TOKEN"] = new_token
+        if result.get("expires_at"):
+            os.environ["THREADS_ACCESS_TOKEN_EXPIRES_AT"] = str(result["expires_at"])
+        return result
+    except Exception as e:
+        return {"ok": False, "provider": "threads", "error": str(e)}
+
+
+def refresh_threads_token_if_due(*, persist_env: bool | None = None) -> dict[str, Any]:
+    seconds_remaining = _token_seconds_remaining()
+    threshold_seconds = THREADS_REFRESH_WINDOW_DAYS * 24 * 60 * 60
+    if seconds_remaining is not None and seconds_remaining > threshold_seconds:
+        return {
+            "ok": True,
+            "provider": "threads",
+            "skipped": True,
+            "reason": "not_due",
+            "seconds_remaining": seconds_remaining,
+        }
+    should_persist = _env_bool("THREADS_REFRESH_PERSIST_ENV", False) if persist_env is None else persist_env
+    result = refresh_threads_token(persist_env=should_persist)
+    result["seconds_remaining_before_refresh"] = seconds_remaining
+    return result
+
+
+def _post_threads(text: str, image_url: str | None) -> dict[str, Any]:
+    refresh_result = refresh_threads_token_if_due()
+    if not refresh_result.get("ok"):
+        return {"ok": False, "provider": "threads", "stage": "refresh", "refresh": refresh_result}
+    token, user_id, base = _threads_config()
     if not token or not user_id:
         return {"ok": False, "provider": "threads", "error": "THREADS_ACCESS_TOKEN or THREADS_USER_ID not set"}
 
@@ -466,12 +591,28 @@ def _cmd() -> int:
     parser.add_argument("--open-browser", action="store_true", help="open the AIsa/X authorization URL in a browser")
     parser.add_argument("--providers", default="", help="comma-separated providers overriding WEEKLY_SOCIAL_PROVIDERS")
     parser.add_argument("--copy-image-to", default="", help="copy draft image to a public hosting folder before posting")
+    parser.add_argument(
+        "--refresh-threads-token",
+        action="store_true",
+        help="refresh the configured long-lived Threads token",
+    )
+    parser.add_argument("--persist-env", action="store_true", help="write refreshed Threads token values back to THREADS_TOKEN_ENV_PATH/.env")
+    parser.add_argument("--env-path", default="", help="env file path used with --persist-env")
     args = parser.parse_args()
 
     providers = tuple(p.strip().lower() for p in args.providers.split(",") if p.strip()) or None
 
     if args.authorize_x:
         print(json.dumps(authorize_x(open_browser=args.open_browser), ensure_ascii=False, indent=2))
+        return 0
+    if args.refresh_threads_token:
+        print(
+            json.dumps(
+                refresh_threads_token(persist_env=args.persist_env, env_path=args.env_path or None),
+                ensure_ascii=False,
+                indent=2,
+            )
+        )
         return 0
     if args.draft:
         mem = AikoMemorize(silent=True)

--- a/core/social.py
+++ b/core/social.py
@@ -65,7 +65,16 @@ _LLM_CLIENT = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed")
 
 MAX_POST_CHARS = int(os.getenv("WEEKLY_SOCIAL_MAX_CHARS", "260"))
 
-THREADS_REFRESH_WINDOW_DAYS = int(os.getenv("THREADS_REFRESH_WINDOW_DAYS", "55"))
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except ValueError:
+        log.warning("Invalid integer env var %s; falling back to %s", name, default)
+        return default
+
+
+THREADS_REFRESH_WINDOW_DAYS = _int_env("THREADS_REFRESH_WINDOW_DAYS", 55)
 THREADS_TOKEN_ENV_PATH = os.getenv("THREADS_TOKEN_ENV_PATH", ".env")
 
 _WEEKDAYS = {
@@ -426,9 +435,12 @@ def _write_env_values(env_path: str | Path, values: Mapping[str, str]) -> None:
         if not stripped or stripped.startswith("#") or "=" not in line:
             updated.append(line)
             continue
-        key = line.split("=", 1)[0].strip().removeprefix("export ").strip()
+        lhs = line.split("=", 1)[0]
+        stripped_lhs = lhs.lstrip()
+        export_prefix = "export " if stripped_lhs.startswith("export ") else ""
+        key = stripped_lhs.removeprefix("export ").strip()
         if key in remaining:
-            updated.append(f"{key}={remaining.pop(key)}")
+            updated.append(f"{export_prefix}{key}={remaining.pop(key)}")
         else:
             updated.append(line)
     for key, value in remaining.items():
@@ -467,7 +479,15 @@ def refresh_threads_token(
         except ValueError:
             payload = {"raw": resp.text[:2000]}
         ok = 200 <= resp.status_code < 300 and isinstance(payload, dict) and bool(payload.get("access_token"))
-        result: dict[str, Any] = {"ok": ok, "provider": "threads", "status_code": resp.status_code, "response": payload}
+        safe_payload = dict(payload) if isinstance(payload, dict) else payload
+        if isinstance(safe_payload, dict) and "access_token" in safe_payload:
+            safe_payload["access_token"] = "[redacted]"
+        result: dict[str, Any] = {
+            "ok": ok,
+            "provider": "threads",
+            "status_code": resp.status_code,
+            "response": safe_payload,
+        }
         if not ok:
             return result
 
@@ -487,12 +507,19 @@ def refresh_threads_token(
         if result.get("expires_at"):
             os.environ["THREADS_ACCESS_TOKEN_EXPIRES_AT"] = str(result["expires_at"])
         return result
-    except Exception as e:
+    except (requests.RequestException, ValueError, OSError) as e:
         return {"ok": False, "provider": "threads", "error": str(e)}
 
 
 def refresh_threads_token_if_due(*, persist_env: bool | None = None) -> dict[str, Any]:
     seconds_remaining = _token_seconds_remaining()
+    if seconds_remaining is None:
+        return {
+            "ok": True,
+            "provider": "threads",
+            "skipped": True,
+            "reason": "expiry_unknown",
+        }
     threshold_seconds = THREADS_REFRESH_WINDOW_DAYS * 24 * 60 * 60
     if seconds_remaining is not None and seconds_remaining > threshold_seconds:
         return {
@@ -606,14 +633,15 @@ def _cmd() -> int:
         print(json.dumps(authorize_x(open_browser=args.open_browser), ensure_ascii=False, indent=2))
         return 0
     if args.refresh_threads_token:
+        result = refresh_threads_token(persist_env=args.persist_env, env_path=args.env_path or None)
         print(
             json.dumps(
-                refresh_threads_token(persist_env=args.persist_env, env_path=args.env_path or None),
+                result,
                 ensure_ascii=False,
                 indent=2,
             )
         )
-        return 0
+        return 0 if result.get("ok") else 1
     if args.draft:
         mem = AikoMemorize(silent=True)
         print(json.dumps(generate_weekly_draft(mem, force=args.force), ensure_ascii=False, indent=2))

--- a/tests/test_social_threads.py
+++ b/tests/test_social_threads.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.modules.setdefault("requests", MagicMock())
+sys.modules.setdefault("openai", MagicMock())
+sys.modules.setdefault("dotenv", MagicMock(load_dotenv=lambda: None))
+
+mock_log_module = MagicMock()
+mock_log_module.get_logger.return_value = MagicMock()
+sys.modules.setdefault("core.log", mock_log_module)
+mock_memorize_module = MagicMock()
+mock_memorize_module.AikoMemorize = MagicMock
+mock_memorize_module.USER_ID = "test-user"
+sys.modules.setdefault("core.memorize", mock_memorize_module)
+mock_reflect_module = MagicMock()
+mock_reflect_module._generate_image.return_value = ""
+mock_reflect_module._load_soul.return_value = ""
+sys.modules.setdefault("core.reflect", mock_reflect_module)
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core import social
+
+
+class DummyResponse:
+    def __init__(self, status_code: int, payload: dict[str, object]):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = str(payload)
+
+    def json(self) -> dict[str, object]:
+        return self._payload
+
+
+def test_refresh_threads_token_updates_process_env_and_optional_env_file(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_get(url, params, timeout):
+        calls.append((url, params, timeout))
+        return DummyResponse(200, {"access_token": "new-token", "expires_in": 5_184_000})
+
+    env_path = tmp_path / ".env"
+    env_path.write_text("THREADS_ACCESS_TOKEN=old-token\nKEEP=value\n", encoding="utf-8")
+    monkeypatch.setenv("THREADS_ACCESS_TOKEN", "old-token")
+    monkeypatch.setenv("THREADS_API_BASE", "https://graph.threads.net/v1.0")
+    monkeypatch.setattr(social.requests, "get", fake_get)
+
+    result = social.refresh_threads_token(persist_env=True, env_path=env_path)
+
+    assert result["ok"] is True
+    assert result["expires_in"] == 5_184_000
+    assert calls == [
+        (
+            "https://graph.threads.net/v1.0/refresh_access_token",
+            {"grant_type": "th_refresh_token", "access_token": "old-token"},
+            120,
+        )
+    ]
+    assert social.os.environ["THREADS_ACCESS_TOKEN"] == "new-token"
+    written = env_path.read_text(encoding="utf-8")
+    assert "THREADS_ACCESS_TOKEN=new-token" in written
+    assert "THREADS_ACCESS_TOKEN_EXPIRES_AT=" in written
+    assert "KEEP=value" in written
+
+
+def test_refresh_threads_token_if_due_skips_when_expiry_is_after_threshold(monkeypatch):
+    future = datetime.now(timezone.utc) + timedelta(days=59)
+    monkeypatch.setenv("THREADS_ACCESS_TOKEN_EXPIRES_AT", future.isoformat())
+    monkeypatch.setattr(social, "THREADS_REFRESH_WINDOW_DAYS", 55)
+
+    def fail_refresh(**kwargs):  # pragma: no cover - should never be called
+        raise AssertionError("refresh should not be called")
+
+    monkeypatch.setattr(social, "refresh_threads_token", fail_refresh)
+
+    result = social.refresh_threads_token_if_due()
+
+    assert result["ok"] is True
+    assert result["skipped"] is True
+    assert result["reason"] == "not_due"
+
+
+def test_refresh_threads_token_if_due_refreshes_inside_threshold(monkeypatch):
+    future = datetime.now(timezone.utc) + timedelta(days=50)
+    monkeypatch.setenv("THREADS_ACCESS_TOKEN_EXPIRES_AT", future.isoformat())
+    monkeypatch.setattr(social, "THREADS_REFRESH_WINDOW_DAYS", 55)
+
+    def fake_refresh(*, persist_env=False):
+        return {"ok": True, "persist_env": persist_env}
+
+    monkeypatch.setattr(social, "refresh_threads_token", fake_refresh)
+
+    result = social.refresh_threads_token_if_due(persist_env=True)
+
+    assert result["ok"] is True
+    assert result["persist_env"] is True
+    assert result["seconds_remaining_before_refresh"] is not None

--- a/tests/test_social_threads.py
+++ b/tests/test_social_threads.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 import os
 import sys
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-sys.modules.setdefault("requests", MagicMock())
+mock_requests = SimpleNamespace(get=MagicMock(), post=MagicMock(), RequestException=RuntimeError)
+sys.modules.setdefault("requests", mock_requests)
 sys.modules.setdefault("openai", MagicMock())
 sys.modules.setdefault("dotenv", MagicMock(load_dotenv=lambda: None))
 
@@ -44,7 +46,7 @@ def test_refresh_threads_token_updates_process_env_and_optional_env_file(monkeyp
         return DummyResponse(200, {"access_token": "new-token", "expires_in": 5_184_000})
 
     env_path = tmp_path / ".env"
-    env_path.write_text("THREADS_ACCESS_TOKEN=old-token\nKEEP=value\n", encoding="utf-8")
+    env_path.write_text("export THREADS_ACCESS_TOKEN=old-token\nKEEP=value\n", encoding="utf-8")
     monkeypatch.setenv("THREADS_ACCESS_TOKEN", "old-token")
     monkeypatch.setenv("THREADS_API_BASE", "https://graph.threads.net/v1.0")
     monkeypatch.setattr(social.requests, "get", fake_get)
@@ -53,6 +55,7 @@ def test_refresh_threads_token_updates_process_env_and_optional_env_file(monkeyp
 
     assert result["ok"] is True
     assert result["expires_in"] == 5_184_000
+    assert result["response"]["access_token"] == "[redacted]"
     assert calls == [
         (
             "https://graph.threads.net/v1.0/refresh_access_token",
@@ -62,9 +65,42 @@ def test_refresh_threads_token_updates_process_env_and_optional_env_file(monkeyp
     ]
     assert social.os.environ["THREADS_ACCESS_TOKEN"] == "new-token"
     written = env_path.read_text(encoding="utf-8")
-    assert "THREADS_ACCESS_TOKEN=new-token" in written
+    assert "export THREADS_ACCESS_TOKEN=new-token" in written
     assert "THREADS_ACCESS_TOKEN_EXPIRES_AT=" in written
     assert "KEEP=value" in written
+    assert "new-token" not in str(result["response"])
+
+
+def test_refresh_threads_token_failure_leaves_env_and_file_untouched(monkeypatch, tmp_path):
+    def fake_get(url, params, timeout):
+        return DummyResponse(400, {"error": "too early"})
+
+    env_path = tmp_path / ".env"
+    original_env = "THREADS_ACCESS_TOKEN=old-token\nKEEP=value\n"
+    env_path.write_text(original_env, encoding="utf-8")
+    monkeypatch.setenv("THREADS_ACCESS_TOKEN", "old-token")
+    monkeypatch.setattr(social.requests, "get", fake_get)
+
+    result = social.refresh_threads_token(persist_env=True, env_path=env_path)
+
+    assert result["ok"] is False
+    assert social.os.environ["THREADS_ACCESS_TOKEN"] == "old-token"
+    assert env_path.read_text(encoding="utf-8") == original_env
+
+
+def test_refresh_threads_token_if_due_skips_when_expiry_is_unknown(monkeypatch):
+    monkeypatch.delenv("THREADS_ACCESS_TOKEN_EXPIRES_AT", raising=False)
+
+    def fail_refresh(**kwargs):  # pragma: no cover - should never be called
+        raise AssertionError("refresh should not be called")
+
+    monkeypatch.setattr(social, "refresh_threads_token", fail_refresh)
+
+    result = social.refresh_threads_token_if_due()
+
+    assert result["ok"] is True
+    assert result["skipped"] is True
+    assert result["reason"] == "expiry_unknown"
 
 
 def test_refresh_threads_token_if_due_skips_when_expiry_is_after_threshold(monkeypatch):
@@ -99,3 +135,13 @@ def test_refresh_threads_token_if_due_refreshes_inside_threshold(monkeypatch):
     assert result["ok"] is True
     assert result["persist_env"] is True
     assert result["seconds_remaining_before_refresh"] is not None
+
+
+def test_refresh_threads_token_cli_returns_nonzero_on_failure(monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", ["social.py", "--refresh-threads-token"])
+    monkeypatch.setattr(social, "refresh_threads_token", lambda **kwargs: {"ok": False, "error": "bad token"})
+
+    exit_code = social._cmd()
+
+    assert exit_code == 1
+    assert '"ok": false' in capsys.readouterr().out


### PR DESCRIPTION
### Motivation
- Ensure long-lived Threads access tokens are refreshed before they expire so scheduled posting does not fail. 
- Provide a configurable refresh window and optional persistence to an `.env` file so token rotation can be automated without manual edits. 
- Allow manual CLI-driven refreshes for testing or one-off updates when `.env` is not available.

### Description
- Add `THREADS_REFRESH_WINDOW_DAYS` and `THREADS_TOKEN_ENV_PATH` configuration and helper `_threads_config()` to centralize Threads settings. 
- Implement token helpers: `_token_seconds_remaining()`, `_env_bool()`, `_write_env_values()`, `refresh_threads_token()` and `refresh_threads_token_if_due()` that call Meta’s `refresh_access_token` endpoint, update process env, and optionally persist values to an env file. 
- Wire a pre-post check so `_post_threads()` calls `refresh_threads_token_if_due()` and fails fast if refresh fails or is required. 
- Add CLI flags `--refresh-threads-token`, `--persist-env`, and `--env-path` to allow manual refresh and optional env persistence, and add tests in `tests/test_social_threads.py` covering refresh, persistence, and due-window skipping.

### Testing
- `python -m py_compile core/social.py` succeeded and confirms the module compiles. 
- `pytest -q tests/test_social_threads.py` ran the new unit tests and they all passed (`3 passed`). 
- `uv run pytest -q tests/test_social_threads.py` failed due to a local build dependency (`onnxruntime` wheel) missing from the environment and is unrelated to the changes here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4559ccabc0832c98d1de0039541ebc)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Threads token refresh support for autoposting, including automatic refresh when a token is nearing expiration.
  * Added CLI options to refresh the Threads token manually and optionally save updated values to an environment file.

* **Bug Fixes**
  * Improved posting flow so refresh happens before publishing, reducing failures caused by expired tokens.
  * Updated token values in the running environment immediately after refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->