### PR TITLE
Fix multi-user state isolation and environment handling

### DIFF
--- a/core/consolidate.py
+++ b/core/consolidate.py
@@ -117,15 +117,15 @@ def target_month_for(now: datetime) -> tuple[datetime, datetime, str]:
 
 # ── state ────────────────────────────────────────────────────────────────────
 
-def _load_state() -> dict:
+def _load_state(user_id: str | None = None) -> dict:
     try:
-        return json.loads(consolidation_state_path().read_text(encoding="utf-8"))
+        return json.loads(consolidation_state_path(user_id).read_text(encoding="utf-8"))
     except Exception:
         return {}
 
 
-def _save_state(state: dict) -> None:
-    path = consolidation_state_path()
+def _save_state(state: dict, user_id: str | None = None) -> None:
+    path = consolidation_state_path(user_id)
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(state, ensure_ascii=False), encoding="utf-8")
 
@@ -283,7 +283,7 @@ def _merge_monthly_facts(month_key: str, chunk_facts: list[list[str]]) -> list[s
 
 # ── main entrypoint ───────────────────────────────────────────────────────────
 
-def maybe_run_consolidation(memorize, now: datetime | None = None) -> dict:
+def maybe_run_consolidation(memorize, now: datetime | None = None, user_id: str | None = None) -> dict:
     """
     Run monthly consolidation if enabled and the target month is not already
     consolidated.
@@ -311,9 +311,10 @@ def maybe_run_consolidation(memorize, now: datetime | None = None) -> dict:
         return {"ran": False, "reason": "disabled"}
 
     now = now or datetime.now()
+    user_id = user_id or getattr(memorize, "_user_id", None) or current_user_id()
 
     start, end, month_key = target_month_for(now)
-    state = _load_state()
+    state = _load_state(user_id)
     if state.get("last_consolidated_month") == month_key:
         return {"ran": False, "reason": "already_done", "month": month_key}
 
@@ -336,7 +337,7 @@ def maybe_run_consolidation(memorize, now: datetime | None = None) -> dict:
 
     if len(daily_rows) < CONSOLIDATION_MIN_MEMS:
         state["last_consolidated_month"] = month_key
-        _save_state(state)
+        _save_state(state, user_id)
         return {"ran": False, "reason": "too_few_memories", "month": month_key, "count": len(daily_rows)}
 
     source_facts = [(m.get("memory") or "").strip() for m in daily_rows if (m.get("memory") or "").strip()]
@@ -388,7 +389,7 @@ def maybe_run_consolidation(memorize, now: datetime | None = None) -> dict:
 
     state["last_consolidated_month"] = month_key
     state["last_summary_ids"]        = written_ids
-    _save_state(state)
+    _save_state(state, user_id)
 
     log.info(
         "monthly_consolidate complete: month=%s source_count=%s facts_written=%s daily_deleted=%s",

--- a/core/schedule.py
+++ b/core/schedule.py
@@ -47,18 +47,20 @@ from typing import Any, Callable
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from core.log import get_logger
-from core.user_context import user_state_path, user_workspace_root
+from core.user_context import current_user_id, user_state_path, user_workspace_root
 
 log = get_logger(__name__)
 
 def workspace_root() -> Path:
     """Resolve the active user workspace root lazily."""
-    return Path(os.getenv("WORKSPACE_ROOT") or user_workspace_root()).resolve()
+    override = os.getenv("WORKSPACE_ROOT")
+    return (Path(override).expanduser() if override else user_workspace_root()).resolve()
 
 
 def schedule_path() -> Path:
     """Resolve the active user schedule path lazily."""
-    return Path(os.getenv("SCHEDULE_PATH") or user_state_path("schedule.json")).resolve()
+    override = os.getenv("SCHEDULE_PATH")
+    return (Path(override).expanduser() if override else user_state_path("schedule.json")).resolve()
 
 DEFAULT_TIMEZONE = os.getenv("TIMEZONE", "UTC")
 
@@ -473,11 +475,13 @@ class ScheduleRunner:
         memorize=None,
         generate_and_post_fn: Callable | None = None,
         consolidate_fn: Callable | None = None,
+        user_id: str | None = None,
     ) -> None:
         self._on_due               = on_due
         self._memorize             = memorize
         self._generate_and_post_fn = generate_and_post_fn
         self._consolidate_fn       = consolidate_fn
+        self._user_id              = user_id or getattr(memorize, "_user_id", None) or current_user_id()
         self._wakeup               = threading.Event()
         self._stop                 = threading.Event()
         self._thread: threading.Thread | None = None
@@ -636,7 +640,7 @@ class ScheduleRunner:
 
         try:
             log.info("monthly_consolidate: starting.")
-            result = self._consolidate_fn(self._memorize, now=datetime.now(_timezone()))
+            result = self._consolidate_fn(self._memorize, now=datetime.now(_timezone()), user_id=self._user_id)
             log.info("monthly_consolidate: done — %s", result)
         except Exception as e:
             log.error("monthly_consolidate failed: %s", e)

--- a/core/secure.py
+++ b/core/secure.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import hmac
 import os
+import base64
 import sqlite3
 from pathlib import Path
 from typing import Any
@@ -40,6 +41,22 @@ def derive_user_sqlite_key(user_id: str) -> str:
     return digest.hex()
 
 
+def _derive_legacy_user_sqlite_key(user_id: str) -> str:
+    """Return the legacy SQLCipher passphrase used before raw hex keys."""
+    digest = hmac.new(_data_secret(), f"aiko-sqlite:{user_id}".encode("utf-8"), hashlib.sha256).digest()
+    return base64.urlsafe_b64encode(digest).decode("ascii")
+
+
+def _quote_sqlcipher_key(key: str) -> str:
+    return "'" + key.replace("'", "''") + "'"
+
+
+def _validate_sqlcipher_connection(conn: Any) -> None:
+    # Force key validation immediately, so a wrong key fails at boot instead of
+    # later after partial initialization.
+    conn.execute("SELECT count(*) FROM sqlite_master")
+
+
 def connect_sqlite(path: str | os.PathLike[str], *, user_id: str) -> Any:
     """Connect to SQLite, using SQLCipher when AIKO_SQLITE_ENCRYPTION=1.
 
@@ -58,15 +75,28 @@ def connect_sqlite(path: str | os.PathLike[str], *, user_id: str) -> Any:
             "Install a SQLCipher-capable Python driver or disable AIKO_SQLITE_ENCRYPTION."
         ) from exc
 
