### PR TITLE
Add daily Vancouver job-post draft workflow (Meta Threads)

### DIFF
--- a/agentic/agentic.py
+++ b/agentic/agentic.py
@@ -68,6 +68,8 @@ from agentic.tools import (
     read_paper_url,
     write_report,
     search_jobs,
+    draft_job_post_social,
+    post_job_post_social,
     draft_photo_social,
     post_photo_social,
     draft_video_social,
@@ -287,7 +289,7 @@ _LOCAL_ARTIFACT_RE = re.compile(r"\b(saved|created|scheduled|cancelled|path|id|d
 # Tools that can genuinely post to a real public account. When one of these
 # ran and succeeded this turn, an answer describing a real "posted" action
 # is not a hallucinated external action — see _verify_final_answer.
-_SOCIAL_POST_TOOLS = {"post_photo_social", "post_video_social"}
+_SOCIAL_POST_TOOLS = {"post_job_post_social", "post_photo_social", "post_video_social"}
 # Any tool message over this length gets compacted to a preview once a
 # later assistant message has arrived — generalized from a research-only
 # rule to cover every bulky tool (repo_read_file, search_jobs, etc.), since
@@ -704,6 +706,15 @@ _reg("search_jobs", "Search configured job boards for a role. If location is omi
     lambda args: json.dumps(search_jobs(args.get("query", ""), args.get("location", ""), int(args["max_results"]) if args.get("max_results") not in (None, "") else None, int(args["max_age_days"]) if args.get("max_age_days") not in (None, "") else None, args.get("job_type", "")), ensure_ascii=False),
     {"query": {"type": "string"}, "location": {"type": "string", "description": "Optional override. Defaults to the job_hunt skill location."}, "max_results": {"type": "integer"}, "max_age_days": {"type": "integer"}, "job_type": {"type": "string", "description": "Optional employment type filter from the user prompt, e.g. full-time, contract, remote."}},
     required=["query"])
+
+_reg("draft_job_post_social", "Create a Vancouver-area daily job-post draft for Meta Threads review. Does NOT post anything.",
+    lambda args: draft_job_post_social(force=bool(args.get("force", False))),
+    {"force": {"type": "boolean", "description": "Create a new draft even if one already exists for today."}})
+
+_reg("post_job_post_social", "Post an ALREADY HUMAN-APPROVED daily job-post draft to Meta Threads only. Will refuse unless a person has approved this exact draft outside this conversation.",
+    lambda args: post_job_post_social(args.get("draft_dir", "")),
+    {"draft_dir": {"type": "string", "description": "The draft_dir path returned by draft_job_post_social or given by the user."}},
+    required=["draft_dir"])
 
 _reg("draft_photo_social", "Scan the photo inbox, caption and curate candidates, and create an Instagram photo draft bundle for human review. Does NOT post anything.",
     lambda args: draft_photo_social(inbox=args.get("inbox") or None, force=bool(args.get("force", False))),

--- a/agentic/toolkit/social.py
+++ b/agentic/toolkit/social.py
@@ -1853,6 +1853,14 @@ def generate_daily_job_post_draft(*, force: bool = False) -> dict[str, Any]:
 
     today = datetime.now(ZoneInfo(timezone_name())).strftime("%Y-%m-%d")
     posting = _choose_daily_job_post()
+    if posting is None:
+        return {
+            "success": False,
+            "skipped": False,
+            "reason": "no_eligible_posting",
+            "draft_dir": str(draft_dir),
+        }
+
     text = _format_threads_job_post(posting, today)
     draft_dir.mkdir(parents=True, exist_ok=True)
     (draft_dir / "draft_post.txt").write_text(text.strip() + "\n", encoding="utf-8")
@@ -1865,7 +1873,7 @@ def generate_daily_job_post_draft(*, force: bool = False) -> dict[str, Any]:
         "success": True,
         "draft_dir": str(draft_dir),
         "provider": "threads",
-        "posting": posting or {},
+        "posting": posting,
         "created_at": datetime.now(timezone.utc).isoformat(),
         "posted": False,
         "human_approved": False,
@@ -1874,9 +1882,26 @@ def generate_daily_job_post_draft(*, force: bool = False) -> dict[str, Any]:
     return meta
 
 
+def _read_job_post_meta(path: Path) -> dict[str, Any]:
+    meta_path = path / "draft.json"
+    if not meta_path.exists():
+        return {}
+    return json.loads(meta_path.read_text(encoding="utf-8"))
+
+
 def post_job_post_draft(draft_dir: str | Path) -> dict[str, Any]:
     path = Path(draft_dir).resolve()
-    text = (path / "draft_post.txt").read_text(encoding="utf-8").strip()
+    try:
+        _require_approved(path)
+        draft_post_path = path / "draft_post.txt"
+        if not draft_post_path.exists():
+            raise SocialApprovalError(f"missing draft_post.txt at {path}")
+        text = draft_post_path.read_text(encoding="utf-8").strip()
+        if not text:
+            raise SocialApprovalError(f"empty draft_post.txt at {path}")
+    except (SocialApprovalError, OSError) as e:
+        return {"posted": False, "error": str(e)}
+
     result = _post_threads(text, None)
     post_meta = {"posted": bool(result.get("ok")), "posted_at": datetime.now(timezone.utc).isoformat(), "results": [result]}
     (path / "posted.json").write_text(json.dumps(post_meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
@@ -1893,15 +1918,21 @@ def run_scheduled_daily_job_post_social(_memorize: Any = None) -> dict[str, Any]
     if not JOB_POST_SOCIAL_AUTODRAFT:
         return {"success": False, "skipped": True, "reason": "JOB_POST_SOCIAL_AUTODRAFT is off"}
     draft = generate_daily_job_post_draft()
-    if JOB_POST_SOCIAL_AUTOPOST and draft.get("success") and not draft.get("skipped"):
+    if JOB_POST_SOCIAL_AUTOPOST and draft.get("success"):
         draft_dir = Path(draft["draft_dir"])
         try:
-            _require_approved(draft_dir)
-        except SocialApprovalError as e:
+            meta = _read_job_post_meta(draft_dir)
+        except (OSError, json.JSONDecodeError) as e:
             draft["post"] = {"posted": False, "skipped": True, "reason": str(e)}
         else:
-            draft["post"] = post_job_post_draft(draft_dir)
+            if meta.get("posted") is True:
+                draft["post"] = {"posted": False, "skipped": True, "reason": "already_posted"}
+            elif meta.get("human_approved") is True:
+                draft["post"] = post_job_post_draft(draft_dir)
+            else:
+                draft["post"] = {"posted": False, "skipped": True, "reason": "not_approved"}
     return draft
+
 
 # ══════════════════════════════════════════════════════════════════════════
 # Agent-tool wrappers. agentic/agentic.py registers four of the wrapper

--- a/agentic/toolkit/social.py
+++ b/agentic/toolkit/social.py
@@ -1839,7 +1839,8 @@ def _format_threads_job_post(posting: Mapping[str, Any] | None, date_text: str) 
         f"類別：{field('employment_type')}\n"
         f"地區：{field('location')}\n"
         f"薪金：{field('salary')}\n"
-        f"經驗：{field('experience')}\n\n"
+        f"經驗：{field('experience')}\n"
+        f"截止日期：{field('close_date', 'application_deadline', 'deadline')}\n\n"
         f"*請入以下連結參看詳情\n{field('url')}"
     )
 

--- a/agentic/toolkit/social.py
+++ b/agentic/toolkit/social.py
@@ -107,6 +107,7 @@ from system.userspace import user_workspace_root
 from memory.reflect import _generate_image, _load_soul
 from agentic.toolkit.common import workspace_root
 from agentic.toolkit.photography import scan_photo_workspace, scan_video_workspace
+from agentic.toolkit.job_hunt import search_jobs
 
 log = get_logger(__name__)
 
@@ -135,6 +136,18 @@ def photo_social_root() -> Path:
     if override:
         return Path(override).expanduser().resolve()
     return (user_workspace_root() / "social" / "photo").resolve()
+
+
+def job_post_social_root() -> Path:
+    """Resolve the active user job-post draft output root lazily.
+
+    Defaults to <USER_STATE_ROOT>/<user_id>/workspace/social/job_posts.
+    Holds daily Meta Threads job-post drafts for human review.
+    """
+    override = os.getenv("JOB_POST_SOCIAL_ROOT")
+    if override:
+        return Path(override).expanduser().resolve()
+    return (user_workspace_root() / "social" / "job_posts").resolve()
 
 
 def video_social_root() -> Path:
@@ -1761,6 +1774,134 @@ def run_scheduled_video_social() -> dict[str, Any]:
     return draft
 
 
+
+# ══════════════════════════════════════════════════════════════════════════
+# Lane D — Daily job-post draft for Meta Threads
+# ══════════════════════════════════════════════════════════════════════════
+
+JOB_POST_SOCIAL_AUTODRAFT = os.getenv("JOB_POST_SOCIAL_AUTODRAFT", "1").lower() in {"1", "true", "yes", "on"}
+JOB_POST_SOCIAL_AUTOPOST = os.getenv("JOB_POST_SOCIAL_AUTOPOST", "0").lower() in {"1", "true", "yes", "on"}
+JOB_POST_SOCIAL_TIME_OF_DAY = os.getenv("JOB_POST_SOCIAL_TIME_OF_DAY", "09:00")
+JOB_POST_QUERIES = (
+    "government technology IT software developer analyst",
+    "government administrative assistant office",
+    "technology software developer IT analyst",
+    "administrative assistant office coordinator",
+)
+LOW_SALARY_HOURLY_FLOOR = float(os.getenv("JOB_POST_LOW_SALARY_HOURLY_FLOOR", "20"))
+LOW_SALARY_ANNUAL_FLOOR = float(os.getenv("JOB_POST_LOW_SALARY_ANNUAL_FLOOR", "45000"))
+
+
+def _job_post_draft_dir(for_date: datetime | None = None) -> Path:
+    day = (for_date or datetime.now(timezone.utc)).astimezone(ZoneInfo(timezone_name())).strftime("%Y-%m-%d")
+    return job_post_social_root() / day
+
+
+def _salary_too_low(salary: str) -> bool:
+    nums = [float(n.replace(",", "")) for n in re.findall(r"\d[\d,]*(?:\.\d+)?", salary or "")]
+    if not nums:
+        return False
+    text = salary.lower()
+    high = max(nums)
+    if any(unit in text for unit in ("/hr", "hour", "hr")):
+        return high < LOW_SALARY_HOURLY_FLOOR
+    return high < LOW_SALARY_ANNUAL_FLOOR if high > 1000 else False
+
+
+def _is_specialty_job(posting: Mapping[str, Any]) -> bool:
+    blob = " ".join(str(posting.get(k, "")) for k in ("title", "experience"))
+    return bool(re.search(r"\b(senior|lead|principal|manager|director|nurse|doctor|engineer iii|security clearance)\b", blob, re.I))
+
+
+def _choose_daily_job_post() -> dict[str, Any] | None:
+    for query in JOB_POST_QUERIES:
+        for posting in search_jobs(query, "Vancouver, BC, Canada", max_results=10, max_age_days=14):
+            if _salary_too_low(str(posting.get("salary", ""))) or _is_specialty_job(posting):
+                continue
+            return posting
+    return None
+
+
+def _format_threads_job_post(posting: Mapping[str, Any] | None, date_text: str) -> str:
+    def field(*names: str) -> str:
+        if not posting:
+            return ""
+        for name in names:
+            value = str(posting.get(name, "") or "").strip()
+            if value:
+                return value
+        return ""
+
+    return (
+        f"Job Post - {date_text}\n"
+        f"機構：{field('organization')}\n"
+        f"職位：{field('title', 'position')}\n"
+        f"類別：{field('employment_type')}\n"
+        f"地區：{field('location')}\n"
+        f"薪金：{field('salary')}\n"
+        f"經驗：{field('experience')}\n\n"
+        f"*請入以下連結參看詳情\n{field('url')}"
+    )
+
+
+def generate_daily_job_post_draft(*, force: bool = False) -> dict[str, Any]:
+    draft_dir = _job_post_draft_dir()
+    meta_path = draft_dir / "draft.json"
+    if meta_path.exists() and not force:
+        return {"success": True, "skipped": True, "reason": "draft_exists", "draft_dir": str(draft_dir)}
+
+    today = datetime.now(ZoneInfo(timezone_name())).strftime("%Y-%m-%d")
+    posting = _choose_daily_job_post()
+    text = _format_threads_job_post(posting, today)
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    (draft_dir / "draft_post.txt").write_text(text.strip() + "\n", encoding="utf-8")
+    (draft_dir / "review.md").write_text(
+        f"# Daily Job Post Draft — {today}\n\n## Draft post\n\n{text}\n\n"
+        "## Review checklist\n\n- [ ] Job details look correct\n- [ ] Salary is acceptable\n- [ ] Approved to post to Meta Threads\n",
+        encoding="utf-8",
+    )
+    meta = {
+        "success": True,
+        "draft_dir": str(draft_dir),
+        "provider": "threads",
+        "posting": posting or {},
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "posted": False,
+        "human_approved": False,
+    }
+    meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return meta
+
+
+def post_job_post_draft(draft_dir: str | Path) -> dict[str, Any]:
+    path = Path(draft_dir).resolve()
+    text = (path / "draft_post.txt").read_text(encoding="utf-8").strip()
+    result = _post_threads(text, None)
+    post_meta = {"posted": bool(result.get("ok")), "posted_at": datetime.now(timezone.utc).isoformat(), "results": [result]}
+    (path / "posted.json").write_text(json.dumps(post_meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    meta_path = path / "draft.json"
+    if meta_path.exists():
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        meta["posted"] = post_meta["posted"]
+        meta["post_results"] = [result]
+        meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return post_meta
+
+
+def run_scheduled_daily_job_post_social(_memorize: Any = None) -> dict[str, Any]:
+    if not JOB_POST_SOCIAL_AUTODRAFT:
+        return {"success": False, "skipped": True, "reason": "JOB_POST_SOCIAL_AUTODRAFT is off"}
+    draft = generate_daily_job_post_draft()
+    if JOB_POST_SOCIAL_AUTOPOST and draft.get("success") and not draft.get("skipped"):
+        draft_dir = Path(draft["draft_dir"])
+        try:
+            _require_approved(draft_dir)
+        except SocialApprovalError as e:
+            draft["post"] = {"posted": False, "skipped": True, "reason": str(e)}
+        else:
+            draft["post"] = post_job_post_draft(draft_dir)
+    return draft
+
 # ══════════════════════════════════════════════════════════════════════════
 # Agent-tool wrappers. agentic/agentic.py registers four of the wrapper
 # functions below (draft_photo_social, post_photo_social, draft_video_social,
@@ -1793,6 +1934,21 @@ def _resolve_contained_draft_dir(draft_dir: str | Path, allowed_root: Path) -> P
     except ValueError:
         raise ValueError(f"draft_dir must be inside {root}, got {resolved}")
     return resolved
+
+
+def draft_job_post_social(*, force: bool = False) -> dict[str, Any]:
+    """Create a daily Vancouver-area job-post draft for Meta Threads review."""
+    return generate_daily_job_post_draft(force=force)
+
+
+def post_job_post_social(draft_dir: str) -> dict[str, Any]:
+    """Post a human-approved daily job-post draft to Meta Threads only."""
+    try:
+        path = _resolve_contained_draft_dir(draft_dir, job_post_social_root())
+        _require_approved(path)
+    except (ValueError, SocialApprovalError) as e:
+        return {"posted": False, "error": str(e)}
+    return post_job_post_draft(path)
 
 
 def draft_weekly_social(*, force: bool = False) -> dict[str, Any]:

--- a/agentic/tools.py
+++ b/agentic/tools.py
@@ -19,6 +19,7 @@ from agentic.toolkit.photography import scan_photo_workspace, propose_photo_inge
 from agentic.toolkit.self_improve import repo_file_tree, repo_read_file, repo_search_text
 from agentic.toolkit.job_hunt import search_jobs, dedupe_postings
 from agentic.toolkit.social import (
+    draft_job_post_social, post_job_post_social,
     draft_photo_social, post_photo_social,
     draft_video_social, post_video_social,
 )
@@ -30,11 +31,13 @@ __all__ = [
     "dedupe_postings",
     "deep_research",
     "deep_search",
+    "draft_job_post_social",
     "draft_photo_social",
     "draft_video_social",
     "list_reminders",
     "list_schedule",
     "make_plan",
+    "post_job_post_social",
     "post_photo_social",
     "post_video_social",
     "propose_photo_ingestion",

--- a/system/schedule.py
+++ b/system/schedule.py
@@ -556,6 +556,9 @@ PHOTO_SOCIAL_SCAN_INTERVAL_SECONDS = int(os.getenv("PHOTO_SOCIAL_SCAN_INTERVAL_S
 VIDEO_SOCIAL_JOB_TITLE = "video_social_scan"
 VIDEO_SOCIAL_SCAN_INTERVAL_SECONDS = int(os.getenv("VIDEO_SOCIAL_SCAN_INTERVAL_SECONDS", str(6 * 60 * 60)))  # 6h default
 
+JOB_POST_SOCIAL_JOB_TITLE = "daily_job_post_social"
+JOB_POST_SOCIAL_TIME_OF_DAY = os.getenv("JOB_POST_SOCIAL_TIME_OF_DAY", "09:00")
+
 
 def ensure_weekly_social_job(timezone: str | None = None) -> None:
     """Idempotently seed the weekly memory-postcard job (Lane A).
@@ -640,6 +643,23 @@ def ensure_video_social_job(timezone: str | None = None) -> None:
     log.info("Seeded video social scan job every %ss", max(60, VIDEO_SOCIAL_SCAN_INTERVAL_SECONDS))
 
 
+def ensure_daily_job_post_social_job(timezone: str | None = None) -> None:
+    """Idempotently seed the daily Vancouver-area Meta Threads job-post draft job."""
+    existing_titles = {job.get("title") for job in _read_all()}
+    if JOB_POST_SOCIAL_JOB_TITLE in existing_titles:
+        return
+    schedule_job_record(
+        title=JOB_POST_SOCIAL_JOB_TITLE,
+        task="Draft one recent Vancouver-area job post for Meta Threads review",
+        time_of_day=JOB_POST_SOCIAL_TIME_OF_DAY,
+        frequency="daily",
+        timezone=timezone,
+        action="agentic",
+        handler="daily_job_post_social",
+    )
+    log.info("Seeded daily job-post social job at %s", JOB_POST_SOCIAL_TIME_OF_DAY)
+
+
 def register_social_handlers(timezone: str | None = None) -> None:
     """Register the weekly/photo/video social handlers and seed their jobs.
 
@@ -664,19 +684,22 @@ def register_social_handlers(timezone: str | None = None) -> None:
         run_scheduled_photo_social,
         run_scheduled_video_social,
         retry_weekly_social_if_needed,
+        run_scheduled_daily_job_post_social,
     )
 
     register_system_handler("weekly_social", run_scheduled_weekly_social)
     register_system_handler("photo_social", lambda memorize: run_scheduled_photo_social())
     register_system_handler("video_social", lambda memorize: run_scheduled_video_social())
     register_system_handler("weekly_social_retry", retry_weekly_social_if_needed)
+    register_system_handler("daily_job_post_social", run_scheduled_daily_job_post_social)
 
     ensure_weekly_social_job(timezone)
     ensure_photo_social_job(timezone)
     ensure_video_social_job(timezone)
     ensure_weekly_social_retry_job(timezone)
+    ensure_daily_job_post_social_job(timezone)
 
-    log.info("Registered social handlers (weekly_social, weekly_social_retry, photo_social, video_social) and seeded their jobs.")
+    log.info("Registered social handlers (weekly_social, weekly_social_retry, photo_social, video_social, daily_job_post_social) and seeded their jobs.")
 
 
 def ensure_deep_study_window_jobs(timezone: str | None = None) -> None:

--- a/tests/unit/test_social_threads.py
+++ b/tests/unit/test_social_threads.py
@@ -158,6 +158,7 @@ def test_generate_daily_job_post_draft_writes_threads_review_bundle(monkeypatch,
         "location": "Vancouver, BC",
         "salary": "$70,000 - $82,000/yr",
         "experience": "2 years",
+        "close_date": "2026-08-15",
         "url": "https://example.test/job",
     })
 
@@ -170,6 +171,7 @@ def test_generate_daily_job_post_draft_writes_threads_review_bundle(monkeypatch,
     assert "Job Post -" in post
     assert "機構：City of Vancouver" in post
     assert "職位：IT Support Analyst" in post
+    assert "截止日期：2026-08-15" in post
     assert "*請入以下連結參看詳情\nhttps://example.test/job" in post
     meta = json.loads((draft_dir / "draft.json").read_text(encoding="utf-8"))
     assert meta["provider"] == "threads"

--- a/tests/unit/test_social_threads.py
+++ b/tests/unit/test_social_threads.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import json
 import os
 import sys
 from types import SimpleNamespace
@@ -145,3 +147,44 @@ def test_refresh_threads_token_cli_returns_nonzero_on_failure(monkeypatch, capsy
 
     assert exit_code == 1
     assert '"ok": false' in capsys.readouterr().out
+
+
+def test_generate_daily_job_post_draft_writes_threads_review_bundle(monkeypatch, tmp_path):
+    monkeypatch.setenv("JOB_POST_SOCIAL_ROOT", str(tmp_path / "job_posts"))
+    monkeypatch.setattr(social, "_choose_daily_job_post", lambda: {
+        "organization": "City of Vancouver",
+        "title": "IT Support Analyst",
+        "employment_type": "Full Time Regular",
+        "location": "Vancouver, BC",
+        "salary": "$70,000 - $82,000/yr",
+        "experience": "2 years",
+        "url": "https://example.test/job",
+    })
+
+    result = social.generate_daily_job_post_draft(force=True)
+
+    assert result["success"] is True
+    draft_dir = Path(result["draft_dir"])
+    assert draft_dir.is_dir()
+    post = (draft_dir / "draft_post.txt").read_text(encoding="utf-8")
+    assert "Job Post -" in post
+    assert "機構：City of Vancouver" in post
+    assert "職位：IT Support Analyst" in post
+    assert "*請入以下連結參看詳情\nhttps://example.test/job" in post
+    meta = json.loads((draft_dir / "draft.json").read_text(encoding="utf-8"))
+    assert meta["provider"] == "threads"
+    assert meta["human_approved"] is False
+
+
+def test_post_job_post_social_requires_job_post_root_and_approval(monkeypatch, tmp_path):
+    root = tmp_path / "job_posts"
+    outside = tmp_path / "outside"
+    root.mkdir()
+    outside.mkdir()
+    monkeypatch.setenv("JOB_POST_SOCIAL_ROOT", str(root))
+    (outside / "draft.json").write_text('{"human_approved": true}', encoding="utf-8")
+
+    result = social.post_job_post_social(str(outside))
+
+    assert result["posted"] is False
+    assert "inside" in result["error"]

--- a/tests/unit/test_social_threads.py
+++ b/tests/unit/test_social_threads.py
@@ -190,3 +190,60 @@ def test_post_job_post_social_requires_job_post_root_and_approval(monkeypatch, t
 
     assert result["posted"] is False
     assert "inside" in result["error"]
+
+
+def test_generate_daily_job_post_draft_reports_no_eligible_posting(monkeypatch, tmp_path):
+    monkeypatch.setenv("JOB_POST_SOCIAL_ROOT", str(tmp_path / "job_posts"))
+    monkeypatch.setattr(social, "_choose_daily_job_post", lambda: None)
+
+    result = social.generate_daily_job_post_draft(force=True)
+
+    assert result["success"] is False
+    assert result["reason"] == "no_eligible_posting"
+    assert not Path(result["draft_dir"]).exists()
+
+
+def test_post_job_post_social_denies_unapproved_draft_inside_root(monkeypatch, tmp_path):
+    root = tmp_path / "job_posts"
+    draft_dir = root / "2026-07-25"
+    draft_dir.mkdir(parents=True)
+    monkeypatch.setenv("JOB_POST_SOCIAL_ROOT", str(root))
+    (draft_dir / "draft.json").write_text('{"human_approved": false}', encoding="utf-8")
+    (draft_dir / "draft_post.txt").write_text("draft", encoding="utf-8")
+
+    result = social.post_job_post_social(str(draft_dir))
+
+    assert result["posted"] is False
+    assert "not been approved" in result["error"]
+
+
+def test_post_job_post_draft_handles_missing_draft_post(monkeypatch, tmp_path):
+    draft_dir = tmp_path / "job_posts" / "2026-07-25"
+    draft_dir.mkdir(parents=True)
+    (draft_dir / "draft.json").write_text('{"human_approved": true}', encoding="utf-8")
+
+    result = social.post_job_post_draft(draft_dir)
+
+    assert result["posted"] is False
+    assert "missing draft_post.txt" in result["error"]
+
+
+def test_scheduled_daily_job_post_autoposts_existing_approved_draft(monkeypatch, tmp_path):
+    root = tmp_path / "job_posts"
+    draft_dir = root / "2026-07-25"
+    draft_dir.mkdir(parents=True)
+    monkeypatch.setenv("JOB_POST_SOCIAL_ROOT", str(root))
+    monkeypatch.setattr(social, "JOB_POST_SOCIAL_AUTOPOST", True)
+    monkeypatch.setattr(social, "generate_daily_job_post_draft", lambda: {
+        "success": True,
+        "skipped": True,
+        "reason": "draft_exists",
+        "draft_dir": str(draft_dir),
+    })
+    (draft_dir / "draft.json").write_text('{"human_approved": true, "posted": false}', encoding="utf-8")
+    (draft_dir / "draft_post.txt").write_text("draft", encoding="utf-8")
+    monkeypatch.setattr(social, "_post_threads", lambda text, image_url: {"ok": True, "provider": "threads"})
+
+    result = social.run_scheduled_daily_job_post_social()
+
+    assert result["post"]["posted"] is True


### PR DESCRIPTION
### Motivation
- Provide a scheduled daily task that finds one recent Vancouver-area job posting (prioritizing government, then tech, then admin assistant), drafts a Meta Threads post in the requested format, and saves it for human review rather than auto-publishing. 
- Keep the same human-approval gate and safe posting constraints used by existing social lanes so drafts cannot be posted without manual review. 

### Description
- Added a new job-post lane in `agentic/toolkit/social.py` including `job_post_social_root()`, selection/filtering logic (`_choose_daily_job_post`, `_salary_too_low`, `_is_specialty_job`), formatting for Meta Threads (`_format_threads_job_post`), draft generation `generate_daily_job_post_draft`, and publisher `post_job_post_draft` guarded by `_require_approved`.
- Exposed agent-tool wrappers `draft_job_post_social` and `post_job_post_social` and registered them in the tool registry (`agentic/tools.py`) and agentic tool definitions (`agentic/agentic.py`), and marked the post tool as an allowed social poster so posting is reflected as an external action.
- Seeded and registered a daily scheduler handler `daily_job_post_social` and an idempotent seeding function `ensure_daily_job_post_social_job` in `system/schedule.py` so the workflow can be scheduled (default `09:00`) and run by the scheduler.
- Added unit tests in `tests/unit/test_social_threads.py` to cover draft bundle creation and the approval / path-containment checks.

### Testing
- Ran Python byte-compile on modified modules with `python -m py_compile agentic/toolkit/social.py system/schedule.py agentic/tools.py agentic/agentic.py tests/unit/test_social_threads.py`, which succeeded. 
- Ran `pytest -q tests/unit/test_social_threads.py` but the test run was blocked in this environment due to a missing test dependency (`ModuleNotFoundError: No module named 'numpy'`).
- Attempted a lightweight import exercise (`import agentic.toolkit.social`) to exercise runtime imports, which was blocked in this environment due to `requests` not being installed; behavior in a fully provisioned environment should be validated by running the unit tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a640e7be4bc832b876988de48c57df7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added daily social job-post draft generation using matching job opportunities.
  - Added human approval workflow before posting drafts to Threads.
  - Added optional automatic posting through scheduled daily jobs.
  - Added agent tools for creating and posting approved job-post drafts.
  - Added configurable posting time, search filters, salary thresholds, and draft storage location.

- **Bug Fixes**
  - Added validation to prevent posting drafts from unauthorized locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->