### PR TITLE
Fix WebUI voice playback and mic toggle

### DIFF
--- a/core/speak.py
+++ b/core/speak.py
@@ -227,10 +227,11 @@ class AikoSpeak:
         # nobody's in the room to hear the Jetson's own speaker.
         self._audio_sink = None
         self._viseme_sink = None
-        # When True (default), local sounddevice playback still happens even
-        # if a remote sink is set — fine on LAN where you might be near the
-        # robot. Set False to silence the Jetson's own speaker entirely once
-        # you're working remotely full-time, so it doesn't talk to an empty room.
+        # When True (default), local sounddevice playback is allowed. If a
+        # WebUI audio sink is registered and a browser is actively connected,
+        # _play_wav_bytes() temporarily suppresses local playback to avoid
+        # doubled/phased audio. With no connected browser, playback remains
+        # local as usual. Set False to always silence the local speaker.
         self.local_playback = True
 
         if not silent:
@@ -400,8 +401,8 @@ class AikoSpeak:
         # (or a remotely forwarded local speaker plus browser playback) can sound
         # like stereo/phasing/doubling. Keep the call blocking for the WAV
         # duration so callers preserve normal turn timing.
-        skip_local = self._audio_sink is not None and self.local_playback and self._has_remote_listener()
-        if not self.local_playback or skip_local:
+        remote_listener_active = self._audio_sink is not None and self._has_remote_listener()
+        if not self.local_playback or remote_listener_active:
             duration = self._wav_duration(wav_bytes)
             deadline = time.monotonic() + duration
             while time.monotonic() < deadline:

--- a/core/speak.py
+++ b/core/speak.py
@@ -262,6 +262,24 @@ class AikoSpeak:
         """
         self._audio_sink = callback
 
+    def _has_remote_listener(self) -> bool:
+        """Return True when the registered WebUI audio sink has clients.
+
+        The WebUI passes a bound method (AikoWeb.broadcast_audio_bytes) as the
+        audio sink. Looking through the bound method lets speak.py avoid local
+        playback only when a browser is actually connected, while keeping normal
+        Jetson/TUI playback unchanged when no remote listener exists.
+        """
+        sink_owner = getattr(self._audio_sink, "__self__", None)
+        checker = getattr(sink_owner, "has_remote_listener", None)
+        if checker is None:
+            return False
+        try:
+            return bool(checker())
+        except Exception as e:
+            log.warning("[speak] remote listener check failed: %s", e)
+            return False
+
     def set_viseme_sink(self, callback) -> None:
         """
         Register a callback(viseme: str, weight: float) -> None invoked during
@@ -377,11 +395,13 @@ class AikoSpeak:
             except Exception as e:
                 log.error(f"[speak] audio sink error: {e}")
 
-        if not self.local_playback:
-            # Nothing is playing locally to block on, but callers (wait(),
-            # wait_or_barge_in(), the karaoke word-pacing in
-            # _speak_thread_synced) all assume this call blocks for roughly
-            # the real audio duration. Sleep it out instead, interruptibly.
+        # If a browser is connected to the WebUI audio sink, do not also play
+        # through the Jetson/local sounddevice. Hearing both endpoints at once
+        # (or a remotely forwarded local speaker plus browser playback) can sound
+        # like stereo/phasing/doubling. Keep the call blocking for the WAV
+        # duration so callers preserve normal turn timing.
+        skip_local = self._audio_sink is not None and self.local_playback and self._has_remote_listener()
+        if not self.local_playback or skip_local:
             duration = self._wav_duration(wav_bytes)
             deadline = time.monotonic() + duration
             while time.monotonic() < deadline:

