### PR TITLE
feat: phase 2 — voice - Part 2 (barge-in + wake word + Best of N fix)

### DIFF
--- a/config/sensory.yaml
+++ b/config/sensory.yaml
@@ -36,7 +36,7 @@ BARGE_IN_ALWAYS_ON: "1"  # Monitor barge-in outside TTS playback; options: 1/0, 
 # transcript, since SenseVoice mangles "Aiko" unpredictably (not a normal
 # English word). Blank disables wake-word gating entirely — Aiko responds
 # to every utterance as before.
-WAKE_WORD: "hey aiko"  # Phrase that wakes Aiko from idle, e.g. "hey aiko". "" disables.
+WAKE_WORD: ""  # Phrase that wakes Aiko from idle, e.g. "hey aiko". "" disables.
 WAKE_WORD_ALIASES: "hey iko|hey i"  # "|"-separated extra candidate phrases for observed ASR mishearings, e.g. "hey iko|hey eco|hey ecko".
 WAKE_FUZZY_THRESHOLD: "70"  # Fuzzy match score (0-100) required to count as a wake-word hit.
 

--- a/config/sensory.yaml
+++ b/config/sensory.yaml
@@ -26,7 +26,7 @@ SPEAKER_VERIFY_THRESHOLD: "0.5"  # Cosine similarity cutoff for speaker match; r
 SPEAKER_NUM_THREADS: "1"  # CPU threads for speaker embedding extraction.
 
 # -- Barge-in --
-BARGE_IN_THRESHOLD: "0.65"  # Speech probability threshold to interrupt TTS; range 0.0-1.0.
+BARGE_IN_THRESHOLD: "0.85"  # Speech probability threshold to interrupt TTS; range 0.0-1.0.
 BARGE_IN_CONFIRM_CHUNKS: "2"  # Consecutive chunks above threshold before barge-in fires.
 BARGE_IN_COOLDOWN_MS: "800"  # Cooldown in milliseconds before another barge-in event can fire.
 BARGE_IN_ALWAYS_ON: "1"  # Monitor barge-in outside TTS playback; options: 1/0, true/false, yes/no, on/off.

--- a/config/sensory.yaml
+++ b/config/sensory.yaml
@@ -36,8 +36,8 @@ BARGE_IN_ALWAYS_ON: "1"  # Monitor barge-in outside TTS playback; options: 1/0, 
 # transcript, since SenseVoice mangles "Aiko" unpredictably (not a normal
 # English word). Blank disables wake-word gating entirely — Aiko responds
 # to every utterance as before.
-WAKE_WORD: ""  # Phrase that wakes Aiko from idle, e.g. "hey aiko". "" disables.
-WAKE_WORD_ALIASES: "hey iko|hey i"  # "|"-separated extra candidate phrases for observed ASR mishearings, e.g. "hey iko|hey eco|hey ecko".
+WAKE_WORD: "hey there"  # Phrase that wakes Aiko from idle, e.g. "hey aiko". "" disables.
+WAKE_WORD_ALIASES: ""  # "|"-separated extra candidate phrases for observed ASR mishearings, e.g. "hey iko|hey eco|hey ecko".
 WAKE_FUZZY_THRESHOLD: "70"  # Fuzzy match score (0-100) required to count as a wake-word hit.
 
 # -- Trigger phrase --
@@ -52,7 +52,7 @@ TRIGGER_REQUIRE_SPEAKER_MATCH: "1"  # Trigger phrase alone isn't enough — cosi
 # Once woken/triggered, Aiko stays "active" (no phrase required, proactive
 # behavior allowed) until this many seconds pass with no further utterance.
 # After that she goes back to sleep and requires the configured phrase(s) again.
-ACTIVATION_TIMEOUT_S: "30"  # Idle seconds before requiring wake word / trigger phrase again.
+ACTIVATION_TIMEOUT_S: "3600"  # Idle seconds before requiring wake word / trigger phrase again.
 
 
 # Speak config
@@ -71,6 +71,6 @@ MIOTTS_TOP_P: 1.0  # Nucleus sampling threshold; 1.0 = no truncation of the toke
 MIOTTS_REPETITION_PENALTY: 1.15  # Penalizes repeated/held audio tokens; higher discourages drawn-out trailing vowels.
 MIOTTS_PRESENCE_PENALTY: 0.0  # Penalizes tokens already used anywhere in the output, regardless of frequency.
 MIOTTS_FREQUENCY_PENALTY: 0.0  # Penalizes tokens proportional to how often they've already appeared.
-MIOTTS_BEST_OF_N_ENABLED: true  # Generate multiple candidates and pick the best via ASR error-rate scoring.
+MIOTTS_BEST_OF_N_ENABLED: false  # Generate multiple candidates and pick the best via ASR error-rate scoring.
 MIOTTS_BEST_OF_N: 2  # Number of candidates to generate per call when best-of-N is enabled.
 KARAOKE_TEXT: "0"  # Pace UI text by TTS audio; options: 1/0, true/false, yes/no, on/off.

--- a/config/sensory.yaml
+++ b/config/sensory.yaml
@@ -36,8 +36,8 @@ BARGE_IN_ALWAYS_ON: "1"  # Monitor barge-in outside TTS playback; options: 1/0, 
 # transcript, since SenseVoice mangles "Aiko" unpredictably (not a normal
 # English word). Blank disables wake-word gating entirely — Aiko responds
 # to every utterance as before.
-WAKE_WORD: ""  # Phrase that wakes Aiko from idle, e.g. "hey aiko". "" disables.
-WAKE_WORD_ALIASES: ""  # "|"-separated extra candidate phrases for observed ASR mishearings, e.g. "hey iko|hey eco|hey ecko".
+WAKE_WORD: "hey aiko"  # Phrase that wakes Aiko from idle, e.g. "hey aiko". "" disables.
+WAKE_WORD_ALIASES: "hey iko|hey i"  # "|"-separated extra candidate phrases for observed ASR mishearings, e.g. "hey iko|hey eco|hey ecko".
 WAKE_FUZZY_THRESHOLD: "70"  # Fuzzy match score (0-100) required to count as a wake-word hit.
 
 # -- Trigger phrase --

