### PR TITLE
Add proactive idle check-ins with toggleable config and UI integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ uv run python main.py --clear-mem # wipe all memories and exit
 | `/web <query>` | SearXNG search → grounded answer |
 | `/voice` | Toggle TTS on/off |
 | `/listen` | Toggle ASR on/off |
+| `/proactive` | Toggle proactive idle check-ins on/off; timing is configured in `config/proactive.yaml` |
 | `/help` | Show the command list |
 
 ---

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ uv run python main.py --clear-mem # wipe all memories and exit
 | `/web <query>` | SearXNG search → grounded answer |
 | `/voice` | Toggle TTS on/off |
 | `/listen` | Toggle ASR on/off |
-| `/proactive` | Toggle proactive idle check-ins on/off; timing is configured in `config/proactive.yaml` |
+| `/proactive` | Toggle proactive idle check-ins on/off; timing, quiet/focus windows, and prompt hints are configured in `config/proactive.yaml` |
 | `/help` | Show the command list |
 
 ---

--- a/config/index.yaml
+++ b/config/index.yaml
@@ -12,6 +12,7 @@ configs:
 - web.yaml  # SearXNG/search
 - ui.yaml  # TUI/WebUI display and ports
 - schedule.yaml  # scheduler paths and system job times
+- proactive.yaml  # proactive idle check-ins
 - reflect.yaml  # reflection publishing
 - social.yaml  # weekly social drafting/posting
 - log.yaml  # logging and health cache

--- a/config/proactive.yaml
+++ b/config/proactive.yaml
@@ -10,18 +10,20 @@ PROACTIVE_FIRST_IDLE_MAX_SECONDS: "900"  # Latest first check-in after user acti
 PROACTIVE_COOLDOWN_SECONDS: "1800"  # Minimum seconds between proactive check-ins.
 PROACTIVE_MAX_PER_HOUR: "2"  # Hard cap for proactive check-ins in a rolling hour.
 PROACTIVE_REST_AFTER_SECONDS: "3600"  # After this much idle time, Aiko sends one rest note then stays quiet.
-PROACTIVE_USE_LLM: "0"  # Set to 1 to use prompt hints below so the LLM can vary the final wording.
+PROACTIVE_USE_LLM: "1"  # Use prompt hints below so the LLM can vary the final wording.
 PROACTIVE_TIMEZONE: ""  # Blank inherits TIMEZONE from config/schedule.yaml; set an IANA timezone to override.
 PROACTIVE_QUIET_WINDOWS:
   - "00:00-06:00"  # Daily quiet hours.
-PROACTIVE_FOCUS_WINDOWS: []  # Optional, e.g. ["mon-fri 09:00-17:00", "sat-sun 06:00-11:00"].
+PROACTIVE_FOCUS_WINDOWS:
+  - "mon-fri 06:00-19:00"  # Work/focus block.
+  - "sat-sun 06:00-11:00"  # Weekend morning focus block.
 PROACTIVE_SPEAK: "1"  # Speak the check-in aloud when TTS is currently enabled.
 PROACTIVE_REST_MESSAGE: "You've been away for a while so I'll go quiet and rest. Ping me when you need me."
 PROACTIVE_PROMPT_HINTS:
-  - "The user has not spoken to you for a while. What short gentle thing do you want to say now?"
-  - "The user has been quiet for a while. Offer company without being needy or disruptive."
-  - "The user may be focused or away. Say one brief check-in and make it easy to ignore."
-PROACTIVE_REST_PROMPT_HINT: "The user has not spoken to you for about an hour. Say one short warm line that you are going quiet and resting until they return."
+  - "{user} has not spoken to you for a while. What short gentle thing do you want to say now?"
+  - "{user} has been quiet for a while. Offer company without being needy or disruptive."
+  - "{user} may be focused or away. Say one brief check-in and make it easy to ignore."
+PROACTIVE_REST_PROMPT_HINT: "{user} has not spoken to you for about an hour. Say one short warm line that you are going quiet and resting until they return."
 PROACTIVE_MESSAGES:
   - "You've been quiet for a bit. Still with me?"
   - "Checking in. Do you want focus time or should I keep you company?"

--- a/config/proactive.yaml
+++ b/config/proactive.yaml
@@ -9,7 +9,6 @@ PROACTIVE_FIRST_IDLE_MIN_SECONDS: "300"  # Earliest first check-in after user ac
 PROACTIVE_FIRST_IDLE_MAX_SECONDS: "900"  # Latest first check-in after user activity; 900 = 15 minutes.
 PROACTIVE_COOLDOWN_SECONDS: "1800"  # Minimum seconds between proactive check-ins.
 PROACTIVE_MAX_PER_HOUR: "2"  # Hard cap for proactive check-ins in a rolling hour.
-PROACTIVE_POLL_SECONDS: "5"  # Background monitor cadence.
 PROACTIVE_REST_AFTER_SECONDS: "3600"  # After this much idle time, Aiko sends one rest note then stays quiet.
 PROACTIVE_USE_LLM: "1"  # Use prompt hints below so the LLM can vary the final wording.
 PROACTIVE_TIMEZONE: "America/Vancouver"  # Timezone used for quiet/focus windows.

--- a/config/proactive.yaml
+++ b/config/proactive.yaml
@@ -10,20 +10,18 @@ PROACTIVE_FIRST_IDLE_MAX_SECONDS: "900"  # Latest first check-in after user acti
 PROACTIVE_COOLDOWN_SECONDS: "1800"  # Minimum seconds between proactive check-ins.
 PROACTIVE_MAX_PER_HOUR: "2"  # Hard cap for proactive check-ins in a rolling hour.
 PROACTIVE_REST_AFTER_SECONDS: "3600"  # After this much idle time, Aiko sends one rest note then stays quiet.
-PROACTIVE_USE_LLM: "1"  # Use prompt hints below so the LLM can vary the final wording.
-PROACTIVE_TIMEZONE: "America/Vancouver"  # Timezone used for quiet/focus windows.
+PROACTIVE_USE_LLM: "0"  # Set to 1 to use prompt hints below so the LLM can vary the final wording.
+PROACTIVE_TIMEZONE: ""  # Blank inherits TIMEZONE from config/schedule.yaml; set an IANA timezone to override.
 PROACTIVE_QUIET_WINDOWS:
   - "00:00-06:00"  # Daily quiet hours.
-PROACTIVE_FOCUS_WINDOWS:
-  - "mon-fri 06:00-19:00"  # Work/focus block.
-  - "sat-sun 06:00-11:00"  # Weekend morning focus block.
+PROACTIVE_FOCUS_WINDOWS: []  # Optional, e.g. ["mon-fri 09:00-17:00", "sat-sun 06:00-11:00"].
 PROACTIVE_SPEAK: "1"  # Speak the check-in aloud when TTS is currently enabled.
 PROACTIVE_REST_MESSAGE: "You've been away for a while so I'll go quiet and rest. Ping me when you need me."
 PROACTIVE_PROMPT_HINTS:
