### PR TITLE
Improve agentic fallback response

### DIFF
--- a/core/agentic.py
+++ b/core/agentic.py
@@ -500,6 +500,24 @@ def execute_tool_with_policy(name: str, args: dict, state: TaskState) -> ToolRes
 
 
 
+def _sanitize_user_facing_tool_detail(detail: str, max_chars: int = 300) -> str:
+    """Redact sensitive/internal-looking details before surfacing blockers."""
+    text = (detail or "").strip()
+    if not text:
+        return "unknown tool failure"
+    text = re.sub(
+        r"(?i)(api[_-]?key|token|secret|password)(\s*[:=]\s*)([^\s,;]+)",
+        r"\1\2[redacted]",
+        text,
+    )
+    text = re.sub(r"(?i)(authorization\s*:\s*bearer\s+)[A-Za-z0-9._~+/=-]+", r"\1[redacted]", text)
+    text = re.sub(r"(?i)(bearer\s+)[A-Za-z0-9._~+/=-]+", r"\1[redacted]", text)
+    text = re.sub(r"(?i)(https?://)(localhost|127\.0\.0\.1|0\.0\.0\.0|[^\s/]+\.local)([^\s)]*)", r"\1[internal-url-redacted]", text)
+    text = re.sub(r"(?m)^\s*File \"[^\n]+", "File [internal path redacted]", text)
+    text = re.sub(r"(?m)^\s*(Traceback \(most recent call last\):|During handling of the above exception.*)$", "[stack trace redacted]", text)
+    text = re.sub(r"\s+", " ", text).strip()
+    return text[:max_chars] or "unknown tool failure"
+
 def _build_incomplete_task_answer(state: TaskState, last_content: str = "") -> str:
     """Create a useful final response when the model never emits final_answer.
 
@@ -517,8 +535,8 @@ def _build_incomplete_task_answer(state: TaskState, last_content: str = "") -> s
     if state.failures:
         lines.append("I could not fully complete the task because of these blocker(s):")
         for failure in state.failures[-3:]:
-            detail = failure.content.strip() or failure.error_type or "unknown tool failure"
-            lines.append(f"- {failure.tool}: {detail[:300]}")
+            detail = _sanitize_user_facing_tool_detail(failure.content or failure.error_type or "")
+            lines.append(f"- {failure.tool}: {detail}")
     if last_content.strip():
         lines.append("Most recent model draft:")
         lines.append(last_content.strip())

--- a/core/agentic.py
+++ b/core/agentic.py
@@ -499,6 +499,36 @@ def execute_tool_with_policy(name: str, args: dict, state: TaskState) -> ToolRes
     return last
 
 
+
+def _build_incomplete_task_answer(state: TaskState, last_content: str = "") -> str:
+    """Create a useful final response when the model never emits final_answer.
+
+    This is the last-resort path for small/local models that keep looping,
+    produce invalid tool calls, or spend the whole iteration budget repairing a
+    final answer. It should disclose blockers without using the generic
+    "got lost" apology that makes successful partial work look like a total
+    failure.
+    """
+    lines: list[str] = []
+    if state.evidence:
+        lines.append("I completed these step(s):")
+        for item in state.evidence[-5:]:
+            lines.append(f"- {item[:600]}")
+    if state.failures:
+        lines.append("I could not fully complete the task because of these blocker(s):")
+        for failure in state.failures[-3:]:
+            detail = failure.content.strip() or failure.error_type or "unknown tool failure"
+            lines.append(f"- {failure.tool}: {detail[:300]}")
+    if last_content.strip():
+        lines.append("Most recent model draft:")
+        lines.append(last_content.strip())
+    if not lines:
+        lines.append(
+            "I could not complete the task before the agent loop reached its step limit, "
+            "and no tool results were recorded."
+        )
+    return "\n".join(lines)
+
 def _coerce_verifier_bool(value) -> bool:
     """Parse verifier booleans without treating non-empty strings as True."""
     if isinstance(value, bool):
@@ -758,15 +788,11 @@ def run_agentic_chat(owner, user_input: str, token_callback=None) -> str:
             break
 
     if not final_text:
-        if state.failures:
-            failed = "; ".join(f"{f.tool}: {f.content[:160]}" for f in state.failures[-3:])
-            final_text = (
-                "I got a bit lost trying to complete that task. "
-                f"Recent blocker(s): {failed}\n"
-                f"Here is what I have so far:\n{last_content}"
-            )
-        else:
-            final_text = "I got a bit lost trying to complete that task. Here is what I have so far:\n" + last_content
+        log.warning(
+            "Agent loop ended without a final answer after %s iterations; tools=%s failures=%s",
+            MAX_AGENT_ITER, len(state.steps), len(state.failures),
+        )
+        final_text = _build_incomplete_task_answer(state, last_content)
 
     owner._emit(final_text, token_callback=token_callback)
 

--- a/tests/test_agentic_fallback.py
+++ b/tests/test_agentic_fallback.py
@@ -1,0 +1,34 @@
+import os
+import sys
+import types
+
+sys.modules.setdefault("yaml", types.SimpleNamespace(safe_load=lambda *_args, **_kwargs: {}))
+sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda *_args, **_kwargs: None))
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from core.agentic import TaskState, ToolResult, _build_incomplete_task_answer
+
+
+def test_incomplete_task_answer_reports_successful_evidence_without_lost_apology():
+    state = TaskState(goal="search for simple current info")
+    state.record(ToolResult(ok=True, tool="web_search", args={"query": "Aiko"}, content="[Web search results]\n1. Useful result"))
+
+    answer = _build_incomplete_task_answer(state)
+
+    assert "I got a bit lost" not in answer
+    assert "I completed these step(s):" in answer
+    assert "web_search" in answer
+    assert "Useful result" in answer
+
+
+def test_incomplete_task_answer_discloses_blockers():
+    state = TaskState(goal="search web")
+    state.record(ToolResult(ok=False, tool="web_search", args={"query": "x"}, content="[search failed: connection refused]", error_type="search_failed"))
+
+    answer = _build_incomplete_task_answer(state, "")
+
+    assert "I got a bit lost" not in answer
+    assert "could not fully complete" in answer
+    assert "web_search" in answer
+    assert "connection refused" in answer

--- a/tests/test_agentic_fallback.py
+++ b/tests/test_agentic_fallback.py
@@ -7,7 +7,12 @@ sys.modules.setdefault("dotenv", types.SimpleNamespace(load_dotenv=lambda *_args
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from core.agentic import TaskState, ToolResult, _build_incomplete_task_answer
+from core.agentic import (
+    TaskState,
+    ToolResult,
+    _build_incomplete_task_answer,
+    _sanitize_user_facing_tool_detail,
+)
 
 
 def test_incomplete_task_answer_reports_successful_evidence_without_lost_apology():
@@ -32,3 +37,39 @@ def test_incomplete_task_answer_discloses_blockers():
     assert "could not fully complete" in answer
     assert "web_search" in answer
     assert "connection refused" in answer
+
+
+def test_incomplete_task_answer_includes_latest_model_draft():
+    state = TaskState(goal="draft something")
+
+    answer = _build_incomplete_task_answer(state, "Draft answer from the model")
+
+    assert "Most recent model draft:" in answer
+    assert "Draft answer from the model" in answer
+
+
+def test_incomplete_task_answer_handles_empty_state():
+    state = TaskState(goal="do something")
+
+    answer = _build_incomplete_task_answer(state)
+
+    assert "step limit" in answer
+    assert "no tool results were recorded" in answer
+
+
+def test_tool_failure_detail_is_sanitized_for_user_facing_fallback():
+    raw = (
+        "Traceback (most recent call last):\n"
+        "  File \"/workspace/Aiko-chan/core/toolkit/web.py\", line 1\n"
+        "Authorization: Bearer abc.def.ghi token=super-secret "
+        "http://localhost:8081/search?q=private"
+    )
+
+    sanitized = _sanitize_user_facing_tool_detail(raw)
+
+    assert "super-secret" not in sanitized
+    assert "abc.def.ghi" not in sanitized
+    assert "localhost:8081" not in sanitized
+    assert "/workspace/Aiko-chan" not in sanitized
+    assert "[redacted]" in sanitized
+    assert "[internal-url-redacted]" in sanitized


### PR DESCRIPTION
### Motivation
- The agent loop fell back to a hard-coded apology (`"I got a bit lost..."`) when the loop exhausted its iterations without emitting `final_answer`, which masked successful partial work and produced unhelpful user-facing text. 
- Provide a clearer, actionable final message that reports completed steps, discloses blockers, and includes the latest model draft when available. 

### Description
- Added a structured fallback generator `
_build_incomplete_task_answer(state, last_content)` in `core/agentic.py` that assembles evidence, disclosed failures, and the most recent draft instead of the generic apology. 
- Replaced the old fallback in `run_agentic_chat` with a log warning and a call to the new `_build_incomplete_task_answer` to produce more useful partial results. 
- Added regression tests in `tests/test_agentic_fallback.py` to ensure the new fallback reports successful tool evidence and properly discloses blockers and that the old "I got a bit lost" phrasing is not emitted in these cases. 

### Testing
- Ran `python -m py_compile core/agentic.py` to validate syntax; the check succeeded. 
- Ran `pytest -q tests/test_agentic_fallback.py` and the new tests passed (`2 passed`). 
- Attempted `uv run pytest -q tests/test_agentic_fallback.py` in the project environment but it was blocked by a missing local wheel (`onnxruntime_gpu-...whl`); this is an environment/package issue rather than a code failure.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a481a075f688328b20f00ca26311529)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the message shown when an agent task ends without a completed answer, making it more structured and easier to understand.
  * The fallback response now highlights recent successful steps, blockers, and the latest draft when available, instead of a vague generic message.
* **Tests**
  * Added coverage for the incomplete-answer fallback to verify it reports successful evidence and blocker details correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->