+    raw_key = derive_user_sqlite_key(user_id)
     conn = sqlcipher.connect(str(path), check_same_thread=False)
     try:
-        key = derive_user_sqlite_key(user_id)
-        conn.execute(f"PRAGMA key = \"x'{key}'\"")
+        conn.execute(f"PRAGMA key = \"x'{raw_key}'\"")
         conn.execute("PRAGMA cipher_page_size = 4096")
-        # Force key validation immediately, so a wrong key fails at boot instead of
-        # later after partial initialization.
-        conn.execute("SELECT count(*) FROM sqlite_master")
+        _validate_sqlcipher_connection(conn)
         return conn
-    except Exception:
+    except Exception as raw_exc:
         conn.close()
-        raise
+
+        # Databases created by the first SQLCipher integration used the derived
+        # value as a SQLCipher passphrase, letting SQLCipher run its KDF. Keep
+        # those databases readable and migrate them in place to the raw key.
+        legacy_key = _derive_legacy_user_sqlite_key(user_id)
+        legacy_conn = sqlcipher.connect(str(path), check_same_thread=False)
+        try:
+            legacy_conn.execute(f"PRAGMA key = {_quote_sqlcipher_key(legacy_key)}")
+            legacy_conn.execute("PRAGMA cipher_page_size = 4096")
+            _validate_sqlcipher_connection(legacy_conn)
+            legacy_conn.execute(f"PRAGMA rekey = \"x'{raw_key}'\"")
+            _validate_sqlcipher_connection(legacy_conn)
+            return legacy_conn
+        except Exception:
+            legacy_conn.close()
+            raise raw_exc

--- a/core/social.py
+++ b/core/social.py
@@ -45,12 +45,14 @@ log = get_logger(__name__)
 
 def workspace_root() -> Path:
     """Resolve the active user workspace root lazily."""
-    return Path(os.getenv("WORKSPACE_ROOT") or user_workspace_root()).resolve()
+    override = os.getenv("WORKSPACE_ROOT")
+    return (Path(override).expanduser() if override else user_workspace_root()).resolve()
 
 
 def weekly_social_root() -> Path:
     """Resolve the active user weekly social output root lazily."""
-    return Path(os.getenv("SOCIAL_ROOT") or workspace_root() / "social" / "weekly").resolve()
+    override = os.getenv("SOCIAL_ROOT")
+    return (Path(override).expanduser() if override else workspace_root() / "social" / "weekly").resolve()
 TIMEZONE_NAME = os.getenv("TIMEZONE", "UTC")
 
 WEEKLY_AUTODRAFT = os.getenv("WEEKLY_SOCIAL_AUTODRAFT", "1").lower() in {"1", "true", "yes", "on"}

--- a/core/toolkit/photo_grader.py
+++ b/core/toolkit/photo_grader.py
@@ -27,6 +27,7 @@ def scan_photo_workspace(inbox: str = DEFAULT_PHOTO_INBOX, limit: int = 100) -> 
     """Scan a workspace photo inbox for image files Aiko can ingest."""
     try:
         root = safe_path(inbox)
+        ws_root = workspace_root()
         files = _image_files(root, max(1, min(limit, 1000)))
         by_ext = Counter(p.suffix.lower() for p in files)
         return json_block("photo workspace scan", {
@@ -34,7 +35,7 @@ def scan_photo_workspace(inbox: str = DEFAULT_PHOTO_INBOX, limit: int = 100) -> 
             "exists": root.exists(),
             "image_count": len(files),
             "by_extension": dict(sorted(by_ext.items())),
-            "files": [str(p.relative_to(workspace_root())) for p in files[:50]],
+            "files": [str(p.relative_to(ws_root)) for p in files[:50]],
             "note": "Use propose_photo_ingestion to create a dry-run plan before moving or editing metadata.",
         })
     except Exception as e:
@@ -45,10 +46,11 @@ def propose_photo_ingestion(inbox: str = DEFAULT_PHOTO_INBOX, library_root: str 
     """Create a safe dry-run ingestion plan for untracked photos."""
     try:
         root = safe_path(inbox)
+        ws_root = workspace_root()
         files = _image_files(root, 100)
         planned = []
         for path in files:
-            rel = path.relative_to(workspace_root())
+            rel = path.relative_to(ws_root)
             stem_slug = slugify(path.stem, fallback="photo")
             planned.append({
                 "source": str(rel),

--- a/core/user_context.py
+++ b/core/user_context.py
@@ -35,11 +35,19 @@ def normalize_user_id(provider: str | None, user_id: object) -> str:
 
 
 def user_state_dir(user_id: str | None = None) -> Path:
-    """Root directory for user-private mutable state."""
+    """Root directory for user-private mutable state.
+
+    Defaults to ~/.aiko/<user_id>, but keeps existing installs on the legacy
+    ~/.aiko/users/<user_id> layout when that directory already exists.
+    """
     root_value = os.getenv("AIKO_USER_STATE_ROOT") or str(Path.home() / ".aiko")
     root = Path(root_value).expanduser()
     uid = _SAFE_RE.sub("_", user_id or current_user_id()).strip("._-") or _DEFAULT_USER_ID
-    return root / uid
+    state_dir = root / uid
+    legacy_dir = root / "users" / uid
+    if not os.getenv("AIKO_USER_STATE_ROOT") and legacy_dir.exists() and not state_dir.exists():
+        return legacy_dir
+    return state_dir
 
 
 def user_state_path(filename: str, user_id: str | None = None) -> Path:

--- a/docs/MULTI_USER.md
+++ b/docs/MULTI_USER.md
@@ -16,6 +16,7 @@ This is the simple `$5 Patreon tester` isolation model for Aiko. OAuth is the so
   - `SQLITE_MEMORY_PATH`
   - `USER_PROFILE_PATH`
   - `MONTHLY_CONSOLIDATION_STATE_PATH`
+  - `SCHEDULE_PATH`
   - `WORKSPACE_ROOT`
   - `AIKO_USER_STATE_ROOT`
 

--- a/webui/webui.py
+++ b/webui/webui.py
@@ -263,7 +263,6 @@ class AikoWeb:
             return
 
         user_context_token = set_current_user_id(str(session["user_id"]))
-        os.environ["AIKO_USER_ID"] = str(session["user_id"])
         await ws.accept()
 
         with self._clients_lock:
@@ -295,7 +294,6 @@ class AikoWeb:
                         text = (msg.get("text") or "").strip()
                         if text:
                             set_current_user_id(str(session["user_id"]))
-                            os.environ["AIKO_USER_ID"] = str(session["user_id"])
                             self._input_q.put(text)
 
                     elif mtype == "vad":


### PR DESCRIPTION
### Motivation
- Fix reviewer-reported multi-user state leakage and environment-path issues so scheduled jobs and consolidation operate under the correct per-user context and path overrides behave as expected.
- Remove process-global user id writes from the WebUI to avoid cross-session contamination and ensure request-local `ContextVar` usage is sufficient.
- Provide migration/compatibility for existing installs and encrypted DBs so upgrades don’t orphan state or render SQLCipher databases unreadable.

### Description
- Pass explicit `user_id` through monthly consolidation by changing `maybe_run_consolidation` to accept `user_id` and updating `_load_state`/`_save_state` to take a `user_id`, and have `ScheduleRunner` retain/pass a per-run `_user_id` to the consolidation call (`core/consolidate.py`, `core/schedule.py`).
- Stop writing `AIKO_USER_ID` into `os.environ` in the WebSocket handler and rely on `set_current_user_id`/`reset_current_user_id` so the process env is not mutated per-connection (`webui/webui.py`).
- Add legacy-state fallback for existing installs by detecting `~/.aiko/users/<uid>` when `~/.aiko/<uid>` is missing, and make user-state/workspace/profile path env overrides expand `~` (`core/user_context.py`, `core/schedule.py`, `core/social.py`).
- Add SQLCipher migration compatibility that tries the new raw-hex key first and, on failure, opens with the legacy passphrase and runs `PRAGMA rekey` to migrate in-place (`core/secure.py`).
- Hoist `workspace_root()` lookups in photo tooling to avoid repeated calls and use the hoisted value for path relativization (`core/toolkit/photo_grader.py`).
- Document `SCHEDULE_PATH` in the multi-user env override list (`docs/MULTI_USER.md`).

### Testing
- Ran `python3 -m compileall core webui` which succeeded and verified the modified modules compile.
- Attempted `pytest -q`, but collection failed due to missing test-environment dependencies (`numpy`, `sqlite_vec`) and an unrelated syntax error already present in `tests/test_asr.py`, so full test suite could not be executed in this environment.
- Performed local static checks/compilation and ensured the modified functions load cleanly under the current runtime constraints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4d931e1e848328bbadfc5b46f1a8a3)