-  - "Oppa has not spoken to you for a while. What short gentle thing do you want to say to him now?"
-  - "Oppa has been quiet for a while. Offer company without being needy or disruptive."
-  - "Oppa may be focused or away. Say one brief check-in and make it easy for him to ignore you."
-PROACTIVE_REST_PROMPT_HINT: "Oppa has not spoken to you for about an hour. Say one short warm line that you are going quiet and resting until he returns."
+  - "The user has not spoken to you for a while. What short gentle thing do you want to say now?"
+  - "The user has been quiet for a while. Offer company without being needy or disruptive."
+  - "The user may be focused or away. Say one brief check-in and make it easy to ignore."
+PROACTIVE_REST_PROMPT_HINT: "The user has not spoken to you for about an hour. Say one short warm line that you are going quiet and resting until they return."
 PROACTIVE_MESSAGES:
   - "You've been quiet for a bit. Still with me?"
   - "Checking in. Do you want focus time or should I keep you company?"

--- a/config/proactive.yaml
+++ b/config/proactive.yaml
@@ -11,8 +11,20 @@ PROACTIVE_COOLDOWN_SECONDS: "1800"  # Minimum seconds between proactive check-in
 PROACTIVE_MAX_PER_HOUR: "2"  # Hard cap for proactive check-ins in a rolling hour.
 PROACTIVE_POLL_SECONDS: "5"  # Background monitor cadence.
 PROACTIVE_REST_AFTER_SECONDS: "3600"  # After this much idle time, Aiko sends one rest note then stays quiet.
+PROACTIVE_USE_LLM: "1"  # Use prompt hints below so the LLM can vary the final wording.
+PROACTIVE_TIMEZONE: "America/Vancouver"  # Timezone used for quiet/focus windows.
+PROACTIVE_QUIET_WINDOWS:
+  - "00:00-06:00"  # Daily quiet hours.
+PROACTIVE_FOCUS_WINDOWS:
+  - "mon-fri 06:00-19:00"  # Work/focus block.
+  - "sat-sun 06:00-11:00"  # Weekend morning focus block.
 PROACTIVE_SPEAK: "1"  # Speak the check-in aloud when TTS is currently enabled.
 PROACTIVE_REST_MESSAGE: "You've been away for a while so I'll go quiet and rest. Ping me when you need me."
+PROACTIVE_PROMPT_HINTS:
+  - "Oppa has not spoken to you for a while. What short gentle thing do you want to say to him now?"
+  - "Oppa has been quiet for a while. Offer company without being needy or disruptive."
+  - "Oppa may be focused or away. Say one brief check-in and make it easy for him to ignore you."
+PROACTIVE_REST_PROMPT_HINT: "Oppa has not spoken to you for about an hour. Say one short warm line that you are going quiet and resting until he returns."
 PROACTIVE_MESSAGES:
   - "You've been quiet for a bit. Still with me?"
   - "Checking in. Do you want focus time or should I keep you company?"

--- a/config/proactive.yaml
+++ b/config/proactive.yaml
@@ -1,0 +1,20 @@
+# Settings for Aiko's proactive idle check-ins.
+#
+# These are intentionally conservative: Aiko may gently reach out when the
+# session has been quiet for a while, but she should not spam, interrupt an
+# active turn, or require any WebUI vision/screen feature.
+
+PROACTIVE_ENABLED: "1"  # Set to 0/false/off to disable idle check-ins.
+PROACTIVE_FIRST_IDLE_MIN_SECONDS: "300"  # Earliest first check-in after user activity; 300 = 5 minutes.
+PROACTIVE_FIRST_IDLE_MAX_SECONDS: "900"  # Latest first check-in after user activity; 900 = 15 minutes.
+PROACTIVE_COOLDOWN_SECONDS: "1800"  # Minimum seconds between proactive check-ins.
+PROACTIVE_MAX_PER_HOUR: "2"  # Hard cap for proactive check-ins in a rolling hour.
+PROACTIVE_POLL_SECONDS: "5"  # Background monitor cadence.
+PROACTIVE_REST_AFTER_SECONDS: "3600"  # After this much idle time, Aiko sends one rest note then stays quiet.
+PROACTIVE_SPEAK: "1"  # Speak the check-in aloud when TTS is currently enabled.
+PROACTIVE_REST_MESSAGE: "You've been away for a while so I'll go quiet and rest. Ping me when you need me."
+PROACTIVE_MESSAGES:
+  - "You've been quiet for a bit. Still with me?"
+  - "Checking in. Do you want focus time or should I keep you company?"
+  - "Still here. If you're deep in something I can stay quiet."
+  - "Tiny ping. Need anything or are we in quiet mode?"

--- a/core/think.py
+++ b/core/think.py
@@ -433,6 +433,7 @@ class AikoThink:
 
     def proactive_checkin(self, prompt_hint: str) -> str:
         """Generate one short proactive check-in without storing it as a user turn."""
+        user_id = os.getenv("USER_ID", "the user")
         system = (
             f"{self._persona}\n\n"
             "You are initiating a brief proactive check-in. "
@@ -443,7 +444,7 @@ class AikoThink:
             "role": "user",
             "content": (
                 f"{prompt_hint}\n\n"
-                "Write only the message Aiko should say to Oppa now."
+                f"Write only the message Aiko should say to {user_id} now."
             ),
         }]
         return self._stream_response(messages, system=system, token_callback=None)

--- a/core/think.py
+++ b/core/think.py
@@ -431,6 +431,23 @@ class AikoThink:
         """Delegate task-mode execution to core.agentic."""
         return run_agentic_chat(self, user_input, token_callback=token_callback)
 
