### PR TITLE
Per-user runtime paths, request-local user context, and SQLCipher handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,7 +99,7 @@ SECRET_KEY=<Generate a key — see command above>
 #     python3 -c "import secrets; print(secrets.token_urlsafe(64))"
 #   Store only in .env / Modal secrets / secret manager, never in YAML committed to git.
 AIKO_SQLITE_ENCRYPTION=0
-AIKO_DATA_KEY_SECRET=<Generate a separate data encryption secret>
+AIKO_DATA_KEY_SECRET="<Generate a separate data encryption secret>"
 
 # TERMS_STORE_PATH (optional):
 #   Where auth.py persists which users have accepted which TERMS_VERSION.

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ flowchart TD
 | Reflection publishing | optional GitHub REST API + Hugo markdown |
 | Agentic task mode | `core/agentic.py` ReAct loop + `core/tools.py` facade + `core/toolkit/` modules |
 | Skills | `skills/<id>/SKILL.md` workflow registry loaded by `core/skills.py` |
-| Scheduling | local schedule/reminder runner using `workspace/schedule.json` |
+| Scheduling | local schedule/reminder runner using `~/.aiko/<user_id>/schedule.json` |
 
 ---
 

--- a/config/memorize.yaml
+++ b/config/memorize.yaml
@@ -4,7 +4,7 @@
 # Tune local sqlite memory, embedding model behavior, memory decay, and monthly consolidation here.
 
 # -- Storage and embedding endpoint --
-SQLITE_MEMORY_PATH: ""  # Optional override; blank uses per-user ~/.aiko/users/<user_id>/memory.db.
+SQLITE_MEMORY_PATH: ""  # Optional override; blank uses per-user ~/.aiko/<user_id>/memory.db.
 EMBED_BASE_URL: "http://127.0.0.1:8080"  # Embedding server base URL used by core/embed.py.
 EMBED_MODEL: "harrier"  # Embedding model id/alias; must match server/custom embedder.
 EMBED_DIMS: "640"  # Vector dimensions; must match embedding model and sqlite-vec schema.
@@ -62,5 +62,5 @@ MONTHLY_CONSOLIDATION_MAX_INPUT_CHARS: "6000"  # Max source chars per monthly co
 MONTHLY_CONSOLIDATION_DELETE_DAILY_SUMMARIES: "1"  # After folding a month's pinned daily facts/day-records into "[YYYY-MM] ..." consolidated facts, delete the daily-granularity originals. Set to 0 to keep consolidation purely additive (compress + archive, no deletion) until you've verified retrieval/growth behavior.
 MONTHLY_CONSOLIDATION_MIN_MEMS: "5"  # Skip fallback months with fewer memories than this.
 MONTHLY_CONSOLIDATION_LLM_TIMEOUT: "120"  # Seconds before monthly summary LLM calls time out.
-MONTHLY_CONSOLIDATION_STATE_PATH: ""  # Optional override; blank uses per-user consolidation_state.json.
+MONTHLY_CONSOLIDATION_STATE_PATH: ""  # Optional override; blank uses per-user ~/.aiko/<user_id>/monthly_consolidation_state.jsonl.
 IDLE_LEARN_SECONDS: "1800"  # Seconds of inactivity before idle self-learning may start.

--- a/config/reflect.yaml
+++ b/config/reflect.yaml
@@ -4,6 +4,7 @@
 # Controls Hugo/GitHub destination metadata and optional image generation references.
 
 # -- GitHub/Hugo destination --
+REFLECT_BLOG_POST_ENABLED: "1"  # Toggle daily reflection Hugo/GitHub blog posting; 1=post, 0=generate/pin memory only.
 GITHUB_REPO: "OppaAI/aiko-blog"  # Repository for reflection posts, e.g. owner/repo.
 GITHUB_BRANCH: "main"  # Branch to write reflection posts to.
 HUGO_CONTENT_PATH: "content/posts"  # Path inside repo where markdown posts are written.

--- a/config/schedule.yaml
+++ b/config/schedule.yaml
@@ -1,13 +1,12 @@
 # Schedule config
 #
 # Settings for core/schedule.py.
-# This config stores scheduler paths and system job times; user-created jobs remain in workspace/schedule.json.
+# This config stores scheduler paths and system job times; user-created jobs remain in per-user schedule.json.
 
 # -- Paths and timezone --
 TIMEZONE: "America/Vancouver"  # IANA timezone name for reminders/jobs; examples: America/Vancouver, UTC, Asia/Tokyo.
-WORKSPACE_ROOT: ""  # Optional override; blank uses per-user ~/.aiko/users/<user_id>/workspace.
-SCHEDULE_PATH: ""  # Optional override; blank uses <workspace>/schedule.json.
-REMINDERS_PATH: ""  # Optional override; blank uses <workspace>/reminders.json.
+WORKSPACE_ROOT: ""  # Optional override; blank uses per-user ~/.aiko/<user_id>/workspace.
+SCHEDULE_PATH: ""  # Optional override; blank uses per-user ~/.aiko/<user_id>/schedule.json.
 
 # -- System job timing --
 DAILY_JOB_HOUR: "0"  # Local hour for daily reflection/dream job; integer 0-23.

--- a/config/social.yaml
+++ b/config/social.yaml
@@ -11,7 +11,7 @@ WEEKLY_SOCIAL_WEEKDAY: "sunday"  # Weekday for weekly draft; options: monday..su
 WEEKLY_SOCIAL_TIME: "18:00"  # Local wall-clock time for weekly draft in HH:MM 24-hour format.
 WEEKLY_SOCIAL_PROVIDERS: "x, threads"  # Comma-separated provider list; options currently include x, threads.
 WEEKLY_SOCIAL_MAX_CHARS: "260"  # Max post length; keep <= 260 for X with room for metadata/links.