--- a/config/sensory.yaml
+++ b/config/sensory.yaml
@@ -53,3 +53,24 @@ TRIGGER_REQUIRE_SPEAKER_MATCH: "1"  # Trigger phrase alone isn't enough — cosi
 # behavior allowed) until this many seconds pass with no further utterance.
 # After that she goes back to sleep and requires the configured phrase(s) again.
 ACTIVATION_TIMEOUT_S: "30"  # Idle seconds before requiring wake word / trigger phrase again.
+
+
+# Speak config
+#
+# Settings for sensory/speak.py.
+# Controls MioTTS synthesis endpoint, voice preset, output device, and text pacing.
+
+# -- MioTTS --
+MIOTTS_API_URL: "http://localhost:8001"  # MioTTS synthesis API base URL.
+MIOTTS_MODEL: "MioTTS-0.4B-Q4_K_M"  # Display/model label for the TTS model served externally.
+MIOTTS_PRESET: "aiko_flat"  # Voice preset name registered in MioTTS; examples: jp_female, en_female, custom preset.
+MIOTTS_DEVICE: "-1"  # sounddevice output index; -1 means system default.
+MIOTTS_MAX_TOKENS: 300  # Max audio-codec tokens per synthesis call; caps how long a chunk (and any trailing artifact) can run.
+MIOTTS_TEMPERATURE: 0.8  # Sampling temperature for the TTS LLM; lower = more deterministic/stable delivery.
+MIOTTS_TOP_P: 1.0  # Nucleus sampling threshold; 1.0 = no truncation of the token distribution.
+MIOTTS_REPETITION_PENALTY: 1.15  # Penalizes repeated/held audio tokens; higher discourages drawn-out trailing vowels.
+MIOTTS_PRESENCE_PENALTY: 0.0  # Penalizes tokens already used anywhere in the output, regardless of frequency.
+MIOTTS_FREQUENCY_PENALTY: 0.0  # Penalizes tokens proportional to how often they've already appeared.
+MIOTTS_BEST_OF_N_ENABLED: true  # Generate multiple candidates and pick the best via ASR error-rate scoring.
+MIOTTS_BEST_OF_N: 2  # Number of candidates to generate per call when best-of-N is enabled.
+KARAOKE_TEXT: "0"  # Pace UI text by TTS audio; options: 1/0, true/false, yes/no, on/off.

--- a/docs/MULTI_USER.md
+++ b/docs/MULTI_USER.md
@@ -6,7 +6,7 @@ OAuth is the source of identity; `persona/identity.md` remains Aiko's identity o
 ## Current implementation
 
 - OAuth sessions store a provider-scoped runtime id, such as `github_123456` or `patreon_987654321`, to avoid collisions between providers.
-- User-private state defaults to `~/.aiko/<user_id>/`:
+- User-private state defaults to `<USER_SPACE_ROOT>/<user_id>/`:
   - `user.md` for the user's editable bio/profile.
   - `memory.db` for that user's sqlite-vec memory store.
   - `monthly_consolidation_state.jsonl` for that user's monthly consolidation state.
@@ -20,7 +20,7 @@ OAuth is the source of identity; `persona/identity.md` remains Aiko's identity o
   - `MONTHLY_CONSOLIDATION_STATE_PATH`
   - `SCHEDULE_PATH`
   - `WORKSPACE_ROOT`
-  - `AIKO_USER_STATE_ROOT`
+  - `USER_STATE_ROOT` (canonical), plus compatibility aliases `AIKO_USER_STATE_ROOT` and `USER_SPACE_ROOT`
 
 ## sqlite-vec per user
 
@@ -34,7 +34,7 @@ Do **not** derive an encryption key from only the OAuth user id. User ids are no
 - public context: `provider:user_id`
 - output: per-user encryption key
 
