### PR TITLE
Add optional browser VAD gate with raw PCM passthrough for diagnostics

### DIFF
--- a/webui/static/index.html
+++ b/webui/static/index.html
@@ -914,13 +914,16 @@
 
     // ── mic capture ───────────────────────────────────────────────────────────
     // Opened/closed by server mic.start / mic.stop messages.
-    // Frames go through processVADFrame() in vad.js — only speech reaches server.
+    // Frames go through processVADFrame() in vad.js. By default browser VAD gates
+    // network audio; WEBUI_BROWSER_VAD_GATE=0 asks the browser to stream raw PCM
+    // for diagnostics so server-side VAD can be tested.
     let micStream = null;
     let micContext = null;
     let micSource = null;
     let micWorklet = null;
     let micFirstFrameSeen = false;
     let micStreamingEnabled = false;
+    let browserVadGate = true;
     let micCommandSeq = 0;
     let micSecureContextWarned = false;
 
@@ -953,7 +956,7 @@
             micFirstFrameSeen = true;
             console.log('[mic] AudioWorklet is sending PCM frames');
           }
-          if (wsReady() && micStreamingEnabled) processVADFrame(new Float32Array(e.data), ws);
+          if (wsReady() && micStreamingEnabled) processVADFrame(new Float32Array(e.data), ws, browserVadGate);
         };
 
         micSource.connect(micWorklet);
