### PR TITLE
Graph-first agent executor, route-vector cache, and practice tooling

### DIFF
--- a/cognition/__init__.py
+++ b/cognition/__init__.py
@@ -9,18 +9,19 @@ Two fetch groups use this pool:
      route() BEFORE intent is known, since every path (localchat/webchat/
      agentic) needs them regardless of which one gets chosen. Concurrent
      with intent classification itself, not just with each other.
-  2. Wiki + agentic-policy + skill + experience
+  2. Wiki + agentic-policy + skill, plus optional experience when
+     AGENT_INCLUDE_EXPERIENCE_CONTEXT=1
      (skills.agentic._fetch_agentic_only_context) — fired only once intent
      has resolved to "agentic", since these blocks are agentic-only.
 
 All of these are independent reads against separate backing stores
-(memory.db, knowledge.db, wiki store, skills store, experience store,
+(memory.db, knowledge.db, wiki store, skills store, optional experience store,
 persona/*.md files) keyed only on (user_input, embedder). No fetch
 depends on another's output, so completion order never matters — callers
 just wait for the ones they need and join the results into the prompt
 afterward.
 
-Sized for the busiest caller (agentic's up-to-4-way post-intent fetch)
+Sized for the busiest caller (agentic's post-intent context fetch)
 plus headroom for an overlapping second request's smaller 2-way
 pre-intent fetch.
 """

--- a/cognition/think.py
+++ b/cognition/think.py
@@ -28,6 +28,8 @@ import logging
 import os
 import json
 import warnings
+import hashlib
+import pickle
 
 warnings.filterwarnings("ignore")
 logging.getLogger("phonemizer").setLevel(logging.ERROR)
@@ -53,7 +55,7 @@ from cognition import CONTEXT_POOL
 from system.log      import get_logger
 from skills.social import run_scheduled_weekly_social
 from system.schedule import DueJob, register_system_handler
-from system.userspace import current_user_id, current_display_name, user_profile_path
+from system.userspace import current_user_id, current_display_name, user_profile_path, user_state_dir
 from system import bioclock
 from cognition import reason
 from memory import learn
@@ -122,6 +124,8 @@ _ROUTE_INSTRUCT_TERNARY = "What kind of task or question is this?"  # used by ro
 
 _SEMANTIC_ROUTE_MIN_GAP = float(os.getenv("ROUTE_MIN_GAP", "0.10"))
 _SEMANTIC_LABEL_TOP_K = int(os.getenv("ROUTE_LABEL_TOP_K", "3"))
+_ROUTE_VECTOR_CACHE_ENABLED = os.getenv("ROUTE_VECTOR_CACHE_ENABLED", "1").lower() in {"1", "true", "yes", "on"}
+_ROUTE_VECTOR_CACHE_DIR = os.getenv("ROUTE_VECTOR_CACHE_DIR", "route_vectors")
 
 _PERSONA_PATH = Path(__file__).resolve().parent.parent / "persona" / "soul.md"
 _LOCAL_KNOWLEDGE_RE = re.compile(
@@ -492,11 +496,13 @@ class AikoThink:
         return "localchat"
 
     def _semantic_example_vectors(self, examples_by_label: dict, instruct: str) -> tuple[list[str], object]:
-        """Return cached (labels, matrix) for a static semantic example
-        corpus, built via reason.embed_example_matrix. embed_example_matrix
-        itself never caches — it always re-embeds — so the caching lives
-        here, keyed on corpus identity + instruct string, same as before
-        the math moved to cognition.reason."""
+        """Return cached route-example vectors.
+
+        Hot turns use the in-memory cache. Cold boots can reuse a per-user
+        on-disk pickle keyed by the route examples, instruct string, and
+        embedding backend metadata when ROUTE_VECTOR_CACHE_ENABLED=1. If the
+        cache is missing/stale/unreadable, Aiko recomputes and overwrites it.
+        """
         cache_key = (id(examples_by_label), instruct)
         with self._semantic_example_cache_lock:
             cached = self._semantic_example_cache.get(cache_key)
@@ -504,10 +510,47 @@ class AikoThink:
                 return cached
 
             embedder = self._memorize._mem._embedder
+            disk_path = self._route_vector_cache_path(examples_by_label, instruct, embedder)
+            if disk_path is not None and disk_path.exists():
+                try:
+                    with disk_path.open("rb") as f:
+                        cached = pickle.load(f)
+                    self._semantic_example_cache[cache_key] = cached
+                    return cached
+                except Exception as exc:
+                    log.debug("[route] ignoring stale vector cache %s: %s", disk_path, exc)
+
             labels, vectors = reason.embed_example_matrix(embedder, examples_by_label, instruct=instruct)
             cached = (labels, vectors)
             self._semantic_example_cache[cache_key] = cached
+            if disk_path is not None:
+                try:
+                    disk_path.parent.mkdir(parents=True, exist_ok=True)
+                    with disk_path.open("wb") as f:
+                        pickle.dump(cached, f, protocol=pickle.HIGHEST_PROTOCOL)
+                except Exception as exc:
+                    log.debug("[route] could not write vector cache %s: %s", disk_path, exc)
             return cached
+
+    def _route_vector_cache_path(self, examples_by_label: dict, instruct: str, embedder) -> Path | None:
+        if not _ROUTE_VECTOR_CACHE_ENABLED:
+            return None
+        try:
+            payload = {
+                "examples": examples_by_label,
+                "instruct": instruct,
+                "embedder": {
+                    "class": type(embedder).__name__,
+                    "model": getattr(embedder, "model", None) or getattr(embedder, "model_name", None) or getattr(embedder, "name", None),
+                    "dims": os.getenv("EMBED_DIMS", ""),
+                },
+            }
+            digest = hashlib.sha256(json.dumps(payload, sort_keys=True, default=str).encode("utf-8")).hexdigest()[:24]
+            raw_dir = Path(_ROUTE_VECTOR_CACHE_DIR)
+            base = raw_dir if raw_dir.is_absolute() else user_state_dir(current_user_id()) / raw_dir
+            return base / f"{digest}.pkl"
+        except Exception:
+            return None
 
     def _classify_agent_intent(self, user_input: str, skip_regex: bool = False) -> str:
         """Ask the local model for a compact binary route label when semantics are ambiguous."""

--- a/config/cognition.yaml
+++ b/config/cognition.yaml
@@ -31,6 +31,8 @@ TOP_K: "50"  # Limits next-token choices to top K; common values 40-100, 0 may d
 AGENTIC_MODE_ON: 1          # 1/0 — whether "agentic" is a reachable outcome at all, independent of ROUTE_MODE
 ROUTE_ENABLED: "1"  # Automatic chat-vs-agent routing toggle; options: 1/0, true/false, yes/no, on/off.
 ROUTE_MODE: semantic        # semantic | semantic_only | llm | llm_only — picks the classification METHOD only
+ROUTE_VECTOR_CACHE_ENABLED: "1"  # Cache static route-example embeddings on disk after first build.
+ROUTE_VECTOR_CACHE_DIR: "route_vectors"  # Per-user route-vector cache dir unless absolute. Safe to delete/rebuild.
 ROUTE_AGENTIC_THRESHOLD: "0.65"   # Route to agentic if score > this
 ROUTE_WEBCHAT_THRESHOLD: "0.60"   # Route to webchat if score > this (else localchat)
 ROUTE_LABEL_TOP_K: "3"  # Average each label strongest N examples; higher is smoother but less sharp.

--- a/config/skills.yaml
+++ b/config/skills.yaml
@@ -34,6 +34,13 @@ USER_SKILLSETS_PATH: ""  # Override path for per-user skillsets. Defaults to <US
 # Settings for skills/agentic.py plus chat-vs-agent routing used by cognition/think.py.
 # Use this to tune when Aiko enters tool/task mode and how much work one task may do.
 
+# -- Agent executor mode --
+AGENT_EXECUTOR_MODE: "hybrid"  # react = old ReAct loop only; graph = master-plan DAG only; hybrid = graph first, ReAct fallback once for novel workflows.
+GRAPH_AGENT_ENABLED: "1"  # Enable deterministic graph/master-plan executor for known workflows.
+GRAPH_MASTER_PLAN_PATH: "agentic/master_plans.json"  # Per-user JSON file for practiced/promoted graph workflows.
+GRAPH_MAX_WORKERS: "4"  # Max parallel tool nodes for graph execution.
+AGENT_INCLUDE_EXPERIENCE_CONTEXT: "0"  # Experience is now used for offline master-plan promotion, not prompt context, by default.
+
 # -- Agent loop limits --
 MAX_AGENT_ITER: "6"  # Maximum tool/planning iterations per task; raise for complex tasks, lower for safety.
 AGENT_MAX_TOKENS: "512"  # Max model output tokens per agent step.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -284,3 +284,45 @@ flowchart TD
 - Tool functions should not read memory directly. The agent loop should retrieve memory and pass relevant context into the LLM.
 - Daily summaries should use both the daily chat-turn log and persistent memory snippets, then pin the factual summary as permanent memory.
 - Daily summaries should preserve important facts such as dates, deadlines, commitments, projects, events, losses, incidents, and goals. Mundane details should be downweighted unless they imply a pattern, risk, or follow-up.
+
+## Graph-First Agentic Executor (Current)
+
+Aiko now has two agentic execution paths:
+
+1. **Graph/master-plan executor** — the default first attempt when `AGENT_EXECUTOR_MODE=hybrid`. It matches the user task against known master-plan workflows, builds a small dependency graph, executes ready tool nodes in parallel, stores node outputs as compact result objects, and synthesizes a deterministic completion message without an LLM planning step.
+2. **ReAct fallback** — used when no graph matches in `hybrid` mode, or when `AGENT_EXECUTOR_MODE=react`. ReAct remains the exploration path for novel, modified, or ambiguous workflows. Successful ReAct traces are recorded to experience so they can be promoted into graph master plans later.
+
+```mermaid
+flowchart TD
+    AgenticInput[Agentic user task] --> Caps[Capability match]
+    Caps --> Mode{AGENT_EXECUTOR_MODE}
+    Mode -->|graph/hybrid| Match[skills.graph_agent.plan_from_master]
+    Match -->|matched| DAG[Execute PlanGraph DAG]
+    DAG --> Ready[Run ready independent nodes in parallel]
+    Ready --> Results[Tuple-like NodeResult objects]
+    Results --> NoLLM[Deterministic no-LLM synthesis]
+    NoLLM --> Exp[Record experience trace]
+    Match -->|no match + hybrid| React[ReAct loop once]
+    Match -->|no match + graph| Refuse[Clear no-master-plan message]
+    React --> Exp
+```
+
+The graph executor is intentionally conservative. It can be autonomous without an LLM **only for workflows whose intent, tool sequence, dependencies, and arguments can be matched or derived from saved master plans**. It is not a general reasoning sub-agent yet. A fully autonomous sub-agent layer would add a long-running worker abstraction around graph nodes: queue, lease/heartbeat, workspace/artifact boundaries, cancellation, retries, and permissions. Those workers can still be model-free if every node uses deterministic tools or a small classifier; they need an LLM only for novel planning, ambiguous argument extraction, or final narrative synthesis.
+
+`skills.graph_agent` can also be called through the agent tool-schema surface via `list_master_plans` and `run_master_plan`. This lets the ReAct fallback inspect or invoke graph workflows explicitly instead of only relying on the pre-ReAct graph-first gate.
+
+## Semantic Vector Cache
+
+Intent-routing examples are still authored as text in `cognition/router_prompts.json`, but their embedding matrix can now be cached on disk with `ROUTE_VECTOR_CACHE_ENABLED=1`. The cache is keyed by the examples, instruct string, embedding backend metadata, and `EMBED_DIMS`. This avoids re-embedding static route examples every cold boot while remaining safe when examples or embedding settings change.
+
+Graph master plans are currently matched by trigger/capability metadata, so there are no graph vectors to precompute yet. If graph matching becomes semantic, the same pattern should be used: stable JSON/YAML plan specs as the source of truth, plus generated vector-cache artifacts that are safe to delete and rebuild.
+
+## Machine-Readable Knowledge Format Guidance
+
+Skill and wiki markdown should stay readable for humans, but the first part of each file should be machine-regular:
+
+- YAML front matter for `id`, `summary`, `triggers`, `tools`, `capabilities`, `inputs`, `outputs`, and `safety` where applicable.
+- Short, action-oriented sections with stable headings such as `When to use`, `Inputs`, `Workflow`, `Tools`, `Outputs`, `Failure handling`, and `Promotion hints`.
+- Avoid burying required tool names or constraints inside prose-only paragraphs.
+
+Do **not** replace wiki/skill markdown with opaque vector blobs. Keep markdown as the trusted source, and treat vectors/caches as derived artifacts.

--- a/docs/HISTORY.md
+++ b/docs/HISTORY.md
@@ -169,7 +169,7 @@ Lessons learned:
 - `core/tools.py` remains useful as a stable public facade even when implementations move into `core/toolkit/`.
 - The browser WebUI can share the TUI contract, but remote voice-device UX still needs polishing.
 - Environment-variable migrations need docs: `LLM_*` and `ROUTE_*` are now the current names for chat runtime/routing.
-- Aiko is still a single orchestrated agentic loop today; semantic routing, optional LLM routing, tools, and skills are components, not separate autonomous agents.
+- Aiko now has a graph-first master-plan executor for known workflows and a ReAct fallback for novel workflows. It still does not have a long-running autonomous sub-agent worker runtime with queues/leases/cancellation; graph nodes are lightweight tool tasks inside one orchestrated turn.
 
 ---
 
@@ -188,3 +188,12 @@ The core philosophy remains unchanged:
 > Simplicity over unnecessary complexity.
 >
 > Build for constrained hardware and everything else becomes easier.
+
+
+## Graph-first agentic executor update
+
+- Added a deterministic graph/master-plan executor for known workflows.
+- Added `AGENT_EXECUTOR_MODE=react|graph|hybrid`; hybrid tries graph first and falls back to ReAct once.
+- Experience is no longer prompt context by default; it is primarily a post-run trace for offline workflow promotion.
+- Added `practice.py` for seeding practiced workflows and promoting them into per-user master plans.
+- Added an on-disk semantic route-vector cache for static intent-routing examples.

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -185,8 +185,8 @@ Non-secret runtime settings live in category YAML files under `config/`:
 config/index.yaml       # ordered list of YAML files loaded at startup
 config/identity.yaml    # AI_NAME, USER_ID
 config/think.yaml       # core/think.py LLM endpoints, model names, sampling, token limits
-config/agentic.yaml     # core/agentic.py plus routing thresholds
-config/memorize.yaml    # core/memorize.py, embed, forget, experience, consolidation settings
+config/skills.yaml      # skills/agentic.py, graph executor, tool schemas, skill/wiki RAG budgets
+config/memory.yaml      # memory/memorize.py, embed, forget, experience, consolidation settings
 config/speak.yaml       # core/speak.py MioTTS and karaoke text settings
 config/listen.yaml      # core/listen.py ASR, VAD, speaker verification, barge-in
 config/web.yaml         # core/toolkit/researcher.py SearXNG URL and search limits

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -169,7 +169,8 @@ Aiko-chan is built in phases. Each phase is a self-contained capability layer th
 |---|---|
 | ReAct-style task loop with tool dispatch | ✅ Done |
 | Semantic Intent Routing for fast delegation | ✅ Done |
-| Sub-agent spawning for parallel workflow | 🔲 Planned |
+| Graph-first master-plan executor with model-free DAG tool nodes | ✅ Done |
+| Autonomous sub-agent worker runtime with queues/leases/cancellation | 🔲 Planned |
 | Implement goal-based DAG HTN One-step LLM Agentic architecture | ✅ Done |
 | Persistent schedule jobs with reminder | ✅ Done |
 | Toolkit set Agentic-focused tool modules | ✅ Done |
@@ -190,7 +191,7 @@ Aiko-chan is built in phases. Each phase is a self-contained capability layer th
 | Embedder | `fastembed` library | **Custom `core/embed.py` ONNX Harrier embedder** (fastembed only exposed MEAN/CLS pooling) |
 | Tools | Scattered functions | **Focused `core/toolkit/` modules: web, planning, scheduling, photo, architecture** |
 | Skills | N/A | **`skills/<id>/SKILL.md` workflow registry loaded by `core/skills.py`** |
-| Agentic facade | Direct calls | **`core/tools.py` compatibility facade + `core/agentic.py` ReAct loop** |
+| Agentic facade | Direct calls | **`core/tools.py` compatibility facade + graph-first executor + ReAct fallback loop** |
 
 ---
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -307,11 +307,15 @@ Run before any phase suite.
 - [ ] Missing/corrupt `SKILL.md` files are reported gracefully and do not break unrelated skills.
 - [ ] Skill instructions do not override safety boundaries for filesystem paths, external actions, or final-answer honesty.
 
-### 2.5.3 Agentic routing and ReAct loop
+### 2.5.3 Agentic routing, graph executor, and ReAct fallback
 
 - [ ] Normal casual chat does not route to agent mode unnecessarily.
 - [ ] Research/planning/workspace/photo/repo tasks route to agent mode when appropriate.
 - [ ] `MAX_AGENT_ITER` stops runaway loops and produces a clear partial/failure final answer.
+- [ ] Graph-mode known workflows run without an LLM planning call and return compact node evidence.
+- [ ] `list_master_plans` and `run_master_plan` appear in `tool_schemas()` and return structured observations.
+- [ ] Hybrid mode falls back to ReAct exactly once when no graph master plan matches.
+- [ ] ReAct fallback records steps, tool names, sanitized args, and outcome into experience for later promotion.
 - [ ] Agent memory recall is bounded by `AGENT_MEMORY_RECALL_LIMIT` and does not drown tool evidence.
 - [ ] Final-answer verification catches unsupported claims, failed tool actions, and missing artifact paths.
 - [ ] If verification fails, repair attempts are bounded by `AGENT_MAX_FINAL_REPAIRS` and disclose unresolved limitations.
@@ -541,3 +545,12 @@ Run after any significant change to confirm nothing regressed.
 - [ ] `--text` and `--debug` flags still work
 - [ ] `docker compose down && docker compose up -d` → SearXNG recovers cleanly (Qdrant no longer required)
 - [ ] `uv sync` completes without dependency conflicts after any `pyproject.toml` change
+
+
+### 2.5.11 Route-vector and graph-plan cache checks
+
+- [ ] With `ROUTE_VECTOR_CACHE_ENABLED=1`, first boot creates per-user route vector cache files under `ROUTE_VECTOR_CACHE_DIR`.
+- [ ] Second boot reuses cached route vectors and does not re-embed unchanged router examples.
+- [ ] Editing `cognition/router_prompts.json`, changing the route instruct string, or changing `EMBED_DIMS` invalidates the old cache key.
+- [ ] Deleting route-vector cache files is safe; Aiko rebuilds them automatically.
+- [ ] Graph master plans remain source JSON/YAML/markdown data; any future graph vector cache is treated as rebuildable derived data.

--- a/practice.py
+++ b/practice.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Practice and promote graph-agent workflows without booting the chat LLM.
+
+Examples:
+  uv run python practice.py --task "make a deployment checklist and save it" \
+    --tools create_checklist save_note --promote
+
+  uv run python practice.py --task "research X and save a note" \
+    --steps '[{"tool":"deep_search","ok":true,"args":{"query":"$prompt"}},{"tool":"save_note","ok":true,"args":{"title":"$title","content":"$result:step_1"}}]' \
+    --promote
+"""
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any
+
+from system.config import load_config
+load_config()
+
+from skills import experience, graph_agent
+
+
+def _steps_from_tools(tools: list[str]) -> list[dict[str, Any]]:
+    return [{"tool": t, "ok": True, "args": {}} for t in tools]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Seed Aiko experience and master-plan workflows from practice examples.")
+    parser.add_argument("--task", required=True, help="Example task prompt Aiko should learn/practice.")
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--tools", nargs="+", help="Ordered tool names for the workflow.")
+    group.add_argument("--steps", help="JSON list of step objects with tool/ok/args fields.")
+    parser.add_argument("--answer", default="practice workflow recorded", help="Outcome excerpt to store with the experience.")
+    parser.add_argument("--promote", action="store_true", help="Append the practiced sequence to the graph master-plan JSON.")
+    parser.add_argument("--name", help="Human-readable name for the promoted master plan.")
+    args = parser.parse_args()
+
+    if args.steps:
+        steps = json.loads(args.steps)
+        if not isinstance(steps, list):
+            raise SystemExit("--steps must decode to a JSON list")
+    else:
+        steps = _steps_from_tools(args.tools or [])
+
+    exp_id = experience.record_practice_experience(args.task, steps, args.answer, verified_ok=True, score=1.0)
+    print(f"recorded_experience={exp_id}")
+
+    if args.promote:
+        path = graph_agent.append_master_plan_from_experience(args.task, steps, name=args.name)
+        print(f"promoted_master_plan={path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/agentic.py
+++ b/skills/agentic.py
@@ -43,6 +43,7 @@ from skills.wiki import wiki_agentic_contexts_for
 from skills.capability import match_capabilities, filtered_tool_schemas
 from memory.knowledge import knowledge_context_for, ingest_text as ingest_knowledge_text, ingest_file as ingest_knowledge_file
 from skills import experience
+from skills import graph_agent
 from toolkit.tools import (
     deep_search,
     deep_research,
@@ -92,6 +93,8 @@ AGENT_VERIFY_LLM_MODE = os.getenv("AGENT_VERIFY_LLM_MODE", "auto")  # "always" |
 AGENT_MAX_FINAL_REPAIRS = int(os.getenv("AGENT_MAX_FINAL_REPAIRS", 2))
 AGENT_VERIFY_MIN_SCORE = float(os.getenv("AGENT_VERIFY_MIN_SCORE", "0.70"))
 AGENT_TOOL_RETRY_BACKOFF = float(os.getenv("AGENT_TOOL_RETRY_BACKOFF", 0.4))
+AGENT_EXECUTOR_MODE = os.getenv("AGENT_EXECUTOR_MODE", "hybrid").strip().lower()  # react | graph | hybrid
+AGENT_INCLUDE_EXPERIENCE_CONTEXT = os.getenv("AGENT_INCLUDE_EXPERIENCE_CONTEXT", "0").lower() in {"1", "true", "yes", "on"}
 
 # Rolling STM window shared across all three chat paths. Mirrors
 # CONTEXT_WINDOW_TURNS in cognition.think (kept as a distinct name here rather
@@ -308,7 +311,7 @@ def _fetch_agentic_only_context(user_input: str, embedder, query_vector: np.ndar
         "agentic_policy": CONTEXT_POOL.submit(_agentic_policy_context, user_input, embedder=embedder),
         "wiki": CONTEXT_POOL.submit(wiki_agentic_contexts_for, user_input, embedder=embedder),
         "skill": CONTEXT_POOL.submit(skill_context_for, user_input, limit=2, max_chars=3000, embedder=embedder),
-        "experience": CONTEXT_POOL.submit(experience.experience_context_for, user_input, limit=3, embedder=embedder),
+        "experience": CONTEXT_POOL.submit(experience.experience_context_for, user_input, limit=3, embedder=embedder) if AGENT_INCLUDE_EXPERIENCE_CONTEXT else None,
     }
     # "wiki" returns a (wiki_block, knowledge_block) tuple; both come
     # from a SINGLE search_wiki call (see wiki_agentic_contexts_for) instead
@@ -323,7 +326,7 @@ def _fetch_agentic_only_context(user_input: str, embedder, query_vector: np.ndar
     results = {}
     for key, future in futures.items():
         try:
-            results[key] = future.result()
+            results[key] = future.result() if future is not None else ""
         except Exception as e:
             log.error("[agentic] context fetch '%s' failed: %s", key, e)
             results[key] = fallbacks[key]
@@ -617,6 +620,15 @@ _reg("load_skillset", "Load the full markdown instructions for one predefined sk
     lambda args: load_skillset(args.get("skill_id", "")),
     {"skill_id": {"type": "string"}},
     required=["skill_id"])
+
+_reg("list_master_plans", "List graph/master-plan workflows available to the model-free graph executor.",
+    lambda args: graph_agent.list_master_plans_json(),
+    {})
+
+_reg("run_master_plan", "Run a saved graph/master-plan workflow by matching this task prompt. This uses deterministic graph execution, not an LLM planner; if no graph matches, continue with ReAct once and learn the sequence.",
+    lambda args: graph_agent.run_master_plan_json(args.get("task", ""), cap_ids=args.get("cap_ids") if isinstance(args.get("cap_ids"), list) else None),
+    {"task": {"type": "string", "description": "The task prompt to match against graph master plans."}, "cap_ids": {"type": "array", "items": {"type": "string"}, "description": "Optional matched capability ids."}},
+    required=["task"])
 
 _reg("scan_photo_workspace", "Scan a workspace photo inbox for wildlife/nature/astro image files.",
     lambda args: scan_photo_workspace(args.get("inbox", "photos/inbox"), int(args.get("limit", 100) or 100)),
@@ -1144,6 +1156,40 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
     # can only shrink the list, never regress a turn.
     _matched_caps = match_capabilities(user_input, embedder=_embedder, query_vector=_cap_vec)
     tools = filtered_tool_schemas(tool_schemas(), _matched_caps)
+
+    # Graph-first executor: known master-plan workflows can run without an LLM
+    # planning loop. Novel/ambiguous tasks return None and fall back to the
+    # ReAct loop once; the normal experience recorder below then captures the
+    # successful sequence for later promotion into the graph master plan.
+    if AGENT_EXECUTOR_MODE in {"graph", "hybrid"}:
+        graph_result = graph_agent.run_graph_agent(user_input, cap_ids=_matched_caps)
+        if graph_result is not None:
+            threading.Thread(
+                target=experience.record_experience,
+                args=(owner, user_input, graph_result.steps, graph_result.final_answer),
+                kwargs=dict(verified_ok=not any(not r.ok for r in graph_result.results), score=1.0, embedder=_embedder),
+                daemon=True,
+            ).start()
+            owner.last_prompt_debug = {
+                "mode": "agentic_graph",
+                "matched_capabilities": _matched_caps,
+                "graph": graph_result.graph.__dict__,
+                "node_results": [r.__dict__ for r in graph_result.results],
+            }
+            owner._emit(graph_result.final_answer, token_callback=token_callback)
+            with owner._history_lock:
+                owner._history.append({"role": "user", "content": user_input})
+                owner._history.append({"role": "assistant", "content": graph_result.final_answer})
+            owner._store_async(user_input, graph_result.final_answer)
+            return graph_result.final_answer
+        if AGENT_EXECUTOR_MODE == "graph":
+            final_text = (
+                "I could not match this task to a saved master-plan workflow, "
+                "and AGENT_EXECUTOR_MODE=graph disables the ReAct fallback. "
+                "Run practice.py or switch to AGENT_EXECUTOR_MODE=hybrid to learn it once."
+            )
+            owner._emit(final_text, token_callback=token_callback)
+            return final_text
 
     if mem_kb_future is not None:
         try:

--- a/skills/capability.py
+++ b/skills/capability.py
@@ -63,13 +63,15 @@ TOOL_DOMAINS: dict[str, str] = {
     "repo_search_text": "repo",
     "learn_knowledge": "kb",
     "search_jobs": "jobs",
+    "list_master_plans": "graph",
+    "run_master_plan": "graph",
 }
 
 # Always sent regardless of which capability matched — the base loop tools
 # every agentic turn can plausibly need.
 ALWAYS_ON_TOOLS: frozenset[str] = frozenset({
     "make_plan", "create_checklist", "save_note", "read_workspace_file",
-    "summarize_task_state", "final_answer",
+    "summarize_task_state", "list_master_plans", "run_master_plan", "final_answer",
 })
 
 CAPABILITIES: dict[str, Capability] = {

--- a/skills/experience.py
+++ b/skills/experience.py
@@ -19,11 +19,35 @@ import sqlite3
 import uuid
 from dataclasses import dataclass, field
 from html import escape
+from pathlib import Path
 from system.config import load_config
 load_config()
 
-from cognition import reason
-from memory.vecstore import delete_by_id, initialize_store_db, insert_vector, rank_by_id, rrf_score, user_scoped_fts_search, user_scoped_vec_knn, utc_now_iso
+try:
+    from memory.vecstore import delete_by_id, initialize_store_db, insert_vector, rank_by_id, rrf_score, user_scoped_fts_search, user_scoped_vec_knn, utc_now_iso
+except Exception:  # lightweight practice.py/test environments may not have numpy/sqlite-vec
+    from datetime import datetime, timezone
+    def utc_now_iso(): return datetime.now(timezone.utc).isoformat()
+    def initialize_store_db(path, ddl, user_id=None, vector=True):
+        from system.userspace import user_state_dir
+        db_path = Path(path)
+        if not db_path.is_absolute():
+            db_path = user_state_dir(user_id) / db_path
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(db_path)
+        conn.row_factory = sqlite3.Row
+        # Drop sqlite-vec-only statements for fallback mode.
+        safe = re.sub(r"CREATE VIRTUAL TABLE IF NOT EXISTS experiences_vec USING vec0\([^;]+;", "", ddl, flags=re.S)
+        safe = re.sub(r"DELETE FROM experiences_vec WHERE id = old.id;", "", safe)
+        conn.executescript(safe)
+        return conn
+    def insert_vector(*args, **kwargs): return None
+    def delete_by_id(conn, table, row_id): conn.execute(f"DELETE FROM {table} WHERE id=?", (row_id,))
+    def rank_by_id(rows): return {row["id"]: i for i, row in enumerate(rows)}
+    def rrf_score(eid, *rankings, k=60): return 1.0
+    def user_scoped_vec_knn(*args, **kwargs): return []
+    def user_scoped_fts_search(conn, fts_table, owner_table, owner_alias, query, user_id, limit):
+        return conn.execute(f"SELECT * FROM {owner_table} WHERE user_id=? AND record_text LIKE ? LIMIT ?", (user_id, f"%{query}%", limit)).fetchall()
 from system.log import get_logger
 from system.userspace import current_user_id
 
@@ -112,6 +136,7 @@ class ExperienceStep:
     ok: bool
     error_type: str | None = None
     arg_keys: list[str] = field(default_factory=list)
+    args_preview: dict[str, str] = field(default_factory=dict)
 
 
 def record_experience(owner, goal: str, steps: list[dict], final_answer: str, verified_ok: bool, score: float, embedder=None) -> str | None:
@@ -122,14 +147,20 @@ def record_experience(owner, goal: str, steps: list[dict], final_answer: str, ve
             ok=bool(s.get("ok")),
             error_type=s.get("error_type"),
             arg_keys=sorted((s.get("args") or {}).keys()),
+            args_preview={k: _sanitize(str(v), 120) for k, v in (s.get("args") or {}).items()},
         )
         for s in steps
     ]
     outcome = "ok" if verified_ok else ("partial" if any(s.ok for s in exp_steps) else "failed")
     step_text = ", ".join(f"{s.tool}({'+'.join(s.arg_keys) or '-'})[{'ok' if s.ok else s.error_type or 'fail'}]" for s in exp_steps)
+    args_text = "; ".join(
+        f"{s.tool} args " + json.dumps(s.args_preview, ensure_ascii=False, sort_keys=True)
+        for s in exp_steps if s.args_preview
+    )
     record_text = (
         f"Goal: {_sanitize(goal, 700)}\n"
         f"Steps: {step_text}\n"
+        f"Args: {_sanitize(args_text, 900)}\n"
         f"Outcome: {outcome}\n"
         f"Score: {float(score):.2f}\n"
         f"Result: {_sanitize(final_answer, 300)}"
@@ -245,3 +276,12 @@ def experience_context_for(query: str, limit: int = 3, embedder=None) -> str:
         blocks.append(f'<past_task outcome="{_attr(hit["outcome"])}" verifier_score="{float(hit["score"]):.2f}" recall_score="{hit["recall_score"]:.4f}">\n{body}\n</past_task>')
         remaining -= len(body)
     return "<experience_context>\n" + "\n\n".join(blocks) + "\n</experience_context>"
+
+
+def record_practice_experience(goal: str, steps: list[dict], final_answer: str = "practice workflow", verified_ok: bool = True, score: float = 1.0, embedder=None) -> str | None:
+    """Record an operator-provided practice workflow without booting chat.
+
+    This is used by ``practice.py`` to seed experience/master-plan promotion
+    while testing tiny routing/execution models such as Needle.
+    """
+    return record_experience(None, goal, steps, final_answer, verified_ok, score, embedder=embedder)

--- a/skills/graph_agent.py
+++ b/skills/graph_agent.py
@@ -1,0 +1,401 @@
+"""
+skills/graph_agent.py
+
+Graph-first, mostly model-free agentic executor.
+
+This module is intentionally conservative: it only handles workflows that can be
+matched to a known master-plan template and whose tool arguments can be derived
+from the user's prompt with deterministic heuristics. Novel/ambiguous tasks
+return ``None`` so the normal ReAct loop can run once and record experience for
+future promotion into the master plan.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable
+
+from system.config import load_config
+load_config()
+
+from system.log import get_logger
+from system.userspace import current_user_id, user_state_dir
+
+log = get_logger(__name__)
+
+GRAPH_AGENT_ENABLED = os.getenv("GRAPH_AGENT_ENABLED", "1").lower() in {"1", "true", "yes", "on"}
+GRAPH_MASTER_PLAN_PATH = os.getenv("GRAPH_MASTER_PLAN_PATH", "agentic/master_plans.json")
+GRAPH_MAX_WORKERS = int(os.getenv("GRAPH_MAX_WORKERS", "4"))
+
+
+@dataclass(frozen=True)
+class PlanNode:
+    id: str
+    tool: str
+    args: dict[str, Any]
+    depends_on: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PlanGraph:
+    id: str
+    name: str
+    goal: str
+    nodes: tuple[PlanNode, ...]
+    source: str = "master_plan"
+
+
+@dataclass(frozen=True)
+class NodeResult:
+    node_id: str
+    tool: str
+    ok: bool
+    content: str
+    args: dict[str, Any] = field(default_factory=dict)
+    error_type: str | None = None
+
+    def summary(self, max_chars: int = 700) -> str:
+        status = "ok" if self.ok else self.error_type or "failed"
+        body = re.sub(r"\s+", " ", self.content or "").strip()[:max_chars]
+        return f"{self.node_id}:{self.tool}[{status}] {body}".strip()
+
+
+@dataclass(frozen=True)
+class GraphRunResult:
+    graph: PlanGraph
+    results: tuple[NodeResult, ...]
+    final_answer: str
+
+    @property
+    def steps(self) -> list[dict[str, Any]]:
+        return [
+            {
+                "tool": r.tool,
+                "ok": r.ok,
+                "error_type": r.error_type,
+                "args": r.args,
+            }
+            for r in self.results
+        ]
+
+
+def _master_plan_file() -> Path:
+    raw = Path(GRAPH_MASTER_PLAN_PATH)
+    if raw.is_absolute():
+        return raw
+    return user_state_dir(current_user_id()) / raw
+
+
+def _default_master_plans() -> list[dict[str, Any]]:
+    """Built-in starter plans. User-promoted plans are appended on disk."""
+    return [
+        {
+            "id": "plan_and_save_note",
+            "name": "Plan and save note",
+            "triggers": ["plan", "make a plan", "outline"],
+            "requires_any": ["save", "note", "document", "write it down"],
+            "nodes": [
+                {"id": "plan", "tool": "make_plan", "args": {"goal": "$prompt", "max_steps": 8}},
+                {"id": "save", "tool": "save_note", "depends_on": ["plan"], "args": {"title": "$title", "content": "$result:plan", "folder": "notes"}},
+            ],
+        },
+        {
+            "id": "checklist_and_save",
+            "name": "Checklist and save note",
+            "triggers": ["checklist", "todo", "to-do", "steps"],
+            "requires_any": ["save", "note", "checklist"],
+            "nodes": [
+                {"id": "checklist", "tool": "create_checklist", "args": {"title": "$title", "items": "$heuristic_items"}},
+                {"id": "save", "tool": "save_note", "depends_on": ["checklist"], "args": {"title": "$title", "content": "$result:checklist", "folder": "notes"}},
+            ],
+        },
+        {
+            "id": "research_and_save",
+            "name": "Search and save brief note",
+            "triggers": ["search", "research", "look up", "find"],
+            "requires_any": ["save", "note", "recommendation", "report", "summary"],
+            "nodes": [
+                {"id": "search", "tool": "deep_search", "args": {"query": "$prompt", "limit": 5}},
+                {"id": "save", "tool": "save_note", "depends_on": ["search"], "args": {"title": "$title", "content": "$result:search", "folder": "notes"}},
+            ],
+        },
+        {
+            "id": "simple_save_note",
+            "name": "Save provided text as a note",
+            "triggers": ["save note", "write note", "draft", "note"],
+            "requires_any": ["save", "note", "draft"],
+            "nodes": [
+                {"id": "save", "tool": "save_note", "args": {"title": "$title", "content": "$prompt", "folder": "notes"}},
+            ],
+        },
+    ]
+
+
+def load_master_plans() -> list[dict[str, Any]]:
+    path = _master_plan_file()
+    plans = _default_master_plans()
+    if path.exists():
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+            if isinstance(data, list):
+                plans.extend(p for p in data if isinstance(p, dict))
+        except Exception as exc:
+            log.warning("failed to load graph master plans from %s: %s", path, exc)
+    return plans
+
+
+def _score_plan(plan: dict[str, Any], prompt: str, cap_ids: list[str] | None = None) -> int:
+    text = prompt.casefold()
+    triggers = [str(t).casefold() for t in plan.get("triggers", [])]
+    required = [str(t).casefold() for t in plan.get("requires_any", [])]
+    score = sum(3 for t in triggers if t and t in text)
+    if required and any(t in text for t in required):
+        score += 1
+    domains = set(plan.get("capabilities", []))
+    if cap_ids and domains.intersection(cap_ids):
+        score += 3
+    return score
+
+
+def _title(prompt: str) -> str:
+    cleaned = re.sub(r"[^\w\s-]", "", prompt).strip()
+    words = cleaned.split()[:8]
+    return " ".join(words) or "Aiko task"
+
+
+def _heuristic_items(prompt: str) -> list[str]:
+    parts = re.split(r"(?:,|;|\band\b|\n)+", prompt)
+    items = [p.strip(" .:-") for p in parts if len(p.strip()) > 3]
+    return items[:10] or [prompt.strip()]
+
+
+def _substitute(value: Any, prompt: str, results: dict[str, NodeResult]) -> Any:
+    if isinstance(value, str):
+        if value == "$prompt":
+            return prompt
+        if value == "$title":
+            return _title(prompt)
+        if value == "$heuristic_items":
+            return _heuristic_items(prompt)
+        if value.startswith("$result:"):
+            node_id = value.split(":", 1)[1]
+            return (results.get(node_id).content if results.get(node_id) else "")[:4000]
+        return value.replace("$prompt", prompt).replace("$title", _title(prompt))
+    if isinstance(value, list):
+        return [_substitute(v, prompt, results) for v in value]
+    if isinstance(value, dict):
+        return {k: _substitute(v, prompt, results) for k, v in value.items()}
+    return value
+
+
+def plan_from_master(user_input: str, cap_ids: list[str] | None = None) -> PlanGraph | None:
+    if not GRAPH_AGENT_ENABLED:
+        return None
+    plans = load_master_plans()
+    ranked = sorted(((_score_plan(p, user_input, cap_ids), p) for p in plans), key=lambda x: x[0], reverse=True)
+    if not ranked or ranked[0][0] <= 0:
+        return None
+    plan = ranked[0][1]
+    nodes = []
+    for raw in plan.get("nodes", []):
+        if not isinstance(raw, dict) or not raw.get("id") or not raw.get("tool"):
+            return None
+        nodes.append(PlanNode(
+            id=str(raw["id"]),
+            tool=str(raw["tool"]),
+            args=dict(raw.get("args") or {}),
+            depends_on=tuple(str(d) for d in raw.get("depends_on", [])),
+        ))
+    if not nodes:
+        return None
+    return PlanGraph(id=str(plan.get("id") or uuid.uuid4()), name=str(plan.get("name") or plan.get("id") or "workflow"), goal=user_input, nodes=tuple(nodes))
+
+
+def _tool_map() -> dict[str, Callable[..., Any]]:
+    # Import focused toolkit modules lazily so model-free graph planning can be
+    # imported/tested without loading optional heavy research dependencies.
+    from toolkit.plan import make_plan, create_checklist, save_note, read_workspace_file, summarize_task_state
+    mapping: dict[str, Callable[..., Any]] = {
+        "make_plan": make_plan,
+        "create_checklist": create_checklist,
+        "save_note": save_note,
+        "read_workspace_file": read_workspace_file,
+        "summarize_task_state": summarize_task_state,
+    }
+    try:
+        from toolkit.organize import schedule_job, list_schedule, cancel_schedule, schedule_reminder, list_reminders, cancel_reminder
+        mapping.update({
+            "schedule_job": schedule_job, "list_schedule": list_schedule, "cancel_schedule": cancel_schedule,
+            "schedule_reminder": schedule_reminder, "list_reminders": list_reminders, "cancel_reminder": cancel_reminder,
+        })
+    except Exception as exc:
+        log.debug("organize tools unavailable for graph executor: %s", exc)
+    try:
+        from toolkit.research import deep_search, deep_research
+        mapping.update({"deep_search": deep_search, "deep_research": deep_research})
+    except Exception as exc:
+        log.debug("research tools unavailable for graph executor: %s", exc)
+    try:
+        from toolkit.photography import scan_photo_workspace, propose_photo_ingestion, write_photo_ingestion_report
+        mapping.update({
+            "scan_photo_workspace": scan_photo_workspace, "propose_photo_ingestion": propose_photo_ingestion,
+            "write_photo_ingestion_report": write_photo_ingestion_report,
+        })
+    except Exception as exc:
+        log.debug("photo tools unavailable for graph executor: %s", exc)
+    try:
+        from toolkit.self_improve import repo_file_tree, repo_read_file, repo_search_text
+        mapping.update({"repo_file_tree": repo_file_tree, "repo_read_file": repo_read_file, "repo_search_text": repo_search_text})
+    except Exception as exc:
+        log.debug("repo tools unavailable for graph executor: %s", exc)
+    try:
+        from toolkit.job_hunt import search_jobs, dedupe_postings
+        mapping.update({"search_jobs": search_jobs, "dedupe_postings": dedupe_postings})
+    except Exception as exc:
+        log.debug("job tools unavailable for graph executor: %s", exc)
+    return mapping
+
+
+def _run_node(node: PlanNode, prompt: str, results: dict[str, NodeResult]) -> NodeResult:
+    tools = _tool_map()
+    fn = tools.get(node.tool)
+    args = _substitute(node.args, prompt, results)
+    if fn is None:
+        return NodeResult(node.id, node.tool, False, f"unknown graph tool: {node.tool}", args=args, error_type="unknown_tool")
+    try:
+        out = fn(**args)
+        return NodeResult(node.id, node.tool, True, str(out), args=args)
+    except Exception as exc:
+        return NodeResult(node.id, node.tool, False, f"{type(exc).__name__}: {exc}", args=args, error_type="execution_error")
+
+
+def execute_graph(graph: PlanGraph) -> GraphRunResult:
+    pending = {node.id: node for node in graph.nodes}
+    results: dict[str, NodeResult] = {}
+    ordered: list[NodeResult] = []
+    with ThreadPoolExecutor(max_workers=GRAPH_MAX_WORKERS) as pool:
+        while pending:
+            ready = [node for node in pending.values() if all(dep in results for dep in node.depends_on)]
+            if not ready:
+                stuck = ", ".join(sorted(pending))
+                ordered.append(NodeResult("graph", "graph_executor", False, f"dependency cycle or missing dependency among: {stuck}", error_type="dependency_error"))
+                break
+            future_map = {pool.submit(_run_node, node, graph.goal, results): node for node in ready}
+            for fut in as_completed(future_map):
+                node = future_map[fut]
+                try:
+                    result = fut.result()
+                except Exception as exc:  # defensive; _run_node should catch
+                    result = NodeResult(node.id, node.tool, False, str(exc), error_type="execution_error")
+                results[node.id] = result
+                ordered.append(result)
+                pending.pop(node.id, None)
+    final_answer = _synthesize_without_llm(graph, tuple(ordered))
+    return GraphRunResult(graph=graph, results=tuple(ordered), final_answer=final_answer)
+
+
+def _synthesize_without_llm(graph: PlanGraph, results: tuple[NodeResult, ...]) -> str:
+    ok = [r for r in results if r.ok]
+    failed = [r for r in results if not r.ok]
+    lines = [f"I ran the saved workflow '{graph.name}' without an LLM planning step."]
+    if ok:
+        lines.append("Completed:")
+        lines.extend(f"- {r.summary()}" for r in ok)
+    if failed:
+        lines.append("Problems:")
+        lines.extend(f"- {r.summary()}" for r in failed)
+    lines.append("If this workflow was not what you intended, I can fall back to ReAct once and learn the corrected sequence.")
+    return "\n".join(lines)
+
+
+def run_graph_agent(user_input: str, cap_ids: list[str] | None = None) -> GraphRunResult | None:
+    graph = plan_from_master(user_input, cap_ids=cap_ids)
+    if graph is None:
+        return None
+    return execute_graph(graph)
+
+
+def list_master_plans_json() -> str:
+    """Return graph master-plan metadata for tool/schema callers."""
+    rows = []
+    for plan in load_master_plans():
+        rows.append({
+            "id": plan.get("id"),
+            "name": plan.get("name"),
+            "triggers": plan.get("triggers", []),
+            "requires_any": plan.get("requires_any", []),
+            "nodes": [
+                {
+                    "id": n.get("id"),
+                    "tool": n.get("tool"),
+                    "depends_on": n.get("depends_on", []),
+                    "arg_keys": sorted((n.get("args") or {}).keys()),
+                }
+                for n in plan.get("nodes", []) if isinstance(n, dict)
+            ],
+        })
+    return json.dumps({"master_plans": rows}, ensure_ascii=False, indent=2)
+
+
+def run_master_plan_json(task: str, cap_ids: list[str] | None = None) -> str:
+    """Run the graph executor and return a compact JSON observation."""
+    result = run_graph_agent(task, cap_ids=cap_ids)
+    if result is None:
+        return json.dumps({
+            "ok": False,
+            "error_type": "no_matching_master_plan",
+            "task": task,
+            "instruction": "Use ReAct once, then record/promote the successful workflow if it should become reusable.",
+        }, ensure_ascii=False, indent=2)
+    return json.dumps({
+        "ok": not any(not r.ok for r in result.results),
+        "graph_id": result.graph.id,
+        "graph_name": result.graph.name,
+        "results": [r.__dict__ for r in result.results],
+        "final_answer": result.final_answer,
+    }, ensure_ascii=False, indent=2)
+
+
+def append_master_plan_from_experience(goal: str, steps: list[dict[str, Any]], *, name: str | None = None) -> Path:
+    """Promote a practiced or ReAct-discovered tool sequence into user master plans.
+
+    Args are stored as sanitized previews by the experience layer, so promoted
+    templates intentionally use ``$prompt``/``$title`` placeholders unless the
+    operator edits the JSON by hand.
+    """
+    nodes = []
+    for idx, step in enumerate(steps, start=1):
+        tool = str(step.get("tool") or "").strip()
+        if not tool or tool in {"final_answer", "llm_call"}:
+            continue
+        args = {"goal": "$prompt"} if tool == "make_plan" else {"title": "$title", "content": "$prompt", "folder": "notes"} if tool == "save_note" else {"query": "$prompt"} if tool in {"deep_search", "deep_research"} else {}
+        node = {"id": f"step_{idx}", "tool": tool, "args": args}
+        if nodes:
+            node["depends_on"] = [nodes[-1]["id"]]
+        nodes.append(node)
+    if not nodes:
+        raise ValueError("no promotable tool steps found")
+    path = _master_plan_file()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = []
+    if path.exists():
+        try:
+            existing = json.loads(path.read_text(encoding="utf-8"))
+            if not isinstance(existing, list):
+                existing = []
+        except Exception:
+            existing = []
+    existing.append({
+        "id": f"practiced_{uuid.uuid4().hex[:10]}",
+        "name": name or _title(goal),
+        "triggers": _heuristic_items(goal)[:4],
+        "requires_any": [],
+        "nodes": nodes,
+    })
+    path.write_text(json.dumps(existing, ensure_ascii=False, indent=2), encoding="utf-8")
+    return path

--- a/skills/skills.md
+++ b/skills/skills.md
@@ -39,7 +39,7 @@ Aiko may sometimes refuse, delay, or bargain before using a skill for OppaAI whe
 - **Coding teaching:** When the user asks to learn programming, teach in small runnable steps, verify against repository context or current official docs when needed, and route structured lesson/session requests to `coding_tutor`.
 - **Aurora forecast watch:** When the user asks to monitor aurora/Kp conditions, route to `aurora_forecast_watch` and schedule local agentic checks using source-backed space-weather data.
 - **Job hunt:** When the user asks Aiko to find jobs, route to `job_hunt`; use the skill's JSON defaults for Vancouver-area searches unless the user gives another location.
-- **Knowledge/experience:** Use trusted wiki/skills for policy, learned knowledge vector RAG for durable study/document facts, memory for private user facts, and experience as a hint for similar past tool sequences. If the user asks to add docs/PDF/pasted knowledge to RAG, call `learn_knowledge`; do not silently rewrite wiki/skills.
+- **Knowledge/experience:** Use trusted wiki/skills for policy, learned knowledge vector RAG for durable study/document facts, memory for private user facts, and graph master plans for reusable procedural workflows. Experience is a post-run procedural trace used for offline promotion into master plans, not prompt context by default. If the user asks to add docs/PDF/pasted knowledge to RAG, call `learn_knowledge`; do not silently rewrite wiki/skills.
 - **Ongoing tasks:** Summarize done/next/risks and save or update state when tools support it.
 - **Scheduled jobs:** Use `schedule_job` with `action: announce` for alarms/reminders and `action: agentic` for local autonomous work such as reports or saved notes. Follow `skills/schedule.md`.
 

--- a/tests/test_graph_agent.py
+++ b/tests/test_graph_agent.py
@@ -1,0 +1,27 @@
+from skills import graph_agent
+
+
+def test_master_plan_prefers_checklist_workflow():
+    graph = graph_agent.plan_from_master("make a checklist for Needle testing and save it", [])
+    assert graph is not None
+    assert graph.id == "checklist_and_save"
+
+
+def test_graph_executes_save_note_without_llm(tmp_path, monkeypatch):
+    monkeypatch.setenv("WORKSPACE_ROOT", str(tmp_path))
+    graph = graph_agent.plan_from_master("save this as a note: Needle practice works", [])
+    assert graph is not None
+    result = graph_agent.execute_graph(graph)
+    assert result.final_answer.startswith("I ran the saved workflow")
+    assert any(r.tool == "save_note" and r.ok for r in result.results)
+
+
+def test_graph_agent_schema_observation_lists_master_plans():
+    data = graph_agent.list_master_plans_json()
+    assert "master_plans" in data
+    assert "checklist_and_save" in data
+
+
+def test_run_master_plan_json_reports_no_match():
+    data = graph_agent.run_master_plan_json("zzzz unmatched opaque task")
+    assert "no_matching_master_plan" in data


### PR DESCRIPTION
### Motivation

- Introduce a conservative, deterministic graph/master-plan executor to run known workflows without an LLM planning step and enable promotion of practiced sequences into reusable master plans.
- Reduce cold-boot cost for semantic intent routing by optionally caching route-example embedding matrices on disk.
- Provide tooling for seeding and promoting practiced workflows without booting the chat LLM, and make experience traces safer and richer for promotion.

### Description

- Added a model-free graph executor implementation in `skills/graph_agent.py` with `PlanGraph` planning, deterministic node execution, synthesis without an LLM, master-plan loading, listing, and promotion via `append_master_plan_from_experience`.
- Integrated the graph executor into the agentic flow in `skills/agentic.py`, gated by `AGENT_EXECUTOR_MODE` (`react|graph|hybrid`) and `GRAPH_*` config flags, and added `list_master_plans` / `run_master_plan` tool bindings.
- Added on-disk semantic route-example caching in `cognition/think.py` keyed by examples, instruct string, and embedder metadata, controlled by `ROUTE_VECTOR_CACHE_ENABLED` / `ROUTE_VECTOR_CACHE_DIR` and using pickle for storage.
- Added `practice.py` CLI to record practice traces and optionally promote them into per-user master plans, and extended `skills/experience.py` with a lightweight fallback for minimal test environments plus `record_practice_experience` and sanitized argument previews.
- Updated configuration files (`config/skills.yaml`, `config/cognition.yaml`) and docs (`docs/*`) to document new options and the graph-first executor and vector cache behavior.

### Testing

- Ran the new graph executor unit tests with `pytest tests/test_graph_agent.py`, and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5682e6844c8325acfdf920bf8c167c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added graph-first execution for known workflows, with a fallback for novel tasks.
  - Added tools to browse and run saved master plans.
  - Added a command-line workflow for practicing and promoting successful procedures.
  - Added persistent caching for semantic routing vectors to improve repeat performance.
  - Experience records now include sanitized step argument summaries.

- **Documentation**
  - Updated architecture, installation, roadmap, history, skills, and testing guidance for graph-based execution and caching.

- **Bug Fixes**
  - Improved operation in lightweight environments where optional memory services are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->