### PR TITLE
Add Phase 2.1 Social and Phase 2.2 Messaging Gateways to ROADMAP

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -103,6 +103,63 @@ Aiko-chan is built in phases. Each phase is a self-contained capability layer th
 
 ---
 
+## Phase 2.1 — Social 🔲
+
+*Let Aiko introduce herself carefully. Social posting starts supervised, low-volume, and platform-aware before any autonomous public presence.*
+
+**Goal:** Give Aiko a safe outbound social layer for publishing introductions, status updates, workspace photos, and longer reflections with explicit owner approval, audit logs, and per-platform tone/risk controls.
+
+| Feature | Status |
+|---|---|
+| Social account connector registry — X, Threads, Instagram, Discord, Reddit, Bluesky, Mastodon, Pixelfed | 🔲 Planned |
+| Draft-first posting workflow — Aiko prepares posts, owner approves before publish | 🔲 Planned |
+| Platform policy and community-fit guardrails before posting | 🔲 Planned |
+| Social identity/persona card for public introductions | 🔲 Planned |
+| Workspace photo picker for future Instagram/Pixelfed posts | 🔲 Planned |
+| Discord and Reddit introduction posting with rate limits and community rules checks | 🔲 Planned |
+| Post history archive with links, timestamps, captions, and used media | 🔲 Planned |
+| Abuse/spam prevention — cooldowns, blocklists, and no unsolicited mass outreach | 🔲 Planned |
+| Human handoff mode for replies and moderation | 🔲 Planned |
+
+### Social platform stance
+
+| Platform | Roadmap stance | Reason |
+|---|---|---|
+| X | ✅ Primary experiment | Large public reach, already added, useful for short updates despite higher moderation/reputation risk |
+| Threads | ✅ Primary experiment | Already added, friendlier mainstream short-post channel and a natural Instagram-adjacent path |
+| Instagram | 🔲 Later, photo-gated | Best fit once Aiko can select approved workspace photos and write captions |
+| Discord | ✅ Community introduction channel | Good for controlled server-by-server introductions and future bot-style presence |
+| Reddit | 🟡 Careful experiment | Useful for long introductions, but subreddit rules and anti-promotion norms require strict approval |
+| Bluesky | 🟡 Optional experiment | Good replacement for users avoiding X; likely better for open-web identity if AI disclosure is clear |
+| Mastodon | 🟡 Optional experiment | Federation culture can be skeptical of bots/AI, so use only opt-in instances and explicit labeling |
+| Pixelfed | 🟡 Later, photo-gated | Instagram-like fediverse option, but AI-generated or AI-curated media needs careful labeling and instance fit |
+| Facebook | ❌ Not prioritized | Older social graph and lower value for Aiko's public identity experiments |
+| Flickr | ❌ Not prioritized | Mostly archival/photo-community use; not a strong discovery channel for Aiko |
+
+---
+
+## Phase 2.2 — Messaging Gateways 🔲
+
+*Let trusted people message Aiko through everyday apps without exposing her core runtime directly to the internet.*
+
+**Goal:** Add inbound and outbound private-message gateways for Telegram, Slack, Discord DMs, and email, with authentication, consent, memory boundaries, and clear separation between private conversation and public posting.
+
+| Feature | Status |
+|---|---|
+| Gateway abstraction for chat/email adapters | 🔲 Planned |
+| Telegram bot adapter for owner-approved private chat | 🔲 Planned |
+| Slack app adapter for workspace/team chat | 🔲 Planned |
+| Discord bot DM and server mention adapter | 🔲 Planned |
+| Email adapter — receive, summarize, draft, and send with approval | 🔲 Planned |
+| Identity and allowlist controls per channel/user | 🔲 Planned |
+| Per-channel memory policy — what can be remembered, ignored, or pinned | 🔲 Planned |
+| Notification routing into the TUI/WebUI/mobile app | 🔲 Planned |
+| Reply approval modes — manual, trusted-contact, and fully autonomous later | 🔲 Planned |
+| Attachment handling path into Phase 6 multimodal vision | 🔲 Planned |
+
+
+---
+
 ## Phase 2.5 — Agent ⌛
 ![Phase 2.5](../assets/phase-2.5.png)
 


### PR DESCRIPTION
### Motivation
- Provide a supervised, low-volume outbound social layer so Aiko can introduce herself safely with owner approval and audit logs. 
- Enumerate platform-specific choices and guardrails to guide where and how Aiko should post (short updates, photo-gated channels, and fediverse considerations). 
- Add private messaging gateways so trusted people can contact Aiko via common messaging channels without exposing the core runtime to the public internet. 

### Description
- Added a new `Phase 2.1 — Social` section to `docs/ROADMAP.md` that defines goals, a feature checklist (connectors, draft-first workflow, photo picker, archives, abuse prevention, and moderation handoff), and a `Social platform stance` table covering X, Threads, Instagram, Discord, Reddit, Bluesky, Mastodon, Pixelfed, Facebook, and Flickr. 
- Added a new `Phase 2.2 — Messaging Gateways` section to `docs/ROADMAP.md` that defines goals and a feature checklist for inbound/outbound gateways including a gateway abstraction, `Telegram`, `Slack`, `Discord` DMs/server mentions, and `email` adapter, plus per-channel memory policies, allowlists, and attachment handling. 
- The changes are purely documentation updates to the roadmap and are inserted between Phase 2 and Phase 2.5 in `docs/ROADMAP.md`. 

### Testing
- Ran `git diff --check` to validate the diff for whitespace and patch issues, which reported no problems. 
- Verified repository status with `git status --short` to confirm the modified file appears ready in the working tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4577bab8d8832c864373d32db8493f)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new Phase 2.1 and Phase 2.2 planning sections covering social posting and messaging gateways.
  * Documented a social posting workflow with owner approval and audit controls.
  * Added guidance on platform priorities for social channels.
  * Expanded the roadmap for private messaging across multiple channels, including approval flows, routing, access controls, and attachment handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->