@@ -1071,12 +1074,13 @@
           case 'mic':
             if (msg.action === 'start') {
               const seq = ++micCommandSeq;
+              browserVadGate = msg.browser_vad_gate !== false;
               startMic().then((ok) => {
                 if (!ok || seq !== micCommandSeq) return;
                 if (window.resetVADState) window.resetVADState();
                 micStreamingEnabled = true;
                 vadDot.className = 'dot vad';
-                vadStatus.textContent = 'vad active';
+                vadStatus.textContent = browserVadGate ? 'vad active' : 'raw mic';
                 vadStatus.className = 'active';
               });
             } else if (msg.action === 'stop') {

--- a/webui/static/vad.js
+++ b/webui/static/vad.js
@@ -2,23 +2,23 @@
  * vad.js
  * Browser-side VAD between pcm-worklet.js and the WebSocket.
  * Silero ONNX is preferred when its browser assets are present. If ONNX Runtime
- * Web or silero_vad.onnx is missing, this falls back to a simple energy gate so
- * microphone input still works instead of silently dropping every frame.
+ * Web or silero_vad.onnx is missing, this falls back to a simple energy gate.
  *
- * Flow:
- *   pcm-worklet -> Float32Array frame -> processVADFrame(frame, ws)
- *     silence  -> dropped (never leaves the device)
+ * Default flow (browser VAD gate on):
+ *   pcm-worklet -> Float32Array frame -> processVADFrame(frame, ws, true)
+ *     silence  -> kept locally, not sent to the server
  *     speech   -> ws.send(binary frame)
- *     on start -> ws.send({type:'vad', event:'start'})
+ *     on start -> ws.send({type:'vad', event:'start'}) + pre-speech context
  *     on end   -> ws.send({type:'vad', event:'end'})
  *
- * The server (webui.py) uses 'start'/'end' sentinels to gate _mic_active and
- * signal listen.py to skip its own VAD pass.
+ * Diagnostic flow (browser VAD gate off):
+ *   processVADFrame(frame, ws, false) forwards every PCM frame so server-side VAD
+ *   can be used to test whether browser VAD is the failing component.
  */
 
 // -- tunables -----------------------------------------------------------------
 
-const VAD_THRESHOLD = 0.5;    // Silero speech probability cutoff (0-1)
+const VAD_THRESHOLD = 0.5;      // Silero speech probability cutoff (0-1)
 const SILENCE_TIMEOUT = 1200;   // ms of silence before utterance ends
 const PRE_SPEECH_BUFS = 10;     // ~320 ms of context kept before speech starts
 
@@ -101,12 +101,14 @@ function _resetState() {
  * Sends binary frames + VAD sentinel JSON messages over `ws`.
  * @param {Float32Array} frame  - 512 samples at 16 kHz mono
  * @param {WebSocket}    ws     - live WebSocket to Jetson
+ * @param {boolean}      gate   - true: browser VAD gates network audio;
+ *                                false: diagnostic raw PCM passthrough
  */
-async function processVADFrame(frame, ws) {
+async function processVADFrame(frame, ws, gate = true) {
     const epoch = _vadEpoch;
     if (!_canSend(ws, epoch)) return;
     if (!_session || _vadMode !== 'silero') {
-        processEnergyVADFrame(frame, ws, epoch);
+        processEnergyVADFrame(frame, ws, epoch, gate);
         return;
     }
 
@@ -124,6 +126,10 @@ async function processVADFrame(frame, ws) {
     _state = out.stateN;
     const prob = out.output.data[0];
 
+    if (!gate) {
+        ws.send(frame.buffer.slice(0));
+    }
+
     if (prob >= VAD_THRESHOLD) {
         if (_silTimer) { clearTimeout(_silTimer); _silTimer = null; }
 
@@ -131,19 +137,25 @@ async function processVADFrame(frame, ws) {
             _speaking = true;
             if (!_canSend(ws, epoch)) return;
             ws.send(JSON.stringify({ type: 'vad', event: 'start' }));
-            for (const buf of _preBuf) {
-                if (!_canSend(ws, epoch)) return;
-                ws.send(buf);
+            if (gate) {
+                for (const buf of _preBuf) {
+                    if (!_canSend(ws, epoch)) return;
+                    ws.send(buf);
+                }
             }
             _preBuf = [];
         }
 
-        if (!_canSend(ws, epoch)) return;
-        ws.send(frame.buffer.slice(0));
-    } else {
-        if (_speaking) {
+        if (gate) {
             if (!_canSend(ws, epoch)) return;
             ws.send(frame.buffer.slice(0));
+        }
+    } else {
+        if (_speaking) {
+            if (gate) {
+                if (!_canSend(ws, epoch)) return;
+                ws.send(frame.buffer.slice(0));
+            }
 
             if (!_silTimer) {
                 _silTimer = setTimeout(() => {
@@ -155,20 +167,23 @@ async function processVADFrame(frame, ws) {
                     ws.send(JSON.stringify({ type: 'vad', event: 'end' }));
                 }, SILENCE_TIMEOUT);
             }
-        } else {
+        } else if (gate) {
             _pushPreSpeech(frame);
         }
     }
 }
 
-function processEnergyVADFrame(frame, ws, epoch = _vadEpoch) {
+function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
     if (!_canSend(ws, epoch)) return;
+    if (!gate) {
+        ws.send(frame.buffer.slice(0));
+    }
     const rms = _rms(frame);
 
     if (!_speaking && rms >= ENERGY_START_RMS) {
         _energyHits++;
         if (_energyHits < ENERGY_MIN_FRAMES) {
-            _pushPreSpeech(frame);
+            if (gate) _pushPreSpeech(frame);
             return;
         }
 
@@ -177,19 +192,23 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch) {
         if (_silTimer) { clearTimeout(_silTimer); _silTimer = null; }
         if (!_canSend(ws, epoch)) return;
         ws.send(JSON.stringify({ type: 'vad', event: 'start' }));
-        for (const buf of _preBuf) {
+        if (gate) {
+            for (const buf of _preBuf) {
+                if (!_canSend(ws, epoch)) return;
+                ws.send(buf);
+            }
             if (!_canSend(ws, epoch)) return;
-            ws.send(buf);
+            ws.send(frame.buffer.slice(0));
         }
         _preBuf = [];
-        if (!_canSend(ws, epoch)) return;
-        ws.send(frame.buffer.slice(0));
         return;
     }
 
     if (_speaking) {
-        if (!_canSend(ws, epoch)) return;
-        ws.send(frame.buffer.slice(0));
+        if (gate) {
+            if (!_canSend(ws, epoch)) return;
+            ws.send(frame.buffer.slice(0));
+        }
 
         if (rms > ENERGY_END_RMS) {
             if (_silTimer) { clearTimeout(_silTimer); _silTimer = null; }
@@ -210,7 +229,7 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch) {
     }
 
     _energyHits = 0;
-    _pushPreSpeech(frame);
+    if (gate) _pushPreSpeech(frame);
 }
 
 function _canSend(ws, epoch) {

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -17,6 +17,7 @@ Environment variables (all optional):
     WS_PORT     — WebSocket port                (default 8765)
     NO_BROWSER  — set to "1" to suppress auto-open
     WEBUI_HTTPS — set to "1" to serve HTTPS/WSS for remote browser microphones
+    WEBUI_BROWSER_VAD_GATE — set to "0" to stream raw WebUI PCM for VAD diagnostics
     SSL_CERT    — optional TLS certificate path
     SSL_KEY     — optional TLS private key path
 """
@@ -48,6 +49,7 @@ NO_BROWSER = os.getenv("NO_BROWSER", "0") == "1"
 WEBUI_HTTPS = os.getenv("WEBUI_HTTPS", "0").lower() in {"1", "true", "yes", "on"}
 SSL_CERT = os.getenv("SSL_CERT", "")
 SSL_KEY = os.getenv("SSL_KEY", "")
+WEBUI_BROWSER_VAD_GATE = os.getenv("WEBUI_BROWSER_VAD_GATE", "1").lower() in {"1", "true", "yes", "on"}
 
 
 
@@ -116,12 +118,9 @@ class AikoWeb:
     All drawing methods become JSON WebSocket broadcasts.
     get_input() blocks on a threading.Queue until the browser submits a message.
 
-    VAD is handled entirely in the browser (vad.js / Silero ONNX WASM).
-    The browser sends {"type":"vad","event":"start"} when it detects speech onset
-    and {"type":"vad","event":"end"} when silence is detected after speech ends.
-    "end" is translated to an empty-bytes sentinel in _audio_q so _chunk_source
-    can signal listen.py to skip its own VAD pass and treat the frame stream as
-    a pre-segmented utterance.
+    Browser VAD gates WebUI microphone audio by default so silence/private
+    background audio is not streamed to the server. For diagnostics, set
+    WEBUI_BROWSER_VAD_GATE=0 to stream raw PCM and let server-side VAD segment it.
     """
 
     # ------------------------------------------------------------------
@@ -245,7 +244,7 @@ class AikoWeb:
                         # speech ended — push empty-bytes sentinel so _chunk_source
                         # returns None cleanly, ending the recording loop in listen.py
                         self._broadcast({"type": "voice", "status": "transcribing"})
-                        if self._mic_active.is_set():
+                        if WEBUI_BROWSER_VAD_GATE and self._mic_active.is_set():
                             self._audio_q.put(b"")  # end-of-utterance sentinel
 
         except websockets.exceptions.ConnectionClosed:
@@ -475,14 +474,10 @@ class AikoWeb:
         Capture a voice utterance via the browser's microphone and return the
         same (text, info) shape as AikoTUI.get_voice_input().
 
-        The browser's Silero VAD (vad.js) handles speech/silence detection:
-          - Only speech frames are sent as binary WS frames → _audio_q
-          - vad:start  → UI status update (handled in _ws_handler)
-          - vad:end    → empty-bytes sentinel pushed into _audio_q
-
-        _chunk_source feeds these frames into listen.py. When it receives the
-        empty-bytes sentinel it returns None, signalling end-of-utterance to
-        listen.py so it can skip its own VAD pass and go straight to ASR.
+        By default, the browser VAD gates 16 kHz float32 PCM before it enters
+        _audio_q, so only browser-detected speech is sent over the network. Set
+        WEBUI_BROWSER_VAD_GATE=0 for a diagnostic raw-stream mode that bypasses
+        browser gating and lets listen.py run server-side VAD.
         """
         result_holder = [None]
         done_event    = threading.Event()
@@ -495,8 +490,7 @@ class AikoWeb:
                 break
 
         BYTES_PER_CHUNK = 512 * 4   # 512 float32 samples = 2048 bytes
-        FRAME_TIMEOUT_S = 5.0       # longer timeout — browser VAD may take a moment
-                                    # to detect speech onset; 2 s was too aggressive
+        FRAME_TIMEOUT_S = 5.0       # browser disconnected / stopped delivering PCM
 
         def _chunk_source(n: int):
             """
@@ -538,12 +532,17 @@ class AikoWeb:
                 speak=speak,
                 wait_fn=wait_fn,
                 chunk_source=_chunk_source,
-                vad_presegmented=True,  # browser Silero VAD already segmented — skip MIN_SPEECH_CHUNKS gate
+                vad_presegmented=WEBUI_BROWSER_VAD_GATE,
             )
             done_event.set()
 
         self._mic_active.set()
-        self._broadcast({"type": "mic", "action": "start", "bytes_per_chunk": BYTES_PER_CHUNK})
+        self._broadcast({
+            "type": "mic",
+            "action": "start",
+            "bytes_per_chunk": BYTES_PER_CHUNK,
+            "browser_vad_gate": WEBUI_BROWSER_VAD_GATE,
+        })
         threading.Thread(target=_run, daemon=True).start()
 
         text_input = None


### PR DESCRIPTION
### Motivation

- Prevent streaming private silence/background audio by keeping browser VAD gating on by default while providing a diagnostics mode to exercise server-side VAD.
- Allow operators to stream raw browser PCM to the server to debug segmentation differences between browser and server VADs.
- Surface the gating choice through the UI so the client and server agree about how audio is being streamed.

### Description

- Introduce a new environment flag `WEBUI_BROWSER_VAD_GATE` (default `1`) and wire it into `webui.py` to control browser-side gating behavior and `listen.listen` presegmentation via `vad_presegmented`.
- Send the gating preference to the browser in the mic start message (`{

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a47fff5d22083288e94dc49c649b185)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a browser-side mic gating mode that can be enabled or disabled by the server.
  * Mic status now reflects whether audio is being gated in the browser or sent as raw input.
  * Added support for a server-controlled environment setting to toggle this behavior.

* **Bug Fixes**
  * Improved microphone audio handling so browser and server VAD behavior stay in sync.
  * Updated live audio forwarding to better support diagnostic, raw-audio capture flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->