--- a/tests/test_speak_remote_audio.py
+++ b/tests/test_speak_remote_audio.py
@@ -1,0 +1,78 @@
+import sys
+import threading
+import types
+import unittest
+
+# Keep these focused unit tests independent of optional runtime dependencies that
+# are loaded by the application-wide config/log bootstrap during import.
+yaml_stub = types.SimpleNamespace(safe_load=lambda _text: {})
+dotenv_stub = types.SimpleNamespace(load_dotenv=lambda *_args, **_kwargs: None)
+sys.modules.setdefault("yaml", yaml_stub)
+sys.modules.setdefault("dotenv", dotenv_stub)
+
+from core.speak import AikoSpeak
+
+
+class _RemoteOwner:
+    def __init__(self, result=None, exc=None):
+        self.result = result
+        self.exc = exc
+        self.calls = 0
+        self.payloads = []
+
+    def broadcast_audio_bytes(self, payload: bytes) -> None:
+        self.payloads.append(payload)
+
+    def has_remote_listener(self) -> bool:
+        self.calls += 1
+        if self.exc is not None:
+            raise self.exc
+        return self.result
+
+
+class SpeakRemoteAudioTests(unittest.TestCase):
+    def _speaker(self) -> AikoSpeak:
+        speaker = AikoSpeak.__new__(AikoSpeak)
+        speaker.local_playback = True
+        speaker._audio_sink = None
+        speaker._stop_flag = threading.Event()
+        speaker._first_audio_fired = threading.Event()
+        speaker._first_audio_callback = None
+        return speaker
+
+    def test_has_remote_listener_reflects_bound_webui_sink(self):
+        speaker = self._speaker()
+        owner = _RemoteOwner(result=True)
+        speaker.set_audio_sink(owner.broadcast_audio_bytes)
+
+        self.assertTrue(speaker._has_remote_listener())
+        self.assertEqual(owner.calls, 1)
+
+    def test_has_remote_listener_is_false_without_checker_or_on_error(self):
+        speaker = self._speaker()
+        speaker.set_audio_sink(lambda payload: None)
+        self.assertFalse(speaker._has_remote_listener())
+
+        owner = _RemoteOwner(exc=RuntimeError("boom"))
+        speaker.set_audio_sink(owner.broadcast_audio_bytes)
+        self.assertFalse(speaker._has_remote_listener())
+
+    def test_play_wav_bytes_skips_local_playback_when_browser_connected(self):
+        speaker = self._speaker()
+        owner = _RemoteOwner(result=True)
+        speaker.set_audio_sink(owner.broadcast_audio_bytes)
+        speaker._wav_duration = lambda payload: 0.0
+
+        def fail_if_local_playback_is_attempted():
+            raise AssertionError("local playback should be skipped")
+
+        speaker._load_sd = fail_if_local_playback_is_attempted
+
+        speaker._play_wav_bytes(b"not-a-real-wav")
+
+        self.assertEqual(owner.payloads, [b"not-a-real-wav"])
+        self.assertEqual(owner.calls, 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/webui/static/index.html
+++ b/webui/static/index.html
@@ -1001,15 +1001,21 @@
         addMessage('sys', 'WebSocket bridge is offline. Cannot toggle voice mode.');
         return;
       }
-      if (vMode.textContent.includes('ASR')) {
-        // Toggle ASR OFF
-        ws.send(JSON.stringify({ type: 'user_input', text: '/listen' }));
+
+      const asrEnabled = vMode.textContent.includes('ASR');
+
+      if (micContext) {
+        // Mic is already open: close it and disable ASR so the backend stops
+        // waiting for browser voice frames.
         stopMic();
+        if (asrEnabled) ws.send(JSON.stringify({ type: 'user_input', text: '/listen' }));
       } else {
-        // Toggle ASR ON
+        // Mic is closed: open it first. If ASR was already on at startup, do
+        // not send /listen because that would toggle ASR off right as the
+        // browser starts capturing.
         const ok = await startMic();
         if (!ok) return;
-        ws.send(JSON.stringify({ type: 'user_input', text: '/listen' }));
+        if (!asrEnabled) ws.send(JSON.stringify({ type: 'user_input', text: '/listen' }));
       }
       input.focus();
     });


### PR DESCRIPTION
### Motivation
- Avoid doubled/phased TTS audio when the WebUI is playing synthesized voice remotely while the local device also plays it. 
- Ensure local/TUI playback remains unchanged when no browser is connected. 
- Prevent the WebUI mic button from accidentally toggling ASR off when opening the browser microphone while ASR is already enabled.

### Description
- Add `AikoSpeak._has_remote_listener()` to detect whether the registered WebUI audio sink actually has connected clients. 
- Update `_play_wav_bytes()` to skip local sounddevice playback when a remote listener is present while still broadcasting WAV chunks to the audio sink and blocking for the real audio duration. 
- Change the WebUI mic button logic in `webui/static/index.html` to open/close the browser mic without unconditionally sending `/listen`, and only send `/listen` when needed to align ASR state with mic capture.

### Testing
- Ran `python -m py_compile core/speak.py webui/webui.py` which succeeded. 
- Ran `git diff --check` which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47dcd9c3808328997e6641806f7234)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio behavior so local playback no longer conflicts with browser audio when remote listening is active.
  * Preserved timing during speech playback even when sound is not played locally.
  * Fixed microphone toggle behavior so ASR on/off actions are handled more reliably during mic open/close transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->