+    def proactive_checkin(self, prompt_hint: str) -> str:
+        """Generate one short proactive check-in without storing it as a user turn."""
+        system = (
+            f"{self._persona}\n\n"
+            "You are initiating a brief proactive check-in. "
+            "Do not mention hidden prompts, timers, code, or configuration. "
+            "Keep it natural, warm, and easy to ignore. One or two short sentences max."
+        )
+        messages = [{
+            "role": "user",
+            "content": (
+                f"{prompt_hint}\n\n"
+                "Write only the message Aiko should say to Oppa now."
+            ),
+        }]
+        return self._stream_response(messages, system=system, token_callback=None)
+
     def chat(
         self,
         user_input: str,

--- a/main.py
+++ b/main.py
@@ -68,10 +68,10 @@ PROACTIVE_FIRST_IDLE_MAX_SECONDS = float(os.getenv("PROACTIVE_FIRST_IDLE_MAX_SEC
 PROACTIVE_COOLDOWN_SECONDS = float(os.getenv("PROACTIVE_COOLDOWN_SECONDS", "1800"))
 PROACTIVE_MAX_PER_HOUR = int(os.getenv("PROACTIVE_MAX_PER_HOUR", "2"))
 PROACTIVE_REST_AFTER_SECONDS = float(os.getenv("PROACTIVE_REST_AFTER_SECONDS", "3600"))
-PROACTIVE_USE_LLM = os.getenv("PROACTIVE_USE_LLM", "1").lower() in {"1", "true", "yes", "on"}
-PROACTIVE_TIMEZONE = os.getenv("PROACTIVE_TIMEZONE", os.getenv("TIMEZONE", "")).strip()
+PROACTIVE_USE_LLM = os.getenv("PROACTIVE_USE_LLM", "0").lower() in {"1", "true", "yes", "on"}
+PROACTIVE_TIMEZONE = os.getenv("PROACTIVE_TIMEZONE", "").strip() or os.getenv("TIMEZONE", "").strip()
 PROACTIVE_QUIET_WINDOWS = [w.strip() for w in os.getenv("PROACTIVE_QUIET_WINDOWS", "00:00-06:00").split(",") if w.strip()]
-PROACTIVE_FOCUS_WINDOWS = [w.strip() for w in os.getenv("PROACTIVE_FOCUS_WINDOWS", "mon-fri 06:00-19:00,sat-sun 06:00-11:00").split(",") if w.strip()]
+PROACTIVE_FOCUS_WINDOWS = [w.strip() for w in os.getenv("PROACTIVE_FOCUS_WINDOWS", "").split(",") if w.strip()]
 PROACTIVE_SPEAK = os.getenv("PROACTIVE_SPEAK", "1").lower() in {"1", "true", "yes", "on"}
 PROACTIVE_MESSAGES = [
     msg.strip()
@@ -92,15 +92,15 @@ PROACTIVE_PROMPT_HINTS = [
     msg.strip()
     for msg in os.getenv(
         "PROACTIVE_PROMPT_HINTS",
-        "Oppa has not spoken to you for a while. What short gentle thing do you want to say to him now?,"
-        "Oppa has been quiet for a while. Offer company without being needy or disruptive.,"
-        "Oppa may be focused or away. Say one brief check-in and make it easy for him to ignore you.",
+        f"{USER_ID or 'the user'} has not spoken to you for a while. What short gentle thing do you want to say now?,"
+        f"{USER_ID or 'the user'} has been quiet for a while. Offer company without being needy or disruptive.,"
+        f"{USER_ID or 'the user'} may be focused or away. Say one brief check-in and make it easy to ignore.",
     ).split(",")
     if msg.strip()
 ]
 PROACTIVE_REST_PROMPT_HINT = os.getenv(
     "PROACTIVE_REST_PROMPT_HINT",
-    "Oppa has not spoken to you for about an hour. Say one short warm line that you are going quiet and resting until he returns.",
+    f"{USER_ID or 'the user'} has not spoken to you for about an hour. Say one short warm line that you are going quiet and resting until they return.",
 ).strip()
 
 
@@ -294,7 +294,7 @@ class ProactiveIdleRunner:
 
     def _next_prompt_hint(self) -> str:
         hints = PROACTIVE_PROMPT_HINTS or [
-            "Oppa has not spoken to you for a while. What short gentle thing do you want to say to him now?"
+            f"{USER_ID or 'the user'} has not spoken to you for a while. What short gentle thing do you want to say now?"
         ]
         hint = hints[self._message_index % len(hints)]
         self._message_index += 1

--- a/main.py
+++ b/main.py
@@ -27,7 +27,7 @@ load_config()
 
 import argparse
 import collections
-from datetime import datetime
+from datetime import datetime, timedelta
 import difflib
 import os
 import random
@@ -67,7 +67,6 @@ PROACTIVE_FIRST_IDLE_MIN_SECONDS = float(os.getenv("PROACTIVE_FIRST_IDLE_MIN_SEC
 PROACTIVE_FIRST_IDLE_MAX_SECONDS = float(os.getenv("PROACTIVE_FIRST_IDLE_MAX_SECONDS", "900"))
 PROACTIVE_COOLDOWN_SECONDS = float(os.getenv("PROACTIVE_COOLDOWN_SECONDS", "1800"))
 PROACTIVE_MAX_PER_HOUR = int(os.getenv("PROACTIVE_MAX_PER_HOUR", "2"))
-PROACTIVE_POLL_SECONDS = float(os.getenv("PROACTIVE_POLL_SECONDS", "5"))
 PROACTIVE_REST_AFTER_SECONDS = float(os.getenv("PROACTIVE_REST_AFTER_SECONDS", "3600"))
 PROACTIVE_USE_LLM = os.getenv("PROACTIVE_USE_LLM", "1").lower() in {"1", "true", "yes", "on"}
 PROACTIVE_TIMEZONE = os.getenv("PROACTIVE_TIMEZONE", os.getenv("TIMEZONE", "")).strip()
@@ -208,6 +207,27 @@ def _in_proactive_silence_window() -> bool:
     )
 
 
+def _seconds_until_proactive_silence_ends() -> float:
+    """Return seconds until configured quiet/focus windows no longer match."""
+    try:
+        now = datetime.now(ZoneInfo(PROACTIVE_TIMEZONE)) if PROACTIVE_TIMEZONE else datetime.now()
+    except ZoneInfoNotFoundError:
+        now = datetime.now()
+
+    windows = [*PROACTIVE_QUIET_WINDOWS, *PROACTIVE_FOCUS_WINDOWS]
+    if not any(_time_window_matches(window, now) for window in windows):
+        return 0.0
+
+    # Window definitions are minute-granular, so scan minute boundaries instead
+    # of waking every few seconds while Aiko is configured to be quiet.
+    cursor = now.replace(second=0, microsecond=0) + timedelta(minutes=1)
+    for _ in range(8 * 24 * 60):  # enough to cover weekly wraparound windows
+        if not any(_time_window_matches(window, cursor) for window in windows):
+            return max(1.0, (cursor - now).total_seconds())
+        cursor += timedelta(minutes=1)
+    return 3600.0
+
+
 class ProactiveIdleRunner:
     """Lightweight monitor that lets Aiko send gentle idle check-ins.
 
@@ -224,6 +244,7 @@ class ProactiveIdleRunner:
         self._active_turn = active_turn
         self._generate_fn = generate_fn
         self._stop = threading.Event()
+        self._wakeup = threading.Event()
         self._lock = threading.Lock()
         self._last_activity = time.monotonic()
         self._last_prompt = 0.0
@@ -242,6 +263,7 @@ class ProactiveIdleRunner:
 
     def stop(self) -> None:
         self._stop.set()
+        self._wakeup.set()
         if self._thread and self._thread.is_alive():
             self._thread.join(timeout=2.0)
 
@@ -250,6 +272,7 @@ class ProactiveIdleRunner:
             self._last_activity = time.monotonic()
             self._next_checkin_after = self._random_first_idle_delay()
             self._resting = False
+        self._wakeup.set()
 
     def set_enabled(self, enabled: bool) -> None:
         with self._lock:
@@ -257,6 +280,7 @@ class ProactiveIdleRunner:
             self._last_activity = time.monotonic()
             self._next_checkin_after = self._random_first_idle_delay()
             self._resting = False
+        self._wakeup.set()
 
     def is_enabled(self) -> bool:
         with self._lock:
@@ -334,35 +358,69 @@ class ProactiveIdleRunner:
                 self._next_checkin_after = idle_for + PROACTIVE_COOLDOWN_SECONDS
                 self._prompt_times.append(now)
 
+    def _seconds_until_next_check(self, now: float) -> float:
+        """Sleep until the next meaningful proactive deadline or wakeup event."""
+        with self._lock:
+            enabled = self._enabled
+            resting = self._resting
+            last_activity = self._last_activity
+            last_prompt = self._last_prompt
+            next_checkin_after = self._next_checkin_after
+
+        if not enabled or resting:
+            return 3600.0
+
+        quiet_remaining = _seconds_until_proactive_silence_ends()
+        if quiet_remaining > 0:
+            return quiet_remaining
+
+        if self._active_turn.is_set():
+            return 30.0
+        if self._speak is not None and self._speak.is_playing():
+            return 10.0
+
+        candidates = [last_activity + next_checkin_after]
+        if last_prompt:
+            candidates.append(last_prompt + PROACTIVE_COOLDOWN_SECONDS)
+        if PROACTIVE_REST_AFTER_SECONDS > 0:
+            candidates.append(last_activity + PROACTIVE_REST_AFTER_SECONDS)
+        if PROACTIVE_MAX_PER_HOUR > 0 and len(self._prompt_times) >= PROACTIVE_MAX_PER_HOUR:
+            candidates.append(self._prompt_times[0] + 3600)
+
+        future = [target - now for target in candidates if target > now]
+        return max(1.0, min(future) if future else 1.0)
+
     def _loop(self) -> None:
-        poll = max(1.0, PROACTIVE_POLL_SECONDS)
-        while not self._stop.wait(poll):
+        while not self._stop.is_set():
             now = time.monotonic()
             due = self._prompt_due(now)
-            if not due:
-                continue
-            kind, payload = due
-            rest = kind.startswith("rest")
-            self._mark_prompt(now, rest=rest)
-            log.info("[proactive] idle %s: %s", "rest" if rest else "check-in", payload)
-            try:
-                if kind.endswith("_prompt") and self._generate_fn is not None:
-                    text = (self._generate_fn(payload) or "").strip()
-                    if not text:
-                        text = PROACTIVE_REST_MESSAGE if rest else self._next_message()
-                else:
-                    text = payload
-                self._tui.add_message("aiko", text)
-                if (
-                    not kind.endswith("_prompt")
-                    and PROACTIVE_SPEAK
-                    and self._speak is not None
-                    and self._speak_enabled_fn()
-                ):
-                    self._speak.speak(text)
-                self._tui._draw()
-            except Exception as e:
-                log.warning("Proactive idle check-in failed: %s", e)
+            if due:
+                kind, payload = due
+                rest = kind.startswith("rest")
+                self._mark_prompt(now, rest=rest)
+                log.info("[proactive] idle %s: %s", "rest" if rest else "check-in", payload)
+                try:
+                    if kind.endswith("_prompt") and self._generate_fn is not None:
+                        text = (self._generate_fn(payload) or "").strip()
+                        if not text:
+                            text = PROACTIVE_REST_MESSAGE if rest else self._next_message()
+                    else:
+                        text = payload
+                    self._tui.add_message("aiko", text)
+                    if (
+                        not kind.endswith("_prompt")
+                        and PROACTIVE_SPEAK
+                        and self._speak is not None
+                        and self._speak_enabled_fn()
+                    ):
+                        self._speak.speak(text)
+                    self._tui._draw()
+                except Exception as e:
+                    log.warning("Proactive idle check-in failed: %s", e)
+
+            sleep_for = self._seconds_until_next_check(time.monotonic())
+            self._wakeup.wait(timeout=sleep_for)
+            self._wakeup.clear()
 
 
 # ── voice command map ─────────────────────────────────────────────────────────

--- a/main.py
+++ b/main.py
@@ -27,6 +27,7 @@ load_config()
 
 import argparse
 import collections
+from datetime import datetime
 import difflib
 import os
 import random
@@ -35,6 +36,7 @@ import sys
 import threading
 import time
 import warnings
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 warnings.filterwarnings("ignore")
 
@@ -67,6 +69,10 @@ PROACTIVE_COOLDOWN_SECONDS = float(os.getenv("PROACTIVE_COOLDOWN_SECONDS", "1800
 PROACTIVE_MAX_PER_HOUR = int(os.getenv("PROACTIVE_MAX_PER_HOUR", "2"))
 PROACTIVE_POLL_SECONDS = float(os.getenv("PROACTIVE_POLL_SECONDS", "5"))
 PROACTIVE_REST_AFTER_SECONDS = float(os.getenv("PROACTIVE_REST_AFTER_SECONDS", "3600"))
+PROACTIVE_USE_LLM = os.getenv("PROACTIVE_USE_LLM", "1").lower() in {"1", "true", "yes", "on"}
+PROACTIVE_TIMEZONE = os.getenv("PROACTIVE_TIMEZONE", os.getenv("TIMEZONE", "")).strip()
+PROACTIVE_QUIET_WINDOWS = [w.strip() for w in os.getenv("PROACTIVE_QUIET_WINDOWS", "00:00-06:00").split(",") if w.strip()]
+PROACTIVE_FOCUS_WINDOWS = [w.strip() for w in os.getenv("PROACTIVE_FOCUS_WINDOWS", "mon-fri 06:00-19:00,sat-sun 06:00-11:00").split(",") if w.strip()]
 PROACTIVE_SPEAK = os.getenv("PROACTIVE_SPEAK", "1").lower() in {"1", "true", "yes", "on"}
 PROACTIVE_MESSAGES = [
     msg.strip()
@@ -83,6 +89,123 @@ PROACTIVE_REST_MESSAGE = os.getenv(
     "PROACTIVE_REST_MESSAGE",
     "You've been away for a while, so I'll go quiet and rest. Ping me when you need me.",
 ).strip()
+PROACTIVE_PROMPT_HINTS = [
+    msg.strip()
+    for msg in os.getenv(
+        "PROACTIVE_PROMPT_HINTS",
+        "Oppa has not spoken to you for a while. What short gentle thing do you want to say to him now?,"
+        "Oppa has been quiet for a while. Offer company without being needy or disruptive.,"
+        "Oppa may be focused or away. Say one brief check-in and make it easy for him to ignore you.",
+    ).split(",")
+    if msg.strip()
+]
+PROACTIVE_REST_PROMPT_HINT = os.getenv(
+    "PROACTIVE_REST_PROMPT_HINT",
+    "Oppa has not spoken to you for about an hour. Say one short warm line that you are going quiet and resting until he returns.",
+).strip()
+
+
+_DAY_ALIASES = {
+    "mon": 0, "monday": 0,
+    "tue": 1, "tues": 1, "tuesday": 1,
+    "wed": 2, "wednesday": 2,
+    "thu": 3, "thur": 3, "thurs": 3, "thursday": 3,
+    "fri": 4, "friday": 4,
+    "sat": 5, "saturday": 5,
+    "sun": 6, "sunday": 6,
+}
+
+
+def _parse_day_spec(spec: str) -> set[int] | None:
+    """Parse day specs like mon-fri, sat-sun, weekdays, weekend, or daily."""
+    spec = spec.strip().lower()
+    if not spec or spec in {"daily", "everyday", "all"}:
+        return None
+    if spec in {"weekday", "weekdays"}:
+        return {0, 1, 2, 3, 4}
+    if spec in {"weekend", "weekends"}:
+        return {5, 6}
+    days: set[int] = set()
+    for part in spec.split("|"):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            start_name, end_name = [p.strip() for p in part.split("-", 1)]
+            start = _DAY_ALIASES.get(start_name)
+            end = _DAY_ALIASES.get(end_name)
+            if start is None or end is None:
+                continue
+            day = start
+            while True:
+                days.add(day)
+                if day == end:
+                    break
+                day = (day + 1) % 7
+        else:
+            day = _DAY_ALIASES.get(part)
+            if day is not None:
+                days.add(day)
+    return days or None
+
+
+def _parse_hhmm(value: str) -> int | None:
+    try:
+        hour_s, minute_s = value.strip().split(":", 1)
+        hour = int(hour_s)
+        minute = int(minute_s)
+    except ValueError:
+        return None
+    if not (0 <= hour <= 23 and 0 <= minute <= 59):
+        return None
+    return hour * 60 + minute
+
+
+def _time_window_matches(window: str, now: datetime | None = None) -> bool:
+    """Return True when now is inside a YAML window.
+
+    Supported examples:
+      - "00:00-06:00"
+      - "mon-fri 06:00-19:00"
+      - "weekend 06:00-11:00"
+      - "fri-mon 22:00-06:00"
+    """
+    if now is None:
+        try:
+            now = datetime.now(ZoneInfo(PROACTIVE_TIMEZONE)) if PROACTIVE_TIMEZONE else datetime.now()
+        except ZoneInfoNotFoundError:
+            now = datetime.now()
+    raw = window.strip().lower()
+    if not raw:
+        return False
+    if " " in raw:
+        day_spec, time_spec = raw.rsplit(" ", 1)
+    else:
+        day_spec, time_spec = "", raw
+    if "-" not in time_spec:
+        return False
+    start_s, end_s = [part.strip() for part in time_spec.split("-", 1)]
+    start = _parse_hhmm(start_s)
+    end = _parse_hhmm(end_s)
+    if start is None or end is None:
+        return False
+
+    days = _parse_day_spec(day_spec)
+    if days is not None and now.weekday() not in days:
+        return False
+
+    minute = now.hour * 60 + now.minute
+    if start <= end:
+        return start <= minute < end
+    return minute >= start or minute < end
+
+
+def _in_proactive_silence_window() -> bool:
+    """True during configured quiet/focus windows."""
+    return any(
+        _time_window_matches(window)
+        for window in [*PROACTIVE_QUIET_WINDOWS, *PROACTIVE_FOCUS_WINDOWS]
+    )
 
 
 class ProactiveIdleRunner:
@@ -94,11 +217,12 @@ class ProactiveIdleRunner:
     quiet until the user returns.
     """
 
-    def __init__(self, tui, speak, speak_enabled_fn, active_turn: threading.Event) -> None:
+    def __init__(self, tui, speak, speak_enabled_fn, active_turn: threading.Event, generate_fn=None) -> None:
         self._tui = tui
         self._speak = speak
         self._speak_enabled_fn = speak_enabled_fn
         self._active_turn = active_turn
+        self._generate_fn = generate_fn
         self._stop = threading.Event()
         self._lock = threading.Lock()
         self._last_activity = time.monotonic()
@@ -144,6 +268,14 @@ class ProactiveIdleRunner:
         self._message_index += 1
         return msg
 
+    def _next_prompt_hint(self) -> str:
+        hints = PROACTIVE_PROMPT_HINTS or [
+            "Oppa has not spoken to you for a while. What short gentle thing do you want to say to him now?"
+        ]
+        hint = hints[self._message_index % len(hints)]
+        self._message_index += 1
+        return hint
+
     @staticmethod
     def _random_first_idle_delay() -> float:
         low = max(0.0, min(PROACTIVE_FIRST_IDLE_MIN_SECONDS, PROACTIVE_FIRST_IDLE_MAX_SECONDS))
@@ -156,7 +288,7 @@ class ProactiveIdleRunner:
             self._prompt_times.popleft()
         return PROACTIVE_MAX_PER_HOUR > 0 and len(self._prompt_times) < PROACTIVE_MAX_PER_HOUR
 
-    def _prompt_due(self, now: float) -> str | None:
+    def _prompt_due(self, now: float) -> tuple[str, str] | None:
         with self._lock:
             enabled = self._enabled
             idle_for = now - self._last_activity
@@ -168,13 +300,17 @@ class ProactiveIdleRunner:
             return None
         if resting:
             return None
+        if _in_proactive_silence_window():
+            return None
         if self._active_turn.is_set():
             return None
         if self._speak is not None and self._speak.is_playing():
             return None
         if PROACTIVE_REST_AFTER_SECONDS > 0 and idle_for >= PROACTIVE_REST_AFTER_SECONDS:
+            if PROACTIVE_USE_LLM and self._generate_fn is not None and PROACTIVE_REST_PROMPT_HINT:
+                return ("rest_prompt", PROACTIVE_REST_PROMPT_HINT)
             if PROACTIVE_REST_MESSAGE:
-                return PROACTIVE_REST_MESSAGE
+                return ("rest_text", PROACTIVE_REST_MESSAGE)
             with self._lock:
                 self._resting = True
             return None
@@ -184,7 +320,9 @@ class ProactiveIdleRunner:
             return None
         if not self._rate_limit_allows_prompt(now):
             return None
-        return self._next_message()
+        if PROACTIVE_USE_LLM and self._generate_fn is not None:
+            return ("checkin_prompt", self._next_prompt_hint())
+        return ("checkin_text", self._next_message())
 
     def _mark_prompt(self, now: float, *, rest: bool) -> None:
         with self._lock:
@@ -200,15 +338,27 @@ class ProactiveIdleRunner:
         poll = max(1.0, PROACTIVE_POLL_SECONDS)
         while not self._stop.wait(poll):
             now = time.monotonic()
-            text = self._prompt_due(now)
-            if not text:
+            due = self._prompt_due(now)
+            if not due:
                 continue
-            rest = text == PROACTIVE_REST_MESSAGE
+            kind, payload = due
+            rest = kind.startswith("rest")
             self._mark_prompt(now, rest=rest)
-            log.info("[proactive] idle check-in: %s", text)
+            log.info("[proactive] idle %s: %s", "rest" if rest else "check-in", payload)
             try:
+                if kind.endswith("_prompt") and self._generate_fn is not None:
+                    text = (self._generate_fn(payload) or "").strip()
+                    if not text:
+                        text = PROACTIVE_REST_MESSAGE if rest else self._next_message()
+                else:
+                    text = payload
                 self._tui.add_message("aiko", text)
-                if PROACTIVE_SPEAK and self._speak is not None and self._speak_enabled_fn():
+                if (
+                    not kind.endswith("_prompt")
+                    and PROACTIVE_SPEAK
+                    and self._speak is not None
+                    and self._speak_enabled_fn()
+                ):
                     self._speak.speak(text)
                 self._tui._draw()
             except Exception as e:
@@ -470,11 +620,27 @@ def _run_session(tui, args):
     # ── shutdown helper ───────────────────────────────────────────────────────
 
     session_active = threading.Event()
+
+    def _generate_proactive_checkin(prompt_hint: str) -> str:
+        session_active.set()
+        original_speak = getattr(think, "_speak", None)
+        try:
+            if not tts_enabled:
+                think.set_speak(None)
+            return think.proactive_checkin(prompt_hint)
+        finally:
+            if not tts_enabled:
+                think.set_speak(original_speak)
+            session_active.clear()
+            if hasattr(think, "_last_chat_time"):
+                think._last_chat_time = time.time()
+
     proactive = ProactiveIdleRunner(
         tui,
         speak,
         speak_enabled_fn=lambda: tts_enabled,
         active_turn=session_active,
+        generate_fn=_generate_proactive_checkin,
     )
     proactive.start()
 

--- a/main.py
+++ b/main.py
@@ -68,10 +68,10 @@ PROACTIVE_FIRST_IDLE_MAX_SECONDS = float(os.getenv("PROACTIVE_FIRST_IDLE_MAX_SEC
 PROACTIVE_COOLDOWN_SECONDS = float(os.getenv("PROACTIVE_COOLDOWN_SECONDS", "1800"))
 PROACTIVE_MAX_PER_HOUR = int(os.getenv("PROACTIVE_MAX_PER_HOUR", "2"))
 PROACTIVE_REST_AFTER_SECONDS = float(os.getenv("PROACTIVE_REST_AFTER_SECONDS", "3600"))
-PROACTIVE_USE_LLM = os.getenv("PROACTIVE_USE_LLM", "0").lower() in {"1", "true", "yes", "on"}
+PROACTIVE_USE_LLM = os.getenv("PROACTIVE_USE_LLM", "1").lower() in {"1", "true", "yes", "on"}
 PROACTIVE_TIMEZONE = os.getenv("PROACTIVE_TIMEZONE", "").strip() or os.getenv("TIMEZONE", "").strip()
 PROACTIVE_QUIET_WINDOWS = [w.strip() for w in os.getenv("PROACTIVE_QUIET_WINDOWS", "00:00-06:00").split(",") if w.strip()]
-PROACTIVE_FOCUS_WINDOWS = [w.strip() for w in os.getenv("PROACTIVE_FOCUS_WINDOWS", "").split(",") if w.strip()]
+PROACTIVE_FOCUS_WINDOWS = [w.strip() for w in os.getenv("PROACTIVE_FOCUS_WINDOWS", "mon-fri 06:00-19:00,sat-sun 06:00-11:00").split(",") if w.strip()]
 PROACTIVE_SPEAK = os.getenv("PROACTIVE_SPEAK", "1").lower() in {"1", "true", "yes", "on"}
 PROACTIVE_MESSAGES = [
     msg.strip()
@@ -92,16 +92,27 @@ PROACTIVE_PROMPT_HINTS = [
     msg.strip()
     for msg in os.getenv(
         "PROACTIVE_PROMPT_HINTS",
-        f"{USER_ID or 'the user'} has not spoken to you for a while. What short gentle thing do you want to say now?,"
-        f"{USER_ID or 'the user'} has been quiet for a while. Offer company without being needy or disruptive.,"
-        f"{USER_ID or 'the user'} may be focused or away. Say one brief check-in and make it easy to ignore.",
+        "{user} has not spoken to you for a while. What short gentle thing do you want to say now?,"
+        "{user} has been quiet for a while. Offer company without being needy or disruptive.,"
+        "{user} may be focused or away. Say one brief check-in and make it easy to ignore.",
     ).split(",")
     if msg.strip()
 ]
 PROACTIVE_REST_PROMPT_HINT = os.getenv(
     "PROACTIVE_REST_PROMPT_HINT",
-    f"{USER_ID or 'the user'} has not spoken to you for about an hour. Say one short warm line that you are going quiet and resting until they return.",
+    "{user} has not spoken to you for about an hour. Say one short warm line that you are going quiet and resting until they return.",
 ).strip()
+
+
+def _personalize_proactive_text(text: str) -> str:
+    """Fill lightweight proactive placeholders from identity config/env."""
+    user = USER_ID or "the user"
+    return (
+        text.replace("{user}", user)
+        .replace("{USER_ID}", user)
+        .replace("{ai}", AI_NAME)
+        .replace("{AI_NAME}", AI_NAME)
+    )
 
 
 _DAY_ALIASES = {
@@ -290,15 +301,15 @@ class ProactiveIdleRunner:
         messages = PROACTIVE_MESSAGES or ["You've been quiet for a bit. Still with me?"]
         msg = messages[self._message_index % len(messages)]
         self._message_index += 1
-        return msg
+        return _personalize_proactive_text(msg)
 
     def _next_prompt_hint(self) -> str:
         hints = PROACTIVE_PROMPT_HINTS or [
-            f"{USER_ID or 'the user'} has not spoken to you for a while. What short gentle thing do you want to say now?"
+            "{user} has not spoken to you for a while. What short gentle thing do you want to say now?"
         ]
         hint = hints[self._message_index % len(hints)]
         self._message_index += 1
-        return hint
+        return _personalize_proactive_text(hint)
 
     @staticmethod
     def _random_first_idle_delay() -> float:
@@ -332,9 +343,9 @@ class ProactiveIdleRunner:
             return None
         if PROACTIVE_REST_AFTER_SECONDS > 0 and idle_for >= PROACTIVE_REST_AFTER_SECONDS:
             if PROACTIVE_USE_LLM and self._generate_fn is not None and PROACTIVE_REST_PROMPT_HINT:
-                return ("rest_prompt", PROACTIVE_REST_PROMPT_HINT)
+                return ("rest_prompt", _personalize_proactive_text(PROACTIVE_REST_PROMPT_HINT))
             if PROACTIVE_REST_MESSAGE:
-                return ("rest_text", PROACTIVE_REST_MESSAGE)
+                return ("rest_text", _personalize_proactive_text(PROACTIVE_REST_MESSAGE))
             with self._lock:
                 self._resting = True
             return None

--- a/main.py
+++ b/main.py
@@ -26,8 +26,10 @@ from core.config import load_config
 load_config()
 
 import argparse
+import collections
 import difflib
 import os
+import random
 import re
 import sys
 import threading
@@ -58,6 +60,159 @@ AI_NAME = os.getenv("AI_NAME", "Aiko")
 USER_ID = os.getenv("USER_ID", "")
 STREAM_DRAW_INTERVAL = float(os.getenv("STREAM_DRAW_INTERVAL", "0.05"))
 LATENCY_LOG_ENABLED = os.getenv("LATENCY_LOG", "1").lower() in {"1", "true", "yes", "on"}
+PROACTIVE_ENABLED = os.getenv("PROACTIVE_ENABLED", "1").lower() in {"1", "true", "yes", "on"}
+PROACTIVE_FIRST_IDLE_MIN_SECONDS = float(os.getenv("PROACTIVE_FIRST_IDLE_MIN_SECONDS", os.getenv("PROACTIVE_IDLE_SECONDS", "300")))
+PROACTIVE_FIRST_IDLE_MAX_SECONDS = float(os.getenv("PROACTIVE_FIRST_IDLE_MAX_SECONDS", "900"))
+PROACTIVE_COOLDOWN_SECONDS = float(os.getenv("PROACTIVE_COOLDOWN_SECONDS", "1800"))
+PROACTIVE_MAX_PER_HOUR = int(os.getenv("PROACTIVE_MAX_PER_HOUR", "2"))
+PROACTIVE_POLL_SECONDS = float(os.getenv("PROACTIVE_POLL_SECONDS", "5"))
+PROACTIVE_REST_AFTER_SECONDS = float(os.getenv("PROACTIVE_REST_AFTER_SECONDS", "3600"))
+PROACTIVE_SPEAK = os.getenv("PROACTIVE_SPEAK", "1").lower() in {"1", "true", "yes", "on"}
+PROACTIVE_MESSAGES = [
+    msg.strip()
+    for msg in os.getenv(
+        "PROACTIVE_MESSAGES",
+        "You've been quiet for a bit. Still with me?,"
+        "Checking in. Do you want focus time or should I keep you company?,"
+        "Still here. If you're deep in something I can stay quiet.,"
+        "Tiny ping. Need anything or are we in quiet mode?",
+    ).split(",")
+    if msg.strip()
+]
+PROACTIVE_REST_MESSAGE = os.getenv(
+    "PROACTIVE_REST_MESSAGE",
+    "You've been away for a while, so I'll go quiet and rest. Ping me when you need me.",
+).strip()
+
+
+class ProactiveIdleRunner:
+    """Lightweight monitor that lets Aiko send gentle idle check-ins.
+
+    This is deliberately local: it does not call the LLM, does not inspect the
+    screen/camera, and never runs while a turn is active. The first check-in is
+    jittered so Aiko feels less timer-like; after a longer idle window she goes
+    quiet until the user returns.
+    """
+
+    def __init__(self, tui, speak, speak_enabled_fn, active_turn: threading.Event) -> None:
+        self._tui = tui
+        self._speak = speak
+        self._speak_enabled_fn = speak_enabled_fn
+        self._active_turn = active_turn
+        self._stop = threading.Event()
+        self._lock = threading.Lock()
+        self._last_activity = time.monotonic()
+        self._last_prompt = 0.0
+        self._prompt_times: collections.deque[float] = collections.deque()
+        self._message_index = 0
+        self._enabled = PROACTIVE_ENABLED
+        self._next_checkin_after = self._random_first_idle_delay()
+        self._resting = False
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if PROACTIVE_FIRST_IDLE_MAX_SECONDS <= 0:
+            return
+        self._thread = threading.Thread(target=self._loop, name="aiko-proactive", daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join(timeout=2.0)
+
+    def touch(self) -> None:
+        with self._lock:
+            self._last_activity = time.monotonic()
+            self._next_checkin_after = self._random_first_idle_delay()
+            self._resting = False
+
+    def set_enabled(self, enabled: bool) -> None:
+        with self._lock:
+            self._enabled = enabled
+            self._last_activity = time.monotonic()
+            self._next_checkin_after = self._random_first_idle_delay()
+            self._resting = False
+
+    def is_enabled(self) -> bool:
+        with self._lock:
+            return self._enabled
+
+    def _next_message(self) -> str:
+        messages = PROACTIVE_MESSAGES or ["You've been quiet for a bit. Still with me?"]
+        msg = messages[self._message_index % len(messages)]
+        self._message_index += 1
+        return msg
+
+    @staticmethod
+    def _random_first_idle_delay() -> float:
+        low = max(0.0, min(PROACTIVE_FIRST_IDLE_MIN_SECONDS, PROACTIVE_FIRST_IDLE_MAX_SECONDS))
+        high = max(low, PROACTIVE_FIRST_IDLE_MAX_SECONDS)
+        return random.uniform(low, high)
+
+    def _rate_limit_allows_prompt(self, now: float) -> bool:
+        one_hour_ago = now - 3600
+        while self._prompt_times and self._prompt_times[0] < one_hour_ago:
+            self._prompt_times.popleft()
+        return PROACTIVE_MAX_PER_HOUR > 0 and len(self._prompt_times) < PROACTIVE_MAX_PER_HOUR
+
+    def _prompt_due(self, now: float) -> str | None:
+        with self._lock:
+            enabled = self._enabled
+            idle_for = now - self._last_activity
+            cooldown_for = now - self._last_prompt if self._last_prompt else float("inf")
+            next_checkin_after = self._next_checkin_after
+            resting = self._resting
+
+        if not enabled:
+            return None
+        if resting:
+            return None
+        if self._active_turn.is_set():
+            return None
+        if self._speak is not None and self._speak.is_playing():
+            return None
+        if PROACTIVE_REST_AFTER_SECONDS > 0 and idle_for >= PROACTIVE_REST_AFTER_SECONDS:
+            if PROACTIVE_REST_MESSAGE:
+                return PROACTIVE_REST_MESSAGE
+            with self._lock:
+                self._resting = True
+            return None
+        if idle_for < next_checkin_after:
+            return None
+        if cooldown_for < PROACTIVE_COOLDOWN_SECONDS:
+            return None
+        if not self._rate_limit_allows_prompt(now):
+            return None
+        return self._next_message()
+
+    def _mark_prompt(self, now: float, *, rest: bool) -> None:
+        with self._lock:
+            self._last_prompt = now
+            if rest:
+                self._resting = True
+            else:
+                idle_for = now - self._last_activity
+                self._next_checkin_after = idle_for + PROACTIVE_COOLDOWN_SECONDS
+                self._prompt_times.append(now)
+
+    def _loop(self) -> None:
+        poll = max(1.0, PROACTIVE_POLL_SECONDS)
+        while not self._stop.wait(poll):
+            now = time.monotonic()
+            text = self._prompt_due(now)
+            if not text:
+                continue
+            rest = text == PROACTIVE_REST_MESSAGE
+            self._mark_prompt(now, rest=rest)
+            log.info("[proactive] idle check-in: %s", text)
+            try:
+                self._tui.add_message("aiko", text)
+                if PROACTIVE_SPEAK and self._speak is not None and self._speak_enabled_fn():
+                    self._speak.speak(text)
+                self._tui._draw()
+            except Exception as e:
+                log.warning("Proactive idle check-in failed: %s", e)
 
 
 # ── voice command map ─────────────────────────────────────────────────────────
@@ -314,8 +469,18 @@ def _run_session(tui, args):
 
     # ── shutdown helper ───────────────────────────────────────────────────────
 
+    session_active = threading.Event()
+    proactive = ProactiveIdleRunner(
+        tui,
+        speak,
+        speak_enabled_fn=lambda: tts_enabled,
+        active_turn=session_active,
+    )
+    proactive.start()
+
     def _shutdown():
         """Stop background daemons and flush memory writes before exit."""
+        proactive.stop()
         if listen is not None:
             listen.stop_barge_in_monitor()
         think.wait_for_memory()
@@ -345,6 +510,8 @@ def _run_session(tui, args):
 
         if not user_input:
             continue
+
+        proactive.touch()
 
         # ── voice command check (ASR mode only) ───────────────────────────────
         #
@@ -471,6 +638,11 @@ def _run_session(tui, args):
                     tui.add_message('sys',
                         f'Voice input  (ASR): {"ON  🎤" if asr_enabled else "OFF ⌨ "}')
 
+            elif cmd == '/proactive':
+                proactive.set_enabled(not proactive.is_enabled())
+                tui.add_message('sys',
+                    f'Proactive idle check-ins: {"ON  🌸" if proactive.is_enabled() else "OFF 💤"}')
+
             elif cmd == '/help':
                 for line in [
                     '/quit /exit              — end session',
@@ -482,6 +654,7 @@ def _run_session(tui, args):
                     '/web <query>             — web search',
                     '/voice                   — toggle TTS on/off',
                     '/listen                  — toggle ASR on/off',
+                    '/proactive               — toggle idle check-ins on/off',
                     '/help                    — show this list',
                     '',
                     'Voice commands (say aloud in ASR mode):',
@@ -545,19 +718,24 @@ def _run_session(tui, args):
 
         tui.add_message('you', user_input)
         tui.turn_start()
+        session_active.set()
         tui._draw()
 
-        think.route(user_input, token_callback=token_cb)
-        current_latency["assistant_done_at"] = time.monotonic()
-        if speak and tts_enabled:
-            speak.wait()
-        tui.stream_commit()
-        tui._draw()
-        current_latency["turn_done_at"] = time.monotonic()
-        _update_latency_stats(current_latency)
-        _log_latency(current_latency)
-        tui._draw()
-        current_latency = None
+        try:
+            think.route(user_input, token_callback=token_cb)
+            current_latency["assistant_done_at"] = time.monotonic()
+            if speak and tts_enabled:
+                speak.wait()
+            tui.stream_commit()
+            tui._draw()
+            current_latency["turn_done_at"] = time.monotonic()
+            _update_latency_stats(current_latency)
+            _log_latency(current_latency)
+            tui._draw()
+        finally:
+            session_active.clear()
+            proactive.touch()
+            current_latency = None
 
 
 # ═════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Motivation

- Provide an optional, non-intrusive feature for the assistant to gently check in after user idle periods so the agent can offer help or go quiet without calling the LLM or inspecting the screen.

### Description

- Add a new configuration file `config/proactive.yaml` and register it in `config/index.yaml` to expose proactive settings.
- Implement `ProactiveIdleRunner` in `main.py` with jittered first-check delays, cooldowns, hourly rate limiting, a rest-message mode, and safe guards to avoid interrupting active turns or TTS playback.
- Wire the runner into the session lifecycle by instantiating and starting it in `_run_session`, calling `touch()` on user activity, using a `session_active` `Event` to suppress prompts during turns, and ensuring `stop()` is invoked on shutdown.
- Add a `/proactive` slash command and help text, update `README.md` command table, and include necessary env/config parsing and small import additions (`collections`, `random`).

### Testing

- Ran the repository's automated test suite (existing CI/tests); no tests were added for this feature and the existing tests passed.
- No automated regressions were detected by the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4705253e00832ca2580789fda913c6)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `/proactive` command to toggle proactive idle check-ins.
  * Introduced configurable proactive idle check-ins, including first-idle timing, cooldowns, per-hour caps, quiet/focus suppression windows, and optional TTS output.
  * Added “rest” behavior after extended idle, with separate messaging to reduce repetitive prompts.
* **Documentation**
  * Updated the command list to include `/proactive` and documented the new proactive timing/config settings.
* **Bug Fixes**
  * Improved coordination so proactive (and rest) messages only trigger when the user is idle and not actively engaged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->