-SOCIAL_ROOT: "workspace/social/weekly"  # Local folder for weekly review bundles.
+SOCIAL_ROOT: ""  # Optional override; blank uses per-user <workspace>/social/weekly.
 WEEKLY_SOCIAL_IMAGE_URL: ""  # Optional fallback public image URL for Threads when no local draft image exists; local images upload to ImgBB.
 
 # -- X relay metadata --

--- a/core/consolidate.py
+++ b/core/consolidate.py
@@ -64,10 +64,14 @@ CONSOLIDATION_KEEP_MONTHS     = max(1, int(os.getenv("MONTHLY_CONSOLIDATION_KEEP
 CONSOLIDATION_CHUNK_MEMS      = max(5, int(os.getenv("MONTHLY_CONSOLIDATION_CHUNK_MEMS", "25")))
 CONSOLIDATION_MAX_INPUT_CHARS = max(1000, int(os.getenv("MONTHLY_CONSOLIDATION_MAX_INPUT_CHARS", "6000")))
 CONSOLIDATION_MIN_MEMS        = max(1, int(os.getenv("MONTHLY_CONSOLIDATION_MIN_MEMS", "5")))
-CONSOLIDATION_STATE_PATH      = Path(
-    os.getenv("MONTHLY_CONSOLIDATION_STATE_PATH")
-    or str(user_state_path("consolidation_state.json", current_user_id()))
-)
+def consolidation_state_path(user_id: str | None = None) -> Path:
+    """Resolve monthly consolidation state path for the active user."""
+    override = os.getenv("MONTHLY_CONSOLIDATION_STATE_PATH")
+    if override:
+        return Path(override).expanduser()
+    return user_state_path("monthly_consolidation_state.jsonl", user_id or current_user_id())
+
+
 
 LLM_BASE_URL          = os.getenv("LLM_BASE_URL", "http://localhost:8080/v1")
 LLM_MODEL             = os.getenv("REFLECT_MODEL", os.getenv("LLM_MODEL", "ministral"))
@@ -115,14 +119,15 @@ def target_month_for(now: datetime) -> tuple[datetime, datetime, str]:
 
 def _load_state() -> dict:
     try:
-        return json.loads(CONSOLIDATION_STATE_PATH.read_text(encoding="utf-8"))
+        return json.loads(consolidation_state_path().read_text(encoding="utf-8"))
     except Exception:
         return {}
 
 
 def _save_state(state: dict) -> None:
-    CONSOLIDATION_STATE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    CONSOLIDATION_STATE_PATH.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
+    path = consolidation_state_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
 
 
 # ── LLM helpers ───────────────────────────────────────────────────────────────

--- a/core/memorize.py
+++ b/core/memorize.py
@@ -188,7 +188,11 @@ LIFECYCLE_BATCH_SIZE = int(os.getenv("MEMORY_LIFECYCLE_BATCH_SIZE", 500))
 MEMORY_RECENCY_RERANK_ENABLED = _env_bool("MEMORY_RECENCY_RERANK_ENABLED", "1")
 MEMORY_RECENCY_RERANK_THRESHOLD = float(os.getenv("MEMORY_RECENCY_RERANK_THRESHOLD", "0.012"))
 
-USER_ID = current_user_id()
+USER_ID = current_user_id  # Backward-compatible callable alias; resolve at call time.
+
+
+def _default_user_id(user_id: str | None = None) -> str:
+    return user_id or current_user_id()
 
 # ── trivial-input skip ────────────────────────────────────────────────────────
 # Words that carry no retrievable intent on their own. Built dynamically so
@@ -1017,8 +1021,9 @@ class _MemoryBackend:
         """
         return list(self.iter_all(user_id=user_id))
 
-    def get_since(self, since: datetime, user_id: str = USER_ID) -> list[dict]:
+    def get_since(self, since: datetime, user_id: str | None = None) -> list[dict]:
         """Return memories created on or after `since`, newest first."""
+        user_id = _default_user_id(user_id)
         rows = self._conn.execute(
             """
             SELECT * FROM memories
@@ -1029,8 +1034,9 @@ class _MemoryBackend:
         ).fetchall()
         return [dict(r) for r in rows]
 
-    def get_between(self, start: datetime, end: datetime, user_id: str = USER_ID) -> list[dict]:
+    def get_between(self, start: datetime, end: datetime, user_id: str | None = None) -> list[dict]:
         """Return memories created in [start, end), oldest first."""
+        user_id = _default_user_id(user_id)
         rows = self._conn.execute(
             """
             SELECT * FROM memories
@@ -1118,12 +1124,13 @@ class AikoMemorize:
 
     # ── write ─────────────────────────────────────────────────────────────────
 
-    def add(self, messages: list[dict], user_id: str = USER_ID) -> bool:
+    def add(self, messages: list[dict], user_id: str | None = None) -> bool:
         """
         Store a conversation turn into long-term memory.
         Returns True on success, False on failure.
         """
         try:
+            user_id = _default_user_id(user_id)
             t       = time.perf_counter()
             ids     = self._mem.add(messages, user_id=user_id)
             elapsed = time.perf_counter() - t
@@ -1137,13 +1144,14 @@ class AikoMemorize:
             log.error(f"Save failed: {e}")
             return False
 
-    def pin(self, messages: list[dict], user_id: str = USER_ID) -> bool:
+    def pin(self, messages: list[dict], user_id: str | None = None) -> bool:
         """
         Store messages and immediately mark all resulting memories as pinned.
         Pinned memories are immune to cleanup, dream pruning, and merge losses.
         Returns True on success, False on any failure.
         """
         try:
+            user_id = _default_user_id(user_id)
             ids = self._mem.add(messages, user_id=user_id)
 
             if not ids:
@@ -1174,7 +1182,7 @@ class AikoMemorize:
 
     # ── read ──────────────────────────────────────────────────────────────────
 
-    def search(self, query: str, user_id: str = USER_ID, limit: int = 5) -> list[dict]:
+    def search(self, query: str, user_id: str | None = None, limit: int = 5) -> list[dict]:
         """
         Retrieve top-k memories relevant to the current query.
         Side-effect: increments access_count and updates last_accessed_at
@@ -1187,6 +1195,7 @@ class AikoMemorize:
         through, so the skip applies everywhere without duplication. Any
         message with real content attached always searches normally.
         """
+        user_id = _default_user_id(user_id)
         if _is_trivial_input(query or ""):
             log.debug(f"Skipping search for trivial input: {query!r}")
             return []
@@ -1336,7 +1345,7 @@ class AikoMemorize:
 
     def dream(
         self,
-        user_id:   str   = USER_ID,
+        user_id:   str | None = None,
         dry_run:   bool  = False,
         threshold: float = DREAM_MERGE_THRESHOLD,
     ) -> dict:
@@ -1353,6 +1362,7 @@ class AikoMemorize:
 
         Returns dict: {boosted, merged, pruned, duration_s}
         """
+        user_id = _default_user_id(user_id)
         t_start = time.perf_counter()
         log.info(f"{'(dry-run) ' if dry_run else ''}Starting consolidation pass...")
 
@@ -1561,7 +1571,7 @@ class AikoMemorize:
 
     def cleanup(
         self,
-        user_id:   str   = USER_ID,
+        user_id:   str | None = None,
         threshold: float = CLEANUP_THRESHOLD,
         dry_run:   bool  = False,
         _all_mems: Optional[list[dict]] = None,
@@ -1577,6 +1587,7 @@ class AikoMemorize:
 
         Returns dict: {deleted, kept, failed, candidates (dry_run only)}.
         """
+        user_id = _default_user_id(user_id)
         source = [_all_mems] if _all_mems is not None else self._iter_memory_batches(user_id)
 
         kept = 0
@@ -1678,25 +1689,29 @@ class AikoMemorize:
 
     # ── debug ─────────────────────────────────────────────────────────────────
 
-    def get_all(self, user_id: str = USER_ID) -> list[dict]:
+    def get_all(self, user_id: str | None = None) -> list[dict]:
         """Return all stored memories for a user."""
+        user_id = _default_user_id(user_id)
         return self._mem.get_all(user_id=user_id)
 
-    def add_raw(self, memory: str, user_id: str = USER_ID, *, pinned: bool = False, metadata: Optional[dict] = None) -> str | None:
+    def add_raw(self, memory: str, user_id: str | None = None, *, pinned: bool = False, metadata: Optional[dict] = None) -> str | None:
         """Persist one already-curated memory string without LLM extraction."""
         # metadata is accepted for call-site clarity; the current schema stores
         # only the curated text plus pinned flag.
+        user_id = _default_user_id(user_id)
         mem_id = self._mem.add_raw(memory, user_id=user_id, pinned=pinned)
         if mem_id:
             self._clear_search_cache()
         return mem_id
 
-    def get_since(self, since: datetime, user_id: str = USER_ID) -> list[dict]:
+    def get_since(self, since: datetime, user_id: str | None = None) -> list[dict]:
         """Return memories created on or after `since`, newest first."""
+        user_id = _default_user_id(user_id)
         return self._mem.get_since(since, user_id=user_id)
 
-    def get_between(self, start: datetime, end: datetime, user_id: str = USER_ID) -> list[dict]:
+    def get_between(self, start: datetime, end: datetime, user_id: str | None = None) -> list[dict]:
         """Return memories created in [start, end), oldest first."""
+        user_id = _default_user_id(user_id)
         return self._mem.get_between(start, end, user_id=user_id)
 
     def delete(self, memory_id: str) -> None:
@@ -1704,8 +1719,9 @@ class AikoMemorize:
         self._mem.delete(memory_id)
         self._clear_search_cache()
 
-    def clear(self, user_id: str = USER_ID) -> None:
+    def clear(self, user_id: str | None = None) -> None:
         """Wipe all memories for a user. Use carefully."""
+        user_id = _default_user_id(user_id)
         self._mem.delete_all(user_id=user_id)
         self._clear_search_cache()
         log.info(f"Cleared all memories for user '{user_id}'.")

--- a/core/reflect.py
+++ b/core/reflect.py
@@ -75,6 +75,7 @@ SOUL_PATH         = os.getenv("SOUL_PATH", "persona/soul.md")
 
 REFLECT_MAX_MEMS  = int(os.getenv("REFLECT_MAX_MEMS", 50))
 REFLECT_TAGS      = os.getenv("REFLECT_TAGS", "daily-reflection,ai-journal,aiko")
+REFLECT_BLOG_POST_ENABLED = os.getenv("REFLECT_BLOG_POST_ENABLED", "1").lower() in {"1", "true", "yes", "on"}
 
 IMAGEGEN_URL          = os.getenv("IMAGEGEN_URL", "https://oppa-ai-org--aiko-imagegen-fastapi-app.modal.run")
 REFERENCE_IMAGE  = os.getenv("REFERENCE_IMAGE", os.path.expanduser("~/Aiko-chan/assets/Aiko-chan.png"))
@@ -774,8 +775,13 @@ def generate_and_post(
         except Exception as e:
             log.error(f"Daily record pin failed: {e}")
 
-    # Step 5: push image and Hugo post together
-    success = _push_post_and_image(slug, content, image_b64 if image_generated else None, date)
+    # Step 5: optionally push image and Hugo post together. Daily memory
+    # pins still happen even when public blog posting is disabled.
+    if REFLECT_BLOG_POST_ENABLED:
+        success = _push_post_and_image(slug, content, image_b64 if image_generated else None, date)
+    else:
+        log.info("Daily reflection blog posting disabled; skipping GitHub push for %s.", slug)
+        success = True
 
     log.info(
         f"{'Done' if success else 'Failed'} — "

--- a/core/schedule.py
+++ b/core/schedule.py
@@ -47,13 +47,19 @@ from typing import Any, Callable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from core.log import get_logger
-from core.user_context import user_workspace_root
+from core.user_context import user_state_path, user_workspace_root
 
 log = get_logger(__name__)
 
-WORKSPACE_ROOT = Path(os.getenv("WORKSPACE_ROOT") or user_workspace_root()).resolve()
-SCHEDULE_PATH = Path(os.getenv("SCHEDULE_PATH") or WORKSPACE_ROOT / "schedule.json").resolve()
-LEGACY_REMINDERS_PATH = Path(os.getenv("REMINDERS_PATH") or WORKSPACE_ROOT / "reminders.json").resolve()
+def workspace_root() -> Path:
+    """Resolve the active user workspace root lazily."""
+    return Path(os.getenv("WORKSPACE_ROOT") or user_workspace_root()).resolve()
+
+
+def schedule_path() -> Path:
+    """Resolve the active user schedule path lazily."""
+    return Path(os.getenv("SCHEDULE_PATH") or user_state_path("schedule.json")).resolve()
+
 DEFAULT_TIMEZONE = os.getenv("TIMEZONE", "UTC")
 
 # System job timing — env overridable, not user-modifiable via schedule.json
@@ -263,46 +269,18 @@ def _read_raw(path: Path) -> list[dict]:
         return []
 
 
-def _migrate_legacy_reminders(records: list[dict]) -> list[dict]:
-    """Convert older reminder records into the scheduled-job shape."""
-    migrated = []
-    for record in records:
-        migrated.append({
-            "id": record.get("id", uuid.uuid4().hex[:12]),
-            "title": record.get("title", "Reminder"),
-            "task": record.get("message", record.get("title", "Reminder")),
-            "time_of_day": record.get("time_of_day", "06:00"),
-            "frequency": "daily" if record.get("repeat") == "daily" else "once",
-            "days_of_week": [],
-            "timezone": record.get("timezone", DEFAULT_TIMEZONE),
-            "next_due": record.get("next_due"),
-            "created_at": record.get("created_at", _now(record.get("timezone")).isoformat()),
-            "last_ran_at": None,
-            "enabled": record.get("enabled", True),
-            "kind": "reminder",
-            "action": "announce",
-        })
-    return migrated
-
-
 def _read_all() -> list[dict]:
-    """Read scheduled jobs, including one-time migration from reminders.json."""
-    records = _read_raw(SCHEDULE_PATH)
-    if records:
-        return records
-    legacy = _read_raw(LEGACY_REMINDERS_PATH)
-    if legacy:
-        records = _migrate_legacy_reminders(legacy)
-        _write_all(records)
-    return records
+    """Read scheduled jobs for the active user."""
+    return _read_raw(schedule_path())
 
 
 def _write_all(jobs: list[dict]) -> None:
     """Persist scheduled jobs atomically enough for a single local process."""
-    SCHEDULE_PATH.parent.mkdir(parents=True, exist_ok=True)
-    tmp = SCHEDULE_PATH.with_suffix(".tmp")
+    path = schedule_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
     tmp.write_text(json.dumps(jobs, ensure_ascii=False, indent=2), encoding="utf-8")
-    tmp.replace(SCHEDULE_PATH)
+    tmp.replace(path)
 
 
 def schedule_job_record(

--- a/core/secure.py
+++ b/core/secure.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import base64
 import hashlib
 import hmac
 import os
@@ -32,19 +31,13 @@ def _data_secret() -> bytes:
 
 
 def derive_user_sqlite_key(user_id: str) -> str:
-    """Derive a stable per-user SQLCipher passphrase from server secret + user id.
+    """Derive a stable per-user 256-bit SQLCipher raw key.
 
     OAuth user ids are public identifiers, so they are context/salt only. The
     secrecy comes from AIKO_DATA_KEY_SECRET (preferred) or SECRET_KEY.
-    HMAC-SHA256 is intentionally fast because the input secret is server-side
-    high entropy; Argon2id is mainly for low-entropy human passwords.
     """
     digest = hmac.new(_data_secret(), f"aiko-sqlite:{user_id}".encode("utf-8"), hashlib.sha256).digest()
-    return base64.urlsafe_b64encode(digest).decode("ascii")
-
-
-def _quote_sqlcipher_key(key: str) -> str:
-    return "'" + key.replace("'", "''") + "'"
+    return digest.hex()
 
 
 def connect_sqlite(path: str | os.PathLike[str], *, user_id: str) -> Any:
@@ -66,11 +59,14 @@ def connect_sqlite(path: str | os.PathLike[str], *, user_id: str) -> Any:
         ) from exc
 
     conn = sqlcipher.connect(str(path), check_same_thread=False)
-    key = derive_user_sqlite_key(user_id)
-    conn.execute(f"PRAGMA key = {_quote_sqlcipher_key(key)}")
-    conn.execute("PRAGMA cipher_page_size = 4096")
-    conn.execute("PRAGMA kdf_iter = 256000")
-    # Force key validation immediately, so a wrong key fails at boot instead of
-    # later after partial initialization.
-    conn.execute("SELECT count(*) FROM sqlite_master")
-    return conn
+    try:
+        key = derive_user_sqlite_key(user_id)
+        conn.execute(f"PRAGMA key = \"x'{key}'\"")
+        conn.execute("PRAGMA cipher_page_size = 4096")
+        # Force key validation immediately, so a wrong key fails at boot instead of
+        # later after partial initialization.
+        conn.execute("SELECT count(*) FROM sqlite_master")
+        return conn
+    except Exception:
+        conn.close()
+        raise

--- a/core/social.py
+++ b/core/social.py
@@ -37,14 +37,20 @@ import requests
 from openai import OpenAI
 
 from core.log import get_logger
-from core.memorize import AikoMemorize, USER_ID
+from core.memorize import AikoMemorize
 from core.user_context import user_workspace_root
 from core.reflect import _generate_image, _load_soul
 
 log = get_logger(__name__)
 
-WORKSPACE_ROOT = Path(os.getenv("WORKSPACE_ROOT") or user_workspace_root()).resolve()
-WEEKLY_SOCIAL_ROOT = Path(os.getenv("SOCIAL_ROOT") or WORKSPACE_ROOT / "social" / "weekly").resolve()
+def workspace_root() -> Path:
+    """Resolve the active user workspace root lazily."""
+    return Path(os.getenv("WORKSPACE_ROOT") or user_workspace_root()).resolve()
+
+
+def weekly_social_root() -> Path:
+    """Resolve the active user weekly social output root lazily."""
+    return Path(os.getenv("SOCIAL_ROOT") or workspace_root() / "social" / "weekly").resolve()
 TIMEZONE_NAME = os.getenv("TIMEZONE", "UTC")
 
 WEEKLY_AUTODRAFT = os.getenv("WEEKLY_SOCIAL_AUTODRAFT", "1").lower() in {"1", "true", "yes", "on"}
@@ -236,7 +242,7 @@ def _decode_image(image_b64: str, path: Path) -> bool:
 def generate_weekly_draft(memorize: AikoMemorize, *, force: bool = False, now: datetime | None = None) -> dict[str, Any]:
     """Create a weekly social draft bundle for review."""
     window = last_completed_sunday_saturday(now=now)
-    draft_dir = WEEKLY_SOCIAL_ROOT / window.label
+    draft_dir = weekly_social_root() / window.label
     meta_path = draft_dir / "draft.json"
     if meta_path.exists() and not force:
         return {"success": True, "skipped": True, "reason": "draft_exists", "draft_dir": str(draft_dir)}

--- a/core/toolkit/common.py
+++ b/core/toolkit/common.py
@@ -11,10 +11,18 @@ from typing import Any
 
 from core.user_context import user_workspace_root
 
-WORKSPACE_ROOT = user_workspace_root()
-NOTES_DIR = WORKSPACE_ROOT / "notes"
 MAX_WRITE_CHARS = int(os.getenv("MAX_WRITE_CHARS", 20_000))
 MAX_READ_CHARS = int(os.getenv("MAX_READ_CHARS", 12_000))
+
+
+def workspace_root() -> Path:
+    """Resolve the active user workspace root lazily."""
+    return user_workspace_root()
+
+
+def notes_dir() -> Path:
+    """Resolve the active user notes directory lazily."""
+    return workspace_root() / "notes"
 
 
 def now_stamp() -> str:
@@ -29,10 +37,11 @@ def slugify(text: str, fallback: str = "task") -> str:
 
 
 def safe_path(relative_path: str) -> Path:
-    """Resolve a user path under WORKSPACE_ROOT, rejecting path traversal."""
+    """Resolve a user path under the active WORKSPACE_ROOT, rejecting traversal."""
+    root = workspace_root()
     cleaned = relative_path.strip().lstrip("/\\")
-    path = (WORKSPACE_ROOT / cleaned).resolve()
-    if path != WORKSPACE_ROOT and WORKSPACE_ROOT not in path.parents:
+    path = (root / cleaned).resolve()
+    if path != root and root not in path.parents:
         raise ValueError(f"path escapes workspace: {relative_path}")
     return path
 

--- a/core/toolkit/photo_grader.py
+++ b/core/toolkit/photo_grader.py
@@ -7,7 +7,7 @@ from datetime import datetime, timezone
 from itertools import islice
 from pathlib import Path
 
-from core.toolkit.common import WORKSPACE_ROOT, json_block, now_stamp, safe_path, slugify
+from core.toolkit.common import json_block, now_stamp, safe_path, slugify, workspace_root
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".tif", ".tiff", ".webp", ".heic", ".dng", ".cr2", ".cr3", ".nef", ".arw", ".orf", ".rw2"}
 DEFAULT_PHOTO_INBOX = "photos/inbox"
@@ -34,7 +34,7 @@ def scan_photo_workspace(inbox: str = DEFAULT_PHOTO_INBOX, limit: int = 100) -> 
             "exists": root.exists(),
             "image_count": len(files),
             "by_extension": dict(sorted(by_ext.items())),
-            "files": [str(p.relative_to(WORKSPACE_ROOT)) for p in files[:50]],
+            "files": [str(p.relative_to(workspace_root())) for p in files[:50]],
             "note": "Use propose_photo_ingestion to create a dry-run plan before moving or editing metadata.",
         })
     except Exception as e:
@@ -48,7 +48,7 @@ def propose_photo_ingestion(inbox: str = DEFAULT_PHOTO_INBOX, library_root: str 
         files = _image_files(root, 100)
         planned = []
         for path in files:
-            rel = path.relative_to(WORKSPACE_ROOT)
+            rel = path.relative_to(workspace_root())
             stem_slug = slugify(path.stem, fallback="photo")
             planned.append({
                 "source": str(rel),

--- a/core/toolkit/planner.py
+++ b/core/toolkit/planner.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import textwrap
 from datetime import datetime, timezone
 
-from core.toolkit.common import MAX_READ_CHARS, MAX_WRITE_CHARS, NOTES_DIR, json_block, now_stamp, safe_path, slugify
+from core.toolkit.common import MAX_READ_CHARS, MAX_WRITE_CHARS, json_block, notes_dir, now_stamp, safe_path, slugify
 
 
 def make_plan(goal: str, constraints: str = "", max_steps: int = 8) -> str:
@@ -44,7 +44,7 @@ def create_checklist(title: str, items: list[str] | str) -> str:
 
 def save_note(title: str, content: str, folder: str = "notes") -> str:
     """Save a note, plan, draft, or task artifact under WORKSPACE_ROOT."""
-    base = NOTES_DIR if folder == "notes" else safe_path(folder)
+    base = notes_dir() if folder == "notes" else safe_path(folder)
     base.mkdir(parents=True, exist_ok=True)
     filename = f"{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}-{slugify(title)}.md"
     path = base / filename

--- a/core/user_context.py
+++ b/core/user_context.py
@@ -2,17 +2,29 @@
 
 from __future__ import annotations
 
+import contextvars
 import os
 import re
 from pathlib import Path
 
 _DEFAULT_USER_ID = "OppaAI"
 _SAFE_RE = re.compile(r"[^A-Za-z0-9_.-]+")
+_CURRENT_USER_ID: contextvars.ContextVar[str | None] = contextvars.ContextVar("aiko_current_user_id", default=None)
+
+
+def set_current_user_id(user_id: str | None) -> contextvars.Token[str | None]:
+    """Set the request-local active user id and return a token for reset()."""
+    return _CURRENT_USER_ID.set(user_id)
+
+
+def reset_current_user_id(token: contextvars.Token[str | None]) -> None:
+    """Reset the request-local active user id using a token from set_current_user_id()."""
+    _CURRENT_USER_ID.reset(token)
 
 
 def current_user_id() -> str:
     """Return the active runtime user id from OAuth/session or local env."""
-    return os.getenv("AIKO_USER_ID") or os.getenv("USER_ID") or _DEFAULT_USER_ID
+    return _CURRENT_USER_ID.get() or os.getenv("AIKO_USER_ID") or os.getenv("USER_ID") or _DEFAULT_USER_ID
 
 
 def normalize_user_id(provider: str | None, user_id: object) -> str:
@@ -24,7 +36,8 @@ def normalize_user_id(provider: str | None, user_id: object) -> str:
 
 def user_state_dir(user_id: str | None = None) -> Path:
     """Root directory for user-private mutable state."""
-    root = Path(os.getenv("AIKO_USER_STATE_ROOT", str(Path.home() / ".aiko" / "users"))).expanduser()
+    root_value = os.getenv("AIKO_USER_STATE_ROOT") or str(Path.home() / ".aiko")
+    root = Path(root_value).expanduser()
     uid = _SAFE_RE.sub("_", user_id or current_user_id()).strip("._-") or _DEFAULT_USER_ID
     return root / uid
 

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -140,7 +140,7 @@ Major additions:
 - agentic skill discovery and retrieval in `core/skills.py`
 - agentic task-mode skill context injection
 - initial `wildlife_photo`, `aiko_architect`, `coding_tutor`, `japanese_tutor`, and `aurora_forecast_watch` skill projects
-- local scheduling/reminder infrastructure using `workspace/schedule.json`
+- local scheduling/reminder infrastructure using per-user `schedule.json`
 - final-answer verification/repair safeguards in the agentic loop
 - monthly memory consolidation for older full months, using memory facts so the LLM never needs an entire month in one context window
 - routing decision upgrade: keyword-only task detection was replaced by a dual path — fast semantic exemplar routing by default, with optional LLM routing/fallback for context-heavy cases

--- a/docs/MULTI_USER.md
+++ b/docs/MULTI_USER.md
@@ -5,11 +5,12 @@ This is the simple `$5 Patreon tester` isolation model for Aiko. OAuth is the so
 ## Current implementation
 
 - OAuth sessions store a provider-scoped runtime id, such as `github_123456` or `patreon_987654321`, to avoid collisions between providers.
-- User-private state defaults to `~/.aiko/users/<user_id>/`:
+- User-private state defaults to `~/.aiko/<user_id>/`:
   - `user.md` for the user's editable bio/profile.
   - `memory.db` for that user's sqlite-vec memory store.
-  - `consolidation_state.json` for that user's monthly consolidation state.
-  - `workspace/` for that user's notes, schedules, reminders, and tool artifacts.
+  - `monthly_consolidation_state.jsonl` for that user's monthly consolidation state.
+  - `schedule.json` for that user's scheduled jobs/reminders.
+  - `workspace/` for that user's notes and tool artifacts; this can later be redirected to a mounted/synced Google Drive workspace via `WORKSPACE_ROOT`.
 - Existing env overrides still work for local/owner operation; leave YAML path overrides blank for per-user defaults:
   - `USER_ID` or `AIKO_USER_ID`
   - `SQLITE_MEMORY_PATH`
@@ -30,7 +31,7 @@ Do **not** derive an encryption key from only the OAuth user id. User ids are no
 - public context: `provider:user_id`
 - output: per-user encryption key
 
-`sqlite-vec` itself does not provide encryption with a normal SQLite `PRAGMA`. Aiko now has an optional SQLCipher hook for the memory DB: set `AIKO_SQLITE_ENCRYPTION=1`, install a SQLCipher-capable Python driver such as `pysqlcipher3`, and set `AIKO_DATA_KEY_SECRET` in `.env`, Modal secrets, or another secret manager. Aiko derives a per-user SQLCipher passphrase from the server secret plus provider-scoped user id. This keeps latency low because encryption happens at SQLite page I/O, not per vector operation. If SQLCipher is not available in the deployment image, keep using OS/disk encryption, strict filesystem permissions, and per-user files/directories until the image is upgraded.
+`sqlite-vec` itself does not provide encryption with a normal SQLite `PRAGMA`. Aiko now has an optional SQLCipher hook for the memory DB: set `AIKO_SQLITE_ENCRYPTION=1`, install a SQLCipher-capable Python driver such as `pysqlcipher3`, and set `AIKO_DATA_KEY_SECRET` in `.env`, Modal secrets, or another secret manager. Aiko derives a per-user SQLCipher raw key from the server secret plus provider-scoped user id. This keeps latency low because encryption happens at SQLite page I/O, not per vector operation. If SQLCipher is not available in the deployment image, keep using OS/disk encryption, strict filesystem permissions, and per-user files/directories until the image is upgraded.
 
 ## Workspace encryption
 
@@ -41,16 +42,20 @@ For a simple online tester tier, prefer encrypting the storage layer instead of 
 3. Keep each user in a separate directory.
 4. Avoid writing secrets into workspace files.
 
-If the backend runs in Modal, the workspace is server-side unless you explicitly build a client upload/download feature. A browser app cannot silently read arbitrary files from a user's PC; users must upload files through a file picker, and Aiko can only access files that were uploaded to the backend workspace. To let a user take their workspace home, add an authenticated export endpoint that zips only `~/.aiko/users/<user_id>/workspace/` and streams it to the browser.
+If the backend runs in Modal, the workspace is server-side unless you explicitly build a client upload/download feature. A browser app cannot silently read arbitrary files from a user's PC; users must upload files through a file picker, and Aiko can only access files that were uploaded to the backend workspace. To let a user take their workspace home, add an authenticated export endpoint that zips only `~/.aiko/<user_id>/workspace/` and streams it to the browser.
 
 Per-file encryption can come later, but it complicates search, previews, scheduled jobs, and tool access because every tool must decrypt/re-encrypt correctly.
+
+## Google Drive workspace direction
+
+No agentic-tool changes are required just to move Aiko's writable workspace later. The existing workspace tools already go through `WORKSPACE_ROOT`. When Google Drive/Gmail access is added, initialize or mount/sync the Drive-backed workspace during boot/warmup, then point `WORKSPACE_ROOT` at that mounted directory. Keep private runtime state such as `memory.db`, `schedule.json`, and `monthly_consolidation_state.jsonl` under `~/.aiko/<user_id>/` rather than in Drive unless you explicitly want those files synced.
 
 ## Other per-user state to keep isolated
 
 - OAuth sessions and terms acceptance records.
 - Memory DB and daily reflection facts.
 - Monthly consolidation state.
-- Workspace files, schedules, reminders, generated reports, and photo inboxes.
+- Schedule/reminder state, workspace files, generated reports, and photo inboxes.
 - User profile/bio markdown.
 - Any future upload/cache directory that can contain private user content.
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -334,7 +334,7 @@ Run before any phase suite.
 
 ### 2.5.6 Scheduling and reminders
 
-- [ ] Asking Aiko to schedule a reminder creates/updates `workspace/schedule.json`.
+- [ ] Asking Aiko to schedule a reminder creates/updates `~/.aiko/<user_id>/schedule.json`.
 - [ ] `list_schedule` reports IDs, titles, due times, frequency, action, and timezone clearly.
 - [ ] `cancel_schedule` removes the selected job and persists the change.
 - [ ] Once, hourly, daily, weekdays, weekly, biweekly, monthly, and custom weekday schedules are tested.
@@ -342,7 +342,7 @@ Run before any phase suite.
 - [ ] Invalid times, unsupported frequencies, invalid weekdays, duplicate jobs, and past-due once jobs are handled safely.
 - [ ] Due announce jobs play a notification/beep when available and inject a reminder turn into chat.
 - [ ] Agentic scheduled jobs execute only local approved actions and disclose failures.
-- [ ] Corrupt `workspace/schedule.json` is handled with backup/recovery or a clear error; no silent data loss.
+- [ ] Corrupt `~/.aiko/<user_id>/schedule.json` is handled with backup/recovery or a clear error; no silent data loss.
 
 ### 2.5.7 Photo workflow
 

--- a/webui/auth.py
+++ b/webui/auth.py
@@ -138,7 +138,10 @@ def _create_session(user_id, username: str, email: str | None, provider: str) ->
         "created_at": datetime.now(),
         # gate stays closed until they check the box, unless they've already
         # accepted this exact terms version in a previous session
-        "accepted_terms": _has_accepted_terms(provider, runtime_user_id),
+        "accepted_terms": (
+            _has_accepted_terms(provider, runtime_user_id)
+            or _has_accepted_terms(provider, user_id)
+        ),
     }
     return session_id
 

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -38,6 +38,7 @@ from pathlib import Path
 import websockets
 
 from core.config import load_config
+from core.user_context import reset_current_user_id, set_current_user_id
 load_config()
 from websockets.server import serve as ws_serve
 
@@ -261,6 +262,7 @@ class AikoWeb:
             await ws.close(code=1008)
             return
 
+        user_context_token = set_current_user_id(str(session["user_id"]))
         os.environ["AIKO_USER_ID"] = str(session["user_id"])
         await ws.accept()
 
@@ -292,6 +294,7 @@ class AikoWeb:
                     if mtype == "user_input":
                         text = (msg.get("text") or "").strip()
                         if text:
+                            set_current_user_id(str(session["user_id"]))
                             os.environ["AIKO_USER_ID"] = str(session["user_id"])
                             self._input_q.put(text)
 
@@ -312,6 +315,7 @@ class AikoWeb:
         except Exception as e:
             log.exception("[aiko-web] error in WebSocket loop")
         finally:
+            reset_current_user_id(user_context_token)
             with self._clients_lock:
                 self._clients.discard(ws)
             log.info("[aiko-web] browser disconnected (total=%d)", len(self._clients))

--- a/wiki/runtime_state.md
+++ b/wiki/runtime_state.md
@@ -22,9 +22,9 @@ Purpose: keep Aiko from mixing user settings, runtime state, and generated work.
 
 Keep scheduler defaults in `config/schedule.yaml`.
 
-Keep user-created scheduled jobs in `workspace/schedule.json`. This file is runtime state: Aiko and the scheduler update it while running. It should stay in workspace unless the scheduler is intentionally redesigned to use another state directory.
+Keep user-created scheduled jobs in `~/.aiko/<user_id>/schedule.json`. This file is runtime state: Aiko and the scheduler update it while running. It should stay in the per-user state directory, not in config or shared workspace directories.
 
-Do not move `workspace/schedule.json` into `config/` just because it looks like settings. It contains mutable jobs, not static defaults.
+Do not move `~/.aiko/<user_id>/schedule.json` into `config/` just because it looks like settings. It contains mutable jobs, not static defaults.
 
 ## When To Use Runtime
 

--- a/wiki/runtime_state.md
+++ b/wiki/runtime_state.md
@@ -15,7 +15,7 @@ Purpose: keep Aiko from mixing user settings, runtime state, and generated work.
 - `config/`: human-maintained defaults and settings that shape Aiko's behavior.
 - `skills/`: reusable workflows plus skill-specific defaults.
 - `wiki/`: operational routing cards and examples Aiko can retrieve before acting.
-- `workspace/`: Aiko's working area for generated notes, reports, schedules, reminders, and task artifacts.
+- `workspace/`: Aiko's working area for generated notes, reports, and task artifacts.
 - `logs/`: runtime logs and diagnostics.
 
 ## Schedule Files


### PR DESCRIPTION
### Motivation
- Move runtime state from a single shared workspace to per-user directories under `~/.aiko/<user_id>/` so multi-user sessions (OAuth/browser) are isolated and safer.
- Make user identity request-local so server-hosted WebUI and background jobs resolve the active user reliably without module-level globals.
- Lazily resolve workspace/state paths and remove hard-coded module-level Path constants to support per-user overrides and env-based overrides.
- Fix and harden optional SQLCipher integration and clarify related env defaults/docs.

### Description
- Introduced a request-local user id using `contextvars` with `set_current_user_id`/`reset_current_user_id` and updated `current_user_id()` to use it in `core/user_context.py`.
- Replaced many module-level `WORKSPACE_ROOT`/`SCHEDULE_PATH`/`SOCIAL_ROOT` constants with lazy resolver functions (`workspace_root()`, `schedule_path()`, `weekly_social_root()`, `consolidation_state_path()`, `notes_dir()`, etc.) and updated callers across `core/*`, `core/toolkit/*`, and `core/social.py`.
- Made `AikoMemorize` and internal memory backend APIs accept optional `user_id` parameters and resolve the default via `_default_user_id()` at call time, propagating per-user behavior to `add`, `pin`, `search`, `dream`, `cleanup`, `get_all`, `add_raw`, `get_since`, `get_between`, `clear`.
- Changed monthly consolidation state handling to use `monthly_consolidation_state.jsonl` per user and added `consolidation_state_path()` helper; updated `core/consolidate.py` to use it.
- Added WebUI session-scoped user id handling in `webui/webui.py` so each WebSocket handler sets and resets the request-local user id for operations originating from the browser session.
- Hardened SQLCipher handling in `core/secure.py`: `derive_user_sqlite_key()` now returns a raw 256-bit hex key instead of base64 and the `connect_sqlite()` key PRAGMA uses the SQLCipher raw-key quoting form, with cleanup on failure.
- Added optional toggle for public blog posting `REFLECT_BLOG_POST_ENABLED` in `core/reflect.py` and skipped GitHub push when disabled while still pinning daily facts.
- Minor docs/config/readme/.env example updates to reflect per-user defaults, path changes, and quoting `AIKO_DATA_KEY_SECRET` in `.env.example`.

### Testing
- Ran a compile-time smoke check with `python -m compileall .` to validate imports and top-level symbol changes, which completed successfully.
- No project unit test suite was modified or run as part of this change; integration/manual validation is recommended for multi-user flows (WebUI login, scheduled jobs, and SQLCipher-enabled deployments).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d749ca160832bbde4a191020cc8a7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-user runtime state, including schedules, memory, and consolidation data.
  * Added an option to turn daily blog posting on or off for reflection workflows.

* **Bug Fixes**
  * Improved handling of user identity across sessions so actions stay tied to the correct signed-in user.
  * Updated encryption setup and key handling for more reliable secure storage.
  * Tightened schedule file handling to better protect against corrupt or missing state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->