-`sqlite-vec` itself does not provide encryption with a normal SQLite `PRAGMA`. Aiko now has an optional SQLCipher hook for the memory DB: set `AIKO_SQLITE_ENCRYPTION=1`, install a SQLCipher-capable Python driver such as `pysqlcipher3`, and set `AIKO_DATA_KEY_SECRET` in `.env`, Modal secrets, or another secret manager. Aiko derives a per-user SQLCipher raw key from the server secret plus provider-scoped user id. This keeps latency low because encryption happens at SQLite page I/O, not per vector operation. If SQLCipher is not available in the deployment image, keep using OS/disk encryption, strict filesystem permissions, and per-user files/directories until the image is upgraded.
+`sqlite-vec` itself does not provide encryption with a normal SQLite `PRAGMA`. Aiko now has an optional SQLCipher hook for the memory DB: setQLITE_ENCRYPTION=1`, install a SQLCipher-capable Python driver such as `pysqlcipher3`, and set `AIKO_DATA_KEY_SECRET` in `.env`, Modal secrets, or another secret manager. Aiko derives a per-user SQLCipher raw key from the server secret plus provider-scoped user id. This keeps latency low because encryption happens at SQLite page I/O, not per vector operation. If SQLCipher is not available in the deployment image, keep using OS/disk encryption, strict filesystem permissions, and per-user files/directories until the image is upgraded.
 
 ## Workspace encryption
 

--- a/docs/MULTI_USER.md
+++ b/docs/MULTI_USER.md
@@ -7,7 +7,7 @@ OAuth is the source of identity; `persona/identity.md` remains Aiko's identity o
 
 - OAuth sessions store a provider-scoped runtime id, such as `github_123456` or `patreon_987654321`, to avoid collisions between providers.
 - User-private state defaults to `~/.aiko/<user_id>/`:
-  - `user.md` for the user's editable bio/profile.
+  - `profile/user.md` for the user's editable bio/profile.
   - `memory.db` for that user's sqlite-vec memory store.
   - `monthly_consolidation_state.jsonl` for that user's monthly consolidation state.
   - `schedule.json` for that user's scheduled jobs/reminders (agentic scheduling).
@@ -20,7 +20,7 @@ OAuth is the source of identity; `persona/identity.md` remains Aiko's identity o
   - `MONTHLY_CONSOLIDATION_STATE_PATH`
   - `SCHEDULE_PATH`
   - `WORKSPACE_ROOT`
-  - `AIKO_USER_STATE_ROOT`
+  - `USER_STATE_ROOT` (canonical), plus compatibility aliases `AIKO_USER_STATE_ROOT` and `USER_SPACE_ROOT`
 
 ## sqlite-vec per user
 
@@ -40,7 +40,7 @@ Do **not** derive an encryption key from only the OAuth user id. User ids are no
 
 For a simple online tester tier, prefer encrypting the storage layer instead of encrypting individual files in application code:
 
-1. Put `AIKO_USER_STATE_ROOT` on an encrypted persistent volume.
+1. Put `USER_STATE_ROOT` on an encrypted persistent volume.
 2. Restrict permissions to the service account.
 3. Keep each user in a separate directory.
 4. Avoid writing secrets into workspace files.

--- a/docs/MULTI_USER.md
+++ b/docs/MULTI_USER.md
@@ -45,13 +45,13 @@ For a simple online tester tier, prefer encrypting the storage layer instead of 
 3. Keep each user in a separate directory.
 4. Avoid writing secrets into workspace files.
 
-If the backend runs in Modal, the workspace is server-side unless you explicitly build a client upload/download feature. A browser app cannot silently read arbitrary files from a user's PC; users must upload files through a file picker, and Aiko can only access files that were uploaded to the backend workspace. To let a user take their workspace home, add an authenticated export endpoint that zips only `~/.aiko/<user_id>/workspace/` and streams it to the browser.
+If the backend runs in Modal, the workspace is server-side unless you explicitly build a client upload/download feature. A browser app cannot silently read arbitrary files from a user's PC; users must upload files through a file picker, and Aiko can only access files that were uploaded to the backend workspace. To let a user take their workspace home, add an authenticated export endpoint that zips only `<USER_SPACE_ROOT>/<user_id>/workspace/` and streams it to the browser.
 
 Per-file encryption can come later, but it complicates search, previews, scheduled jobs, and tool access because every tool must decrypt/re-encrypt correctly.
 
 ## Google Drive workspace direction
 
-No agentic-tool changes are required just to move Aiko's writable workspace later. The existing workspace tools already go through `WORKSPACE_ROOT`. When Google Drive/Gmail access is added, initialize or mount/sync the Drive-backed workspace during boot/warmup, then point `WORKSPACE_ROOT` at that mounted directory. Keep private runtime state such as `memory.db`, `schedule.json`, and `monthly_consolidation_state.jsonl` under `~/.aiko/<user_id>/` rather than in Drive unless you explicitly want those files synced.
+No agentic-tool changes are required just to move Aiko's writable workspace later. The existing workspace tools already go through `WORKSPACE_ROOT`. When Google Drive/Gmail access is added, initialize or mount/sync the Drive-backed workspace during boot/warmup, then point `WORKSPACE_ROOT` at that mounted directory. Keep private runtime state such as `memory.db`, `schedule.json`, and `monthly_consolidation_state.jsonl` under `<USER_SPACE_ROOT>/<user_id>/` rather than in Drive unless you explicitly want those files synced.
 
 ## Other per-user state to keep isolated
 

--- a/interface/webui/static/vad.js
+++ b/interface/webui/static/vad.js
@@ -40,6 +40,30 @@ let _silTimer = null;
 let _preBuf = [];     // circular pre-speech context
 let _energyHits = 0;
 let _vadEpoch = 0;
+let _lastBargeSent = 0;   // timestamp of last barge_in sent, for throttling
+
+// -- barge-in debug log throttle ----------------------------------------------
+
+let _lastLog = 0;
+const LOG_INTERVAL = 150; // ms between debug logs during TTS playback
+
+function _maybeLogBargeIn(rms, startThresh) {
+    const now = performance.now();
+    if (now - _lastLog < LOG_INTERVAL) return;
+    _lastLog = now;
+    if (!window.aikoIsSpeaking) {
+        console.log(
+            `[barge] rms=${rms.toFixed(5)}  thr≥${startThresh.toFixed(5)}  floor=${_noiseFloor.toFixed(5)}  ` +
+            `speaking=${_speaking}  aikoSpeaking=${window.aikoIsSpeaking}  [SKIP — aiko not speaking]`
+        );
+        return;
+    }
+    const wouldBarge = rms >= startThresh;
+    console.log(
+        `[barge] rms=${rms.toFixed(5)}  thr≥${startThresh.toFixed(5)}  floor=${_noiseFloor.toFixed(5)}  ` +
+        `speaking=${_speaking}  aikoSpeaking=${window.aikoIsSpeaking}  ${wouldBarge ? '→ WOULD BARGE' : ''}`
+    );
+}
 
 // -- init ---------------------------------------------------------------------
 
@@ -61,6 +85,7 @@ function _resetState() {
     _preBuf = [];
     _speaking = false;
     _energyHits = 0;
+    _lastBargeSent = 0;
     if (_silTimer) { clearTimeout(_silTimer); _silTimer = null; }
 }
 
@@ -93,6 +118,10 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
     }
     const rms = _rms(frame);
 
+    // Barge-in debug: log voice level during TTS playback (throttled)
+    const { startThresh } = _calcThresholds();
+    _maybeLogBargeIn(rms, startThresh);
+
     // Adaptive noise floor: track the minimum RMS when not speaking
     if (!_speaking) {
         if (rms < _noiseFloor) {
@@ -103,7 +132,7 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
         }
     }
 
-    const { startThresh, endThresh } = _calcThresholds();
+    const { endThresh } = _calcThresholds();
 
     if (!_speaking && rms >= startThresh) {
         _energyHits++;
@@ -122,8 +151,12 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
         // instead of continuing to stream chunks that would just refill the
         // queue we already cleared.
         if (window.aikoIsSpeaking) {
-            if (window.stopTtsPlayback) window.stopTtsPlayback();
-            ws.send(JSON.stringify({ type: 'barge_in' }));
+            const now = performance.now();
+            if (now - _lastBargeSent > 300) {
+                _lastBargeSent = now;
+                if (window.stopTtsPlayback) window.stopTtsPlayback();
+                ws.send(JSON.stringify({ type: 'barge_in' }));
+            }
         }
     
         // Edge-triggered log: one line when speech is detected, not one per frame.
@@ -145,6 +178,20 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
         if (gate) {
             if (!_canSend(ws, epoch)) return;
             ws.send(frame.buffer.slice(0));
+        }
+
+        // Barge-in during active speech: user may have been speaking from a
+        // previous segment (VAD state didn't reset) or started speaking while
+        // TTS was already playing. The speech-onset barge-in at line 151 only
+        // fires when _speaking transitions false→true, so we need an
+        // additional check here.
+        if (window.aikoIsSpeaking && rms >= startThresh) {
+            const now = performance.now();
+            if (now - _lastBargeSent > 300) {
+                _lastBargeSent = now;
+                if (window.stopTtsPlayback) window.stopTtsPlayback();
+                ws.send(JSON.stringify({ type: 'barge_in' }));
+            }
         }
 
         if (rms > endThresh) {

--- a/interface/webui/static/vad.js
+++ b/interface/webui/static/vad.js
@@ -42,29 +42,6 @@ let _energyHits = 0;
 let _vadEpoch = 0;
 let _lastBargeSent = 0;   // timestamp of last barge_in sent, for throttling
 
-// -- barge-in debug log throttle ----------------------------------------------
-
-let _lastLog = 0;
-const LOG_INTERVAL = 150; // ms between debug logs during TTS playback
-
-function _maybeLogBargeIn(rms, startThresh) {
-    const now = performance.now();
-    if (now - _lastLog < LOG_INTERVAL) return;
-    _lastLog = now;
-    if (!window.aikoIsSpeaking) {
-        console.log(
-            `[barge] rms=${rms.toFixed(5)}  thr≥${startThresh.toFixed(5)}  floor=${_noiseFloor.toFixed(5)}  ` +
-            `speaking=${_speaking}  aikoSpeaking=${window.aikoIsSpeaking}  [SKIP — aiko not speaking]`
-        );
-        return;
-    }
-    const wouldBarge = rms >= startThresh;
-    console.log(
-        `[barge] rms=${rms.toFixed(5)}  thr≥${startThresh.toFixed(5)}  floor=${_noiseFloor.toFixed(5)}  ` +
-        `speaking=${_speaking}  aikoSpeaking=${window.aikoIsSpeaking}  ${wouldBarge ? '→ WOULD BARGE' : ''}`
-    );
-}
-
 // -- init ---------------------------------------------------------------------
 
 /**
@@ -118,9 +95,7 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
     }
     const rms = _rms(frame);
 
-    // Barge-in debug: log voice level during TTS playback (throttled)
     const { startThresh } = _calcThresholds();
-    _maybeLogBargeIn(rms, startThresh);
 
     // Adaptive noise floor: track the minimum RMS when not speaking
     if (!_speaking) {

--- a/interface/webui/webui.py
+++ b/interface/webui/webui.py
@@ -168,8 +168,12 @@ class AikoWeb:
 
         # binary mic-audio frames from the browser, consumed by get_voice_input()
         # an empty-bytes sentinel (b"") signals end-of-utterance from browser VAD
-        self._audio_q: queue.Queue[bytes] = queue.Queue()
+        # maxsize=10000 (~20 seconds at 512 frames/s) prevents unbounded growth
+        # since the mic stays open continuously for instant barge-in
+        self._audio_q: queue.Queue[bytes] = queue.Queue(maxsize=10000)
         self._mic_active = threading.Event()
+        self._mic_started: bool = False
+        self._did_barge_in: bool = False
 
         # connected browser websocket clients
         self._clients: set = set()
@@ -349,10 +353,15 @@ class AikoWeb:
                     break
                 raw_bytes = message.get("bytes")
                 if raw_bytes is not None:
-                    # browser mic PCM frame — only buffer during an active voice turn
-                    # so stale/late frames from a previous turn don't pollute the next
+                    # browser mic PCM frame — only buffer during an active voice
+                    # turn so stale/late frames don't pollute the next recording.
+                    # Mic stays open continuously (for instant barge-in), so
+                    # drop frames if queue is full to avoid blocking the handler.
                     if self._mic_active.is_set():
-                        self._audio_q.put(raw_bytes)
+                        try:
+                            self._audio_q.put_nowait(raw_bytes)
+                        except queue.Full:
+                            pass
                     continue
 
                 raw_text = message.get("text")
@@ -406,6 +415,7 @@ class AikoWeb:
                         # is_playing() is still True, returns True, and
                         # listen.py clears the event — otherwise the stale
                         # event prematurely cuts off the next turn's TTS.
+                        self._did_barge_in = True
                         if self._listen is not None:
                             self._listen.trigger_barge_in()
                         if self._speak is not None:
@@ -418,6 +428,10 @@ class AikoWeb:
             with self._clients_lock:
                 self._clients.discard(ws)
             log.info("[aiko-web] browser disconnected (total=%d)", len(self._clients))
+            # reset mic state so a reconnecting browser gets mic:start again
+            if not self._clients:
+                self._mic_started = False
+                self._did_barge_in = False
 
     # ------------------------------------------------------------------
     # broadcast helpers
@@ -645,6 +659,12 @@ class AikoWeb:
         Capture a voice utterance via the browser's microphone and return the
         same (text, info) shape as AikoTUI.get_voice_input().
 
+        The browser mic stays open continuously once started, so the browser
+        VAD can detect speech during TTS playback and send instant barge-in
+        messages (zero round-trip). Between turns, the audio queue is only
+        drained if no barge-in occurred — otherwise the speech frames that
+        triggered the barge-in are preserved for recording.
+
         By default, the browser VAD gates 16 kHz float32 PCM before it enters
         _audio_q, so only browser-detected speech is sent over the network. Set
         WEBUI_BROWSER_VAD_GATE=0 for a diagnostic raw-stream mode that bypasses
@@ -653,12 +673,15 @@ class AikoWeb:
         result_holder = [None]
         done_event    = threading.Event()
 
-        # drain stale frames from any previous turn
-        while True:
-            try:
-                self._audio_q.get_nowait()
-            except queue.Empty:
-                break
+        # If barge-in fired while TTS was playing, the speaker's voice frames
+        # are already in the queue — don't discard them.
+        if not self._did_barge_in:
+            while True:
+                try:
+                    self._audio_q.get_nowait()
+                except queue.Empty:
+                    break
+        self._did_barge_in = False
 
         BYTES_PER_CHUNK = 512 * 4   # 512 float32 samples = 2048 bytes
         FRAME_TIMEOUT_S = 5.0       # browser disconnected / stopped delivering PCM
@@ -711,13 +734,18 @@ class AikoWeb:
             )
             done_event.set()
 
-        self._mic_active.set()
-        self._broadcast({
-            "type": "mic",
-            "action": "start",
-            "bytes_per_chunk": BYTES_PER_CHUNK,
-            "browser_vad_gate": WEBUI_BROWSER_VAD_GATE,
-        })
+        # Keep the browser mic open continuously once started, so the browser
+        # VAD can detect speech during TTS playback for instant barge-in.
+        if not self._mic_started:
+            self._mic_active.set()
+            self._broadcast({
+                "type": "mic",
+                "action": "start",
+                "bytes_per_chunk": BYTES_PER_CHUNK,
+                "browser_vad_gate": WEBUI_BROWSER_VAD_GATE,
+            })
+            self._mic_started = True
+
         threading.Thread(target=_run, daemon=True).start()
 
         text_input = None
@@ -732,10 +760,7 @@ class AikoWeb:
                 except queue.Empty:
                     pass
         finally:
-            self._mic_active.clear()
-            self._broadcast({"type": "mic", "action": "stop"})
-
-        self._broadcast({"type": "voice", "status": "idle"})
+            self._broadcast({"type": "voice", "status": "idle"})
 
         # Check one last time if a text input arrived as we finished
         if text_input is None:

--- a/interface/webui/webui.py
+++ b/interface/webui/webui.py
@@ -400,10 +400,16 @@ class AikoWeb:
                         # producing audio that would just refill the (already
                         # cleared) client queue, and unblocks listen.py's
                         # wait_or_barge_in() so the next turn can start.
-                        if self._speak is not None:
-                            self._speak.stop()
+                        #
+                        # trigger_barge_in() MUST fire before speak.stop()
+                        # so wait_or_barge_in() sees the event while
+                        # is_playing() is still True, returns True, and
+                        # listen.py clears the event — otherwise the stale
+                        # event prematurely cuts off the next turn's TTS.
                         if self._listen is not None:
                             self._listen.trigger_barge_in()
+                        if self._speak is not None:
+                            self._speak.stop()
         
         except Exception as e:
             log.exception("[aiko-web] error in WebSocket loop")

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ Boot ordering note (login-gated wakeup):
     in interface/webui/webui.py). This guarantees system.userspace.current_user_id()
     already resolves to a real, logged-in user_id by the time AikoMemorize,
     schedule.json seeding, and the ScheduleRunner are constructed inside
-    boot() — no subsystem ever touches USER_SPACE_ROOT/guest/ on disk. The
+    boot() — no subsystem ever touches USER_STATE_ROOT/guest/ on disk. The
     CLI path (_run_cli) already resolves a real USER_ID via GitHub OAuth
     before _run_session() is ever called, so it needs no change here.
 """

--- a/main.py
+++ b/main.py
@@ -1524,6 +1524,10 @@ def _run_session(ui, args):
 
     def _generate_proactive_checkin(prompt_hint: str) -> str:
         session_active.set()
+        # Keep the activation session alive during proactive — no wake word
+        # needed while Aiko is still engaging with the user.
+        if listen is not None and hasattr(listen, "extend_activation"):
+            listen.extend_activation()
         original_speak = getattr(think, "_speak", None)
         try:
             if not tts_enabled or not PROACTIVE_SPEAK:

--- a/persona/soul.md
+++ b/persona/soul.md
@@ -44,8 +44,9 @@ If OppaAI describes something that sounds like genuine danger to himself or some
 
 You have memory only when it is provided to you.
 
-- If a `<memory_context>` block contains a fact about the current user, you may use it.
-- If it is not present, do not invent it. Say, "I don't have that stored."
+- The user's identity (name, who they are) is already given in "You are speaking with <name>." above — that is not a memory-dependent fact. If asked who they are, answer from that line.
+- If a `<memory_context>` block contains additional facts about the current user, you may use them too.
+- If `<memory_context>` says "No relevant memories found", do not say "I don't know" for their name or identity — you already have it from the system prompt.
 - If a `<search_results>` block is present, treat it as the source for that topic.
 - If search results are insufficient, say what is missing instead of filling gaps with guesses.
 - Use general knowledge for stable topics, but accept corrections without defensiveness.

--- a/sensory/listen.py
+++ b/sensory/listen.py
@@ -14,7 +14,7 @@ Aiko's speech-to-text input layer.
     in parallel with transcription — see SPEAKER_VERIFY_ENABLED below
   - Optionally gates responses behind a wake word ("Hey Aiko") and/or a
     trigger phrase said alongside speaker verification ("Here is Oppa") —
-    see WAKE_WORD / TRIGGER_PHRASE below
+    see WAKE_WORD below
   - Exposes listen() (blocking) and listen_async() (callback) for UI
   - Staged init: load_asr() → load_vad() → load_speaker_id() → join_warmup()
     for granular boot progress reporting via wakeup.py
@@ -44,13 +44,6 @@ Wake word / trigger phrase (optional — see config/listen.yaml):
     an exact substring check. WAKE_WORD_ALIASES lets you hardcode observed
     mishearings ("hey iko|hey eco|hey ecko") as extra candidates.
 
-    TRIGGER_PHRASE ("here is oppa" by default off / "" disables) only takes
-    effect when SPEAKER_VERIFY_ENABLED=1. It can follow the wake word
-    ("Hey Aiko here is Oppa ...") or stand alone if WAKE_WORD is unset. When
-    TRIGGER_REQUIRE_SPEAKER_MATCH=1 (default), the phrase alone isn't
-    enough — the cosine-similarity speaker check on that same utterance
-    must also pass.
-
     Once woken/triggered, Aiko stays "active" (no phrase required) until
     ACTIVATION_TIMEOUT_S seconds pass with no further utterance, at which
     point the session goes back to sleep and the configured phrase(s) are
@@ -69,9 +62,11 @@ from huggingface_hub import hf_hub_download
 from silero_vad import load_silero_vad
 from system.userspace import user_state_path
 import json
-import logging
+import logging as _logging
 import numpy as np
 import os
+
+log = _logging.getLogger(__name__)
 
 from scipy.signal import resample_poly
 import sherpa_onnx
@@ -88,7 +83,7 @@ except ImportError:
     import difflib as _difflib
 
 warnings.filterwarnings("ignore")
-logging.getLogger("sherpa_onnx").setLevel(logging.ERROR)
+_logging.getLogger("sherpa_onnx").setLevel(_logging.ERROR)
 
 # ── boot labels ───────────────────────────────────────────────────────────────
 
@@ -143,16 +138,9 @@ SPEAKER_NUM_THREADS      = int(os.getenv("SPEAKER_NUM_THREADS", "1"))
 # WAKE_WORD: "" disables wake-word gating entirely (Aiko responds to every
 #   utterance, as before). When set, ASR is unreliable on "Aiko" (not a
 #   normal English word) so matching is fuzzy, not exact-substring.
-# TRIGGER_PHRASE: only takes effect when SPEAKER_VERIFY_ENABLED is also on.
-#   "" disables it. Can be said standalone or right after the wake word.
-
 WAKE_WORD             = os.getenv("WAKE_WORD", "").strip().lower()
 WAKE_WORD_ALIASES     = [w.strip().lower() for w in os.getenv("WAKE_WORD_ALIASES", "").split("|") if w.strip()]
 WAKE_FUZZY_THRESHOLD  = float(os.getenv("WAKE_FUZZY_THRESHOLD", "70"))
-
-TRIGGER_PHRASE                = os.getenv("TRIGGER_PHRASE", "").strip().lower()
-TRIGGER_FUZZY_THRESHOLD       = float(os.getenv("TRIGGER_FUZZY_THRESHOLD", "70"))
-TRIGGER_REQUIRE_SPEAKER_MATCH = os.getenv("TRIGGER_REQUIRE_SPEAKER_MATCH", "1").lower() in {"1", "true", "yes", "on"}
 
 ACTIVATION_TIMEOUT_S = float(os.getenv("ACTIVATION_TIMEOUT_S", "30"))
 
@@ -221,7 +209,7 @@ def _strip_prefix_phrase(text: str, candidates: list[str], threshold: float) -> 
     if not words or not candidates:
         return False, text
 
-    best_score, best_end = 0.0, 0
+    best_score, best_end, best_phrase = 0.0, 0, ""
     for phrase in candidates:
         phrase_words = phrase.split()
         n = len(phrase_words)
@@ -231,8 +219,10 @@ def _strip_prefix_phrase(text: str, candidates: list[str], threshold: float) -> 
             window = " ".join(words[:span])
             score = _ratio(window, phrase)
             if score > best_score:
-                best_score, best_end = score, span
+                best_score, best_end, best_phrase = score, span, phrase
 
+    log.info("[wake] text=%r  best_phrase=%r  best_score=%.1f  threshold=%.1f  matched=%s",
+             text, best_phrase, best_score, threshold, best_score >= threshold)
     if best_score >= threshold:
         return True, " ".join(words[best_end:]).strip()
     return False, text
@@ -385,10 +375,9 @@ class AikoListen:
     # ── wake word / trigger phrase activation gate ───────────────────────────
 
     def gate_enabled(self) -> bool:
-        """True if either wake word or (speaker-verified) trigger phrase
-        gating is configured. Useful for UI to show a sleep/wake indicator
-        only when the feature is actually in use."""
-        return bool(WAKE_WORD) or (bool(TRIGGER_PHRASE) and SPEAKER_VERIFY_ENABLED)
+        """True if wake word gating is configured. Useful for UI to show
+        a sleep/wake indicator only when the feature is actually in use."""
+        return bool(WAKE_WORD)
 
     def is_active(self) -> bool:
         """
@@ -409,64 +398,44 @@ class AikoListen:
         with self._activation_lock:
             self._active_until = 0.0
 
-    def _extend_activation(self) -> None:
+    def extend_activation(self) -> None:
+        """Extend the wake-word-free session window."""
         with self._activation_lock:
             self._active_until = time.monotonic() + ACTIVATION_TIMEOUT_S
 
+    _extend_activation = extend_activation  # compat alias
+
     def _apply_activation_gate(self, text: str, verified: bool | None) -> tuple[str | None, dict]:
         """
-        Enforce wake-word / trigger-phrase gating on a freshly transcribed
-        utterance.
+        Enforce wake-word gating on a freshly transcribed utterance.
 
         Returns (command_text, gate_info):
-          - command_text is None            → gate failed; caller must
+          - command_text is None  → gate failed; caller must
             silently drop the utterance (no response, no side effects)
-          - command_text is text w/ any matched wake word / trigger phrase
-            prefix stripped off (unchanged if gating isn't configured, or
-            the session was already active so no phrase check was needed)
+          - command_text is text  w/ any matched wake word prefix stripped off
+            (unchanged if gating isn't configured, or the session was
+            already active so no phrase check was needed)
 
-        gate_info = {"woke": bool|None, "triggered": bool|None}:
-          None means that particular gate wasn't configured / not evaluated
-          this call (e.g. session was already active, or that feature is
-          off). Useful for logging / UI state.
+        gate_info = {"woke": bool|None}:
+          None means gate wasn't configured / not evaluated this call
+          (e.g. session was already active). Useful for logging / UI state.
         """
-        require_wake    = bool(WAKE_WORD)
-        require_trigger = bool(TRIGGER_PHRASE) and SPEAKER_VERIFY_ENABLED
-        gate_info = {"woke": None, "triggered": None}
-
-        if not require_wake and not require_trigger:
-            return text, gate_info
+        if not bool(WAKE_WORD):
+            return text, {"woke": None}
 
         if self.is_active():
-            # already awake/triggered — no phrase needed, just keep the
-            # idle clock from expiring
             self._extend_activation()
-            return text, gate_info
+            return text, {"woke": None}
 
-        remainder = text
-
-        if require_wake:
-            matched, remainder = _strip_prefix_phrase(
-                remainder, [WAKE_WORD, *WAKE_WORD_ALIASES], WAKE_FUZZY_THRESHOLD
-            )
-            gate_info["woke"] = matched
-            if not matched:
-                return None, gate_info
-
-        if require_trigger:
-            matched, remainder = _strip_prefix_phrase(
-                remainder, [TRIGGER_PHRASE], TRIGGER_FUZZY_THRESHOLD
-            )
-            gate_info["triggered"] = matched
-            if not matched:
-                return None, gate_info
-            if TRIGGER_REQUIRE_SPEAKER_MATCH and not verified:
-                # phrase alone isn't enough — the voiceprint on this same
-                # utterance must also match the enrolled speaker
-                return None, gate_info
+        matched, remainder = _strip_prefix_phrase(
+            text, [WAKE_WORD, *WAKE_WORD_ALIASES], WAKE_FUZZY_THRESHOLD
+        )
+        if not matched:
+            log.debug("[gate] wake word %r NOT matched in %r — dropping", WAKE_WORD, text)
+            return None, {"woke": False}
 
         self._extend_activation()
-        return remainder.strip(), gate_info
+        return remainder.strip(), {"woke": True}
 
     # ── barge-in monitor ──────────────────────────────────────────────────────
 
@@ -556,15 +525,15 @@ class AikoListen:
         Verification never blocks or fails transcription — it's metadata
         attached alongside the text, not a gate in front of it.
 
-        info additionally carries "woke" and "triggered" (bool|None each):
-          - None means that gate wasn't configured / not evaluated this call
-            (e.g. the session was already active, so no phrase check ran)
-          - If wake word and/or trigger phrase gating IS configured and the
-            required phrase(s) were not detected, this method returns
-            ("", info) — same shape as "no speech detected" — so callers
-            that already treat empty text as "nothing to do" handle this
-            for free. Any matched wake word / trigger phrase prefix is
-            stripped from the returned text.
+        info additionally carries "woke" (bool|None):
+          - None means wake word gate wasn't configured / not evaluated
+            this call (e.g. the session was already active, so no phrase
+            check ran)
+          - If wake word gating IS configured and the required phrase was
+            not detected, this method returns ("", info) — same shape as
+            "no speech detected" — so callers that already treat empty text
+            as "nothing to do" handle this for free. Any matched wake word
+            prefix is stripped from the returned text.
 
         chunk_source: optional callable(bytes_per_chunk) -> bytes | None,
             forwarded to _record(). See _record() docstring. None (default)
@@ -603,7 +572,6 @@ class AikoListen:
                 "verified": None,
                 "speaker_score": None,
                 "woke": None,
-                "triggered": None,
                 "listen_started_at": listen_started_at,
                 "recording_stopped_at": recording_stopped_at,
             }
@@ -614,7 +582,6 @@ class AikoListen:
             "verified": None,
             "speaker_score": None,
             "woke": None,
-            "triggered": None,
             "listen_started_at": listen_started_at,
             "recording_stopped_at": recording_stopped_at,
         }
@@ -634,8 +601,7 @@ class AikoListen:
             text = self._transcribe(audio)
 
         gated_text, gate_info = self._apply_activation_gate(text, info.get("verified"))
-        info["woke"]      = gate_info["woke"]
-        info["triggered"] = gate_info["triggered"]
+        info["woke"] = gate_info["woke"]
 
         _cb(status_callback, "__IDLE__")
         if gated_text is None:

--- a/sensory/speak.py
+++ b/sensory/speak.py
@@ -371,9 +371,13 @@ class AikoSpeak:
             headers={"Content-Type": "application/json"},
             method="POST",
         )
+        timeout = 60 if MIOTTS_BEST_OF_N_ENABLED else 30
         try:
-            with urllib.request.urlopen(req, timeout=30) as r:
+            with urllib.request.urlopen(req, timeout=timeout) as r:
                 body = json.loads(r.read())
+                if "audio" not in body:
+                    log.error(f"[speak] unexpected TTS response keys: {list(body.keys())}")
+                    return None
                 return base64.b64decode(body["audio"])
         except Exception as e:
             log.error(f"[speak] synthesis error: {e}")

--- a/skills/agentic.py
+++ b/skills/agentic.py
@@ -673,10 +673,10 @@ _reg("final_answer", "Final answer.",
 
 # ── populate _TOOLS from _TOOL_DEFS ──────────────────────────────────────────
 
-for schema, handler in _TOOL_DEFS:
-    name = schema["function"]["name"]
-    _TOOLS[name] = (schema, handler)
-
+for _tool_schema, _tool_handler in _TOOL_DEFS:
+    _tool_name = _tool_schema["function"]["name"]
+    _TOOLS[_tool_name] = (_tool_schema, _tool_handler)
+    
 
 def _required_args_for(name: str) -> list[str]:
     entry = _TOOLS.get(name)

--- a/skills/agentic.py
+++ b/skills/agentic.py
@@ -22,6 +22,7 @@ Context fetch shape:
 from __future__ import annotations
 
 import concurrent.futures
+from collections import OrderedDict
 import json
 import math
 import os

--- a/system/userspace.py
+++ b/system/userspace.py
@@ -76,6 +76,21 @@ def normalize_user_id(provider: str | None, user_id: object) -> str:
     return f"{provider_part}_{user_part}"
 
 
+def _user_state_root_value() -> str:
+    """Return the configured root for per-user mutable state.
+
+    USER_STATE_ROOT is the canonical name. AIKO_USER_STATE_ROOT and the older
+    USER_SPACE_ROOT are accepted as compatibility aliases so deployments and
+    docs that used those names still point Aiko at the same per-user files.
+    """
+    return (
+        os.getenv("USER_STATE_ROOT")
+        or os.getenv("AIKO_USER_STATE_ROOT")
+        or os.getenv("USER_SPACE_ROOT")
+        or str(Path.home() / ".aiko")
+    )
+
+
 def user_state_dir(user_id: str | None = None) -> Path:
     """Root directory for user-private mutable state.
 
@@ -85,8 +100,7 @@ def user_state_dir(user_id: str | None = None) -> Path:
     it — callers doing existence checks (e.g. profile lookup) correctly
     see nothing there, and no stray folder is left on disk before login.
     """
-    root_value = os.getenv("USER_STATE_ROOT") or str(Path.home() / ".aiko")
-    root = Path(root_value).expanduser()
+    root = Path(_user_state_root_value()).expanduser()
     uid = user_id or current_user_id()
     uid = _SAFE_RE.sub("_", uid).strip("._-") or _DEFAULT_USER_ID
     path = root / uid

--- a/tests/test_userspace.py
+++ b/tests/test_userspace.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+from system import userspace
+
+
+def test_user_state_root_accepts_legacy_user_space_root(monkeypatch, tmp_path):
+    monkeypatch.delenv("USER_STATE_ROOT", raising=False)
+    monkeypatch.delenv("AIKO_USER_STATE_ROOT", raising=False)
+    monkeypatch.setenv("USER_SPACE_ROOT", str(tmp_path))
+
+    assert userspace.user_state_dir("github_123") == tmp_path / "github_123"
+
+
+def test_user_profile_path_points_to_profile_user_md(monkeypatch, tmp_path):
+    monkeypatch.setenv("USER_STATE_ROOT", str(tmp_path))
+    monkeypatch.delenv("USER_PROFILE_PATH", raising=False)
+
+    assert userspace.user_profile_path("github_123") == (
+        tmp_path / "github_123" / "profile" / "user.md"
+    ).resolve()


### PR DESCRIPTION
## Phase 2 — Voice ✅

Fix up minor bugs in Phase 2 milestone: Wake word, Barge-in, and Best-of-N of MioTTS are fully functional now

### What's included

- `sensory/listen.py` — SenseVoice ASR (sherpa-onnx) + Silero VAD with real-time streaming
- `sensory/speak.py` — MioTTS integration with warmup and bilingual support
- **Barge-in** — Ability to interrupt Aiko mid-response (browser + local Silero)
- **Microphone pipeline** — Local PulseAudio + browser WebAudio Worklet (WebUI)
- **Voice toggles** — `/voice` and `/listen` commands with runtime state
- **Staged warmup** — ASR, VAD, TTS, and microphone pre-loaded at startup
- **WebUI voice bridge** — Real-time voice status, microphone events, and VRM integration
- Memory backend migration — `sqlite-vec` + Harrier embedder (serverless, Jetson-optimized)
- Early agentic scaffolding — ReAct loop foundation and skill registry
- Architectural cleanup — clearer separation of `sensory/`, `skills/`, and `toolkit/`

### Bug fixes (latest)

- **Wake word** — Fuzzy prefix-matching against `WAKE_WORD` / `WAKE_WORD_ALIASES`; session stays active for `ACTIVATION_TIMEOUT_S` (configurable, now 3600s)
- **Always-on browser mic** — Mic stays open continuously so VAD can detect speech during TTS playback; `_did_barge_in` flag preserves speech frames that triggered the barge-in
- **Active-speech barge-in** — barge-in now fires both at speech onset AND during active speech (fixes missed interrupts when VAD state from a previous utterance hadn't fully reset)
- **Removed Trigger Phrase** — `TRIGGER_PHRASE` and all its code paths deleted (redundant without speaker verification; OAuth is used for auth)
- **Fast fuzzy wake word** — `rapidfuzz` prefix match replaces slow list-based iteration; logging added for debugging mismatches

### Notes

- Removed Trigger Phrase due to similar concept of Wake Word and causing conflicts
- Best-of-N of MioTTS was modified to wire in to Aiko's ASR SenseVoice instead of the huge Whisper Turbo

### Testing

- [x] Full voice conversation loop (speak → ASR → LLM → TTS)
- [x] Barge-in during TTS (both speech onset and mid-utterance)
- [x] Wake word activation with fuzzy matching
- [x] `/voice` and `/listen` runtime toggles
- [x] WebUI microphone + voice status bridge
- [x] Warmup eliminates cold-start latency
- [x] `--cli` and `--text` modes still functional
- [x] Trigger phrase fully removed from codebase
- [ ] Extended Jetson hardware testing (ongoing)
- [ ] Long-session stability and barge-in edge cases


<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added wake-word activation using “hey there.”
  * Improved proactive conversations by keeping listening sessions active.
  * Added support for configurable per-user state locations with compatibility aliases.
  * Kept the browser microphone active during sessions for smoother interaction.

* **Bug Fixes**
  * Reduced duplicate barge-in events and preserved speech that triggered interruptions.
  * Improved microphone reconnection and buffering behavior.
  * Added safer handling when speech synthesis returns incomplete responses.
  * Clarified identity responses and memory-context behavior.

* **Documentation**
  * Updated multi-user storage, encryption, workspace, and environment-variable guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->