### PR TITLE
Add greeting routing, semantic trigger caching, content/log truncation, and combine_evidence limits

### DIFF
--- a/agentic/graph_engine.py
+++ b/agentic/graph_engine.py
@@ -122,11 +122,20 @@ _SEMANTIC_TRIGGER_CACHE: dict[tuple[int, str], Any] = {}
 _SEMANTIC_TRIGGER_LOCK = threading.Lock()
 
 
+def _truncate_with_marker(text: str, max_chars: int, marker: str) -> str:
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    if max_chars <= len(marker):
+        return marker[:max_chars]
+    return text[:max_chars - len(marker)] + marker
+
+
 def _trim_node_content(content: Any) -> str:
-    text = str(content)
-    if GRAPH_NODE_RESULT_MAX_CHARS > 0 and len(text) > GRAPH_NODE_RESULT_MAX_CHARS:
-        return text[:GRAPH_NODE_RESULT_MAX_CHARS] + "\n[truncated by GRAPH_NODE_RESULT_MAX_CHARS]"
-    return text
+    return _truncate_with_marker(
+        str(content),
+        GRAPH_NODE_RESULT_MAX_CHARS,
+        "\n[truncated by GRAPH_NODE_RESULT_MAX_CHARS]",
+    )
 
 
 def _semantic_trigger_matrix(embedder, semantic_triggers: list[Any]):

--- a/agentic/graph_engine.py
+++ b/agentic/graph_engine.py
@@ -96,7 +96,7 @@ def _apply_reducer(current: Any, new: Any, strategy: str | None) -> Any:
 
 GRAPH_AGENT_ENABLED = os.getenv("GRAPH_AGENT_ENABLED", "1").lower() in {"1", "true", "yes", "on"}
 GRAPH_AGENT_PLAYBOOK = os.getenv("GRAPH_AGENT_PLAYBOOK", "agentic/playbook.json")
-GRAPH_MAX_WORKERS = int(os.getenv("GRAPH_MAX_WORKERS", "4"))
+GRAPH_MAX_WORKERS = int(os.getenv("GRAPH_MAX_WORKERS", "2"))
 
 # Goal-verification tiers — each independently toggleable so users can match
 # their hardware budget.  Heuristic is always cheap; embedder reuses the
@@ -108,6 +108,8 @@ GRAPH_VERIFY_LLM = os.getenv("GRAPH_VERIFY_LLM", "0").lower() in {"1", "true", "
 # Kept in sync with agentic.py's AGENT_NOTE_MAX_CHARS so a note saved via the
 # graph executor can't end up longer than one saved via the ReAct path.
 AGENT_NOTE_MAX_CHARS = int(os.getenv("AGENT_NOTE_MAX_CHARS", "5000"))
+GRAPH_TOOL_EXECUTION_LOG_MAX = int(os.getenv("GRAPH_TOOL_EXECUTION_LOG_MAX", "100"))
+GRAPH_NODE_RESULT_MAX_CHARS = int(os.getenv("GRAPH_NODE_RESULT_MAX_CHARS", "20000"))
 
 # Cost tracking — env-driven so Jetson local can set 0, cloud can override.
 GRAPH_COST_PER_1M_INPUT = float(os.getenv("GRAPH_COST_PER_1M_INPUT", "0"))
@@ -116,6 +118,53 @@ GRAPH_COST_PER_1M_OUTPUT = float(os.getenv("GRAPH_COST_PER_1M_OUTPUT", "0"))
 _TOOL_MAP_CACHE: dict[str, Callable[..., Any]] | None = None
 _TOOL_MAP_LOCK = threading.Lock()
 _PLAYBOOK_WRITE_LOCK = threading.Lock()
+_SEMANTIC_TRIGGER_CACHE: dict[tuple[int, str], Any] = {}
+_SEMANTIC_TRIGGER_LOCK = threading.Lock()
+
+
+def _trim_node_content(content: Any) -> str:
+    text = str(content)
+    if GRAPH_NODE_RESULT_MAX_CHARS > 0 and len(text) > GRAPH_NODE_RESULT_MAX_CHARS:
+        return text[:GRAPH_NODE_RESULT_MAX_CHARS] + "\n[truncated by GRAPH_NODE_RESULT_MAX_CHARS]"
+    return text
+
+
+def _semantic_trigger_matrix(embedder, semantic_triggers: list[Any]):
+    """Return cached normalized vectors for static playbook semantic triggers."""
+    if embedder is None or not semantic_triggers:
+        return None
+    try:
+        import numpy as np
+        from cognition import reason
+    except Exception:
+        return None
+    missing: list[str] = []
+    vectors: list[Any] = []
+    embedder_id = id(embedder)
+    with _SEMANTIC_TRIGGER_LOCK:
+        for raw in semantic_triggers:
+            text = str(raw)
+            key = (embedder_id, hashlib.sha256(text.encode("utf-8")).hexdigest())
+            cached = _SEMANTIC_TRIGGER_CACHE.get(key)
+            if cached is None:
+                missing.append(text)
+            else:
+                vectors.append(cached)
+    for text in missing:
+        try:
+            vec = reason.normalize_vec(np.asarray(embedder.embed_query(text), dtype=np.float32))
+        except Exception:
+            continue
+        key = (embedder_id, hashlib.sha256(text.encode("utf-8")).hexdigest())
+        with _SEMANTIC_TRIGGER_LOCK:
+            _SEMANTIC_TRIGGER_CACHE[key] = vec
+        vectors.append(vec)
+    if not vectors:
+        return None
+    try:
+        return np.vstack(vectors)
+    except Exception:
+        return None
 
 
 @dataclass(frozen=True, slots=True)
@@ -216,6 +265,8 @@ class GraphState:
             "result": str(result)[:500],
             "iteration": self.iteration(),
         })
+        if GRAPH_TOOL_EXECUTION_LOG_MAX > 0 and len(exec_log) > GRAPH_TOOL_EXECUTION_LOG_MAX:
+            exec_log = exec_log[-GRAPH_TOOL_EXECUTION_LOG_MAX:]
         self.set("_tool_executions", exec_log)
 
     def get_tool_executions(self, tool_name: str | None = None) -> list[dict]:
@@ -692,7 +743,7 @@ def load_playbooks() -> list[dict[str, Any]]:
 
 
 def _score_plan(plan: dict[str, Any], prompt: str, cap_ids: list[str] | None = None,
-                embedder=None) -> int:
+                embedder=None, prompt_vec=None) -> int:
     text = prompt.casefold()
     triggers = [str(t).casefold() for t in plan.get("triggers", [])]
     required = [str(t).casefold() for t in plan.get("requires_any", [])]
@@ -710,21 +761,19 @@ def _score_plan(plan: dict[str, Any], prompt: str, cap_ids: list[str] | None = N
     if embedder is not None and sem_triggers:
         try:
             import numpy as np
-            from cognition import reason
-            prompt_vec = reason.normalize_vec(np.asarray(embedder.embed_query(prompt), dtype=np.float32))
-            best = 0.0
-            for st in sem_triggers:
-                st_vec = reason.normalize_vec(np.asarray(embedder.embed_query(st), dtype=np.float32))
-                cos = float(np.dot(prompt_vec, st_vec))
-                if cos > best:
-                    best = cos
-            # Scale: 0.7+ cos = strong match (adds ~5), 0.5+ = moderate (adds ~3)
-            if best >= 0.7:
-                score += 5
-            elif best >= 0.5:
-                score += 3
-            elif best >= 0.35:
-                score += 1
+            if prompt_vec is None:
+                from cognition import reason
+                prompt_vec = reason.normalize_vec(np.asarray(embedder.embed_query(prompt), dtype=np.float32))
+            matrix = _semantic_trigger_matrix(embedder, sem_triggers)
+            if matrix is not None:
+                best = float(np.max(matrix @ prompt_vec))
+                # Scale: 0.7+ cos = strong match (adds ~5), 0.5+ = moderate (adds ~3)
+                if best >= 0.7:
+                    score += 5
+                elif best >= 0.5:
+                    score += 3
+                elif best >= 0.35:
+                    score += 1
         except Exception:
             pass
     return score
@@ -789,7 +838,15 @@ def plan_from_master(user_input: str, cap_ids: list[str] | None = None, embedder
     if not GRAPH_AGENT_ENABLED:
         return None
     plans = load_playbooks()
-    ranked = sorted(((_score_plan(p, user_input, cap_ids, embedder), p) for p in plans), key=lambda x: x[0], reverse=True)
+    prompt_vec = None
+    if embedder is not None:
+        try:
+            import numpy as np
+            from cognition import reason
+            prompt_vec = reason.normalize_vec(np.asarray(embedder.embed_query(user_input), dtype=np.float32))
+        except Exception:
+            prompt_vec = None
+    ranked = sorted(((_score_plan(p, user_input, cap_ids, embedder, prompt_vec), p) for p in plans), key=lambda x: x[0], reverse=True)
     if not ranked or ranked[0][0] <= 0:
         return None
     plan = ranked[0][1]
@@ -1088,7 +1145,7 @@ def _run_node(node: PlanNode, prompt: str, results: dict[str, NodeResult],
                 time.sleep(wait)
             out = fn(**call_args)
             usage = state.data.pop("_usage", None) if state else None
-            return NodeResult(node.id, node.tool, True, str(out), args=args, usage=usage)
+            return NodeResult(node.id, node.tool, True, _trim_node_content(out), args=args, usage=usage)
         except Exception as e:
             last_exc = e
             log.warning("Node %s retry %d/%d raised: %s", node.id, attempt + 1, node.max_retries + 1, str(e))
@@ -1101,7 +1158,7 @@ def _run_node(node: PlanNode, prompt: str, results: dict[str, NodeResult],
         return NodeResult(
             node.id, node.tool,
             ok=False,
-            content=str(last_exc),
+            content=_trim_node_content(last_exc),
             args=args,
             error_type="exception_after_retries",
             usage=state.data.pop("_usage", None) if state else None,
@@ -1333,7 +1390,7 @@ def _execute_graph_inner(graph: PlanGraph, embedder=None, llm_client=None,
                                 try:
                                     fallback_out = fallback_fn(**call_args)
                                     fallback_usage = state.data.pop("_usage", None) if state else None
-                                    fallback_result = NodeResult(fallback_node.id, fallback_node.tool, True, str(fallback_out), 
+                                    fallback_result = NodeResult(fallback_node.id, fallback_node.tool, True, _trim_node_content(fallback_out),
                                                               args=fallback_args, usage=fallback_usage)
                                     results[fallback_node.id] = fallback_result
                                     ordered.append(fallback_result)

--- a/agentic/router/intent_prompts.json
+++ b/agentic/router/intent_prompts.json
@@ -1,5 +1,32 @@
 {
-  "ternary": {
+  "quaternary": {
+    "greeting": [
+      "hi",
+      "hello",
+      "hey",
+      "hiya",
+      "yo",
+      "good morning",
+      "good afternoon",
+      "good evening",
+      "morning",
+      "evening",
+      "hey there",
+      "hello there",
+      "hi aiko",
+      "hey aiko",
+      "how are you",
+      "how are you doing",
+      "what's up",
+      "sup",
+      "nice to see you",
+      "just saying hi",
+      "good to see you",
+      "thanks",
+      "thank you",
+      "okay thanks",
+      "cool thanks"
+    ],
     "agentic": [
       "fix this bug in my code",
       "implement this feature in my codebase",

--- a/agentic/toolkit/synthesize.py
+++ b/agentic/toolkit/synthesize.py
@@ -86,6 +86,14 @@ DEFAULT_COMBINE_PART_MAX_CHARS = int(os.getenv("GRAPH_COMBINE_PART_MAX_CHARS", "
 DEFAULT_COMBINE_MAX_CHARS = int(os.getenv("GRAPH_COMBINE_MAX_CHARS", "12000"))
 
 
+def _truncate_with_marker(text: str, max_chars: int, marker: str) -> str:
+    if max_chars <= 0 or len(text) <= max_chars:
+        return text
+    if max_chars <= len(marker):
+        return marker[:max_chars]
+    return text[:max_chars - len(marker)] + marker
+
+
 # Heuristic style keywords. Order matters: "concise" and "brief" should win
 # over "professional" if both are present (a user who explicitly asks for
 # brevity wants brevity, not a 5-page formal report).
@@ -221,13 +229,18 @@ def combine_evidence(parts: list[str], separator: str = "\n\n---\n\n", *, part_m
         text = str(part or "").strip()
         if not text:
             continue
-        if part_max_chars > 0 and len(text) > part_max_chars:
-            text = text[:part_max_chars] + "\n[part truncated by GRAPH_COMBINE_PART_MAX_CHARS]"
+        text = _truncate_with_marker(
+            text,
+            part_max_chars,
+            "\n[part truncated by GRAPH_COMBINE_PART_MAX_CHARS]",
+        )
         cleaned.append(text)
     joined = separator.join(cleaned)
-    if max_chars > 0 and len(joined) > max_chars:
-        return joined[:max_chars] + "\n[combined evidence truncated by GRAPH_COMBINE_MAX_CHARS]"
-    return joined
+    return _truncate_with_marker(
+        joined,
+        max_chars,
+        "\n[combined evidence truncated by GRAPH_COMBINE_MAX_CHARS]",
+    )
 
 
 @tool(

--- a/agentic/toolkit/synthesize.py
+++ b/agentic/toolkit/synthesize.py
@@ -82,6 +82,8 @@ DEFAULT_MAX_OUTPUT_TOKENS = int(os.getenv("GRAPH_SYNTH_MAX_OUTPUT_TOKENS", "1500
 DEFAULT_CONDENSE_TOP_K = int(os.getenv("GRAPH_SYNTH_CONDENSE_TOP_K", "12"))
 DEFAULT_CONDENSE_CHUNK_CHARS = int(os.getenv("GRAPH_SYNTH_CONDENSE_CHUNK_CHARS", "500"))
 DEFAULT_CONDENSE_MAX_CHARS = int(os.getenv("GRAPH_SYNTH_CONDENSE_MAX_CHARS", "6000"))
+DEFAULT_COMBINE_PART_MAX_CHARS = int(os.getenv("GRAPH_COMBINE_PART_MAX_CHARS", "4000"))
+DEFAULT_COMBINE_MAX_CHARS = int(os.getenv("GRAPH_COMBINE_MAX_CHARS", "12000"))
 
 
 # Heuristic style keywords. Order matters: "concise" and "brief" should win
@@ -207,16 +209,25 @@ def split_subjects(prompt: str) -> list[str]:
     react=False,
     graph=True,
 )
-def combine_evidence(parts: list[str], separator: str = "\n\n---\n\n") -> str:
+def combine_evidence(parts: list[str], separator: str = "\n\n---\n\n", *, part_max_chars: int = DEFAULT_COMBINE_PART_MAX_CHARS, max_chars: int = DEFAULT_COMBINE_MAX_CHARS) -> str:
     """Concatenate non-empty evidence blocks with a visible separator.
 
     Used as the combine step in every research playbook: web snippets +
     KB context + (optional) prior synthesis go in, one combined text
     comes out, ready to be (optionally) condensed and handed to the LLM.
     """
-    cleaned = [str(p or "").strip() for p in parts]
-    cleaned = [p for p in cleaned if p]
-    return separator.join(cleaned)
+    cleaned: list[str] = []
+    for part in parts:
+        text = str(part or "").strip()
+        if not text:
+            continue
+        if part_max_chars > 0 and len(text) > part_max_chars:
+            text = text[:part_max_chars] + "\n[part truncated by GRAPH_COMBINE_PART_MAX_CHARS]"
+        cleaned.append(text)
+    joined = separator.join(cleaned)
+    if max_chars > 0 and len(joined) > max_chars:
+        return joined[:max_chars] + "\n[combined evidence truncated by GRAPH_COMBINE_MAX_CHARS]"
+    return joined
 
 
 @tool(

--- a/cognition/think.py
+++ b/cognition/think.py
@@ -11,15 +11,13 @@ Aiko's chat facade.
     waits on before starting autonomous quick-study top-ups.
 
 Memory + knowledge-base fetch:
-  route() kicks off _fetch_memory_and_knowledge() on cognition's
-  shared CONTEXT_POOL BEFORE intent is resolved, since every path
-  (localchat/webchat/agentic) needs memory + KB regardless of which one
-  intent routing picks. The resulting future is handed to whichever
-  handler ends up running, so the fetch overlaps intent classification
-  itself instead of waiting for it to finish first. Wiki/policy/skill/
-  experience context is agentic-only and fetched separately, inside
-  agentic.agentic.run_agentic_chat, only once intent has actually resolved
-  to "agentic".
+  route() resolves quaternary intent first (greeting/localchat/webchat/agentic).
+  Greeting-only turns short-circuit directly to the LLM without memory/KB
+  recall or memory writeback. All other paths start memory + KB recall only
+  after intent is known, then hand the resulting future to the selected
+  handler. Wiki/policy/skill/experience context is agentic-only and fetched
+  separately, inside agentic.agentic.run_agentic_chat, only once intent has
+  actually resolved to "agentic".
 """
 
 from __future__ import annotations
@@ -118,7 +116,8 @@ if _ROUTE_MODE not in _ROUTE_VALID_MODES:
 _AGENTIC_MODE_ON = os.getenv("AGENTIC_MODE_ON", "1").lower() in {"1", "true", "yes", "on"}
 
 # Three separate instruct strings, one per embedding context
-_ROUTE_INSTRUCT_TERNARY = "What kind of task or question is this?"  # used by route() for ternary intent routing
+_ROUTE_INSTRUCT_QUATERNARY = "What kind of task or question is this?"  # used by route() for quaternary intent routing
+_ROUTE_INSTRUCT_TERNARY = _ROUTE_INSTRUCT_QUATERNARY  # backwards-compatible alias for wakeup/tests
 
 _SEMANTIC_ROUTE_MIN_GAP = float(os.getenv("ROUTE_MIN_GAP", "0.10"))
 _SEMANTIC_LABEL_TOP_K = int(os.getenv("ROUTE_LABEL_TOP_K", "3"))
@@ -280,15 +279,17 @@ def _play_beep() -> None:
             log.warning("Beep playback failed: %s", e)
     threading.Thread(target=_run, daemon=True).start()
 
-# load route examples (ternary intent only - tools/capability moved to agentic/router)
+# load route examples (quaternary intent only - tools/capability moved to agentic/router)
 _EXAMPLES_PATH = Path(__file__).resolve().parent.parent / "agentic" / "router" / "intent_prompts.json"
 
 def _load_route_examples() -> dict:
     with open(_EXAMPLES_PATH, encoding="utf-8") as f:
         data = json.load(f)
-    return {k: tuple(v) for k, v in data["ternary"].items()}
+    raw = data.get("quaternary") or data.get("ternary") or {}
+    return {k: tuple(v) for k, v in raw.items()}
 
-_ROUTE_TERNARY_EXAMPLES = _load_route_examples()
+_ROUTE_QUATERNARY_EXAMPLES = _load_route_examples()
+_ROUTE_TERNARY_EXAMPLES = _ROUTE_QUATERNARY_EXAMPLES  # backwards-compatible alias for wakeup/tests
 
 _AGENTIC_ROUTE_RE = re.compile(
     r"\b("
@@ -300,6 +301,22 @@ _AGENTIC_ROUTE_RE = re.compile(
     r")\b",
     re.IGNORECASE,
 )
+
+_GREETING_ONLY_RE = re.compile(
+    r"^\s*(?:"
+    r"hi+|hello+|hey+|hiya+|yo+|sup|"
+    r"good\s+(?:morning|afternoon|evening)|morning|evening|"
+    r"(?:hi|hello|hey)\s+(?:there|aiko)|"
+    r"how(?:'|’)s\s+it\s+going|how\s+are\s+you(?:\s+doing)?|"
+    r"what(?:'|’)s\s+up|nice\s+to\s+see\s+you|good\s+to\s+see\s+you|"
+    r"just\s+saying\s+hi|thanks?|thank\s+you|okay\s+thanks|cool\s+thanks"
+    r")(?:[\s!?.~、。！]*|\s+(?:lol|haha|hehe)[\s!?.~、。！]*)$",
+    re.IGNORECASE,
+)
+
+
+def _is_greeting_only(user_input: str) -> bool:
+    return bool(_GREETING_ONLY_RE.match(user_input or ""))
 
 
 def _extract_search_results_block(system_prompt: str) -> str:
@@ -413,13 +430,13 @@ class AikoThink:
     # ── public api ────────────────────────────────────────────────────────────
 
     def route(self, user_input: str, token_callback=None) -> str:
-        """Main entry point. Ternary routing.
+        """Main entry point. Quaternary routing.
 
-        Memory + knowledge-base fetch is kicked off here, BEFORE intent is
-        known — every path (localchat/webchat/agentic) needs both, so
-        there's no reason to wait for _route_intent() to finish before
-        starting them. The future is threaded through to whichever handler
-        ends up running.
+        Intent is resolved before memory/KB recall. Greeting-only turns are
+        intentionally cheap: they go straight to the LLM with persona + recent
+        chat history only and skip memory recall, KB recall, and memory
+        extraction/writeback. Non-greeting turns then start the shared
+        memory+KB future and pass it to the selected handler.
 
         Per-user-active tracking: multiple users' turns can run concurrently
         (e.g. agentic loop for one user, quick chat for another). Shared
@@ -430,21 +447,29 @@ class AikoThink:
             self._active_user_ids.add(user_id)
         self._note_user_activity()
         try:
+            intent = self._route_intent(user_input)
+            log.info("[route] intent=%s", intent)
+
+            if intent == "greeting":
+                return self.chat(
+                    user_input,
+                    token_callback=token_callback,
+                    _skip_search=True,
+                    skip_memory=True,
+                    store_turn=False,
+                )
+
             embedder = self._get_memorize()._mem._embedder
             query_vec = embedder.embed_query(user_input)
             mem_kb_future = CONTEXT_POOL.submit(
                 self._fetch_memory_and_knowledge, user_input, query_vec
             )
 
-            intent = self._route_intent(user_input)
-            log.info("[route] intent=%s", intent)
-
             if intent == "agentic":
                 return self.agentic_chat(user_input, token_callback=token_callback, mem_kb_future=mem_kb_future, query_vec=query_vec)
-            elif intent == "webchat":
+            if intent == "webchat":
                 return self.webchat(user_input, token_callback=token_callback, mem_kb_future=mem_kb_future)
-            else:  # localchat
-                return self.chat(user_input, token_callback=token_callback, _skip_search=True, mem_kb_future=mem_kb_future)
+            return self.chat(user_input, token_callback=token_callback, _skip_search=True, mem_kb_future=mem_kb_future)
         finally:
             with self._active_users_lock:
                 self._active_user_ids.discard(user_id)
@@ -458,9 +483,9 @@ class AikoThink:
         """Fetch long-term memory + learned-knowledge (KB) concurrently.
 
         Both are independent reads against separate stores (memory.db /
-        knowledge.db) with no dependency on user intent, so route() fires
-        this off before intent routing even runs and hands the resulting
-        future to whichever path (agentic/webchat/localchat) gets picked.
+        knowledge.db). route() now starts this only after quaternary intent
+        routing, so greeting-only turns can skip recall entirely while
+        agentic/webchat/localchat still receive the same shared future.
         Callers that run standalone (e.g. a scheduled agentic job with no
         prior route() call) can call this directly instead.
 
@@ -528,7 +553,7 @@ class AikoThink:
             self._proactive_resting = resting
 
     def _route_intent(self, user_input: str) -> str:
-        """Ternary routing: single embedding, three-way decision with a
+        """Quaternary routing: single embedding, four-way decision with a
         high-confidence margin so a close call doesn't get committed to
         agentic (or webchat) just because it happened to be checked first.
 
@@ -541,11 +566,13 @@ class AikoThink:
     
         if not _ROUTE_ENABLED:
             return "localchat"
+        if _ROUTE_MODE == "llm_only":
+            return self._classify_quaternary_intent_llm(user_input, allow_agentic=_AGENTIC_MODE_ON)
     
-        instruct = _ROUTE_INSTRUCT_TERNARY
+        instruct = _ROUTE_INSTRUCT_QUATERNARY
         embedder = self._get_memorize()._mem._embedder
         query_vec = embedder.embed_query(user_input, instruct=instruct)
-        labels, example_vecs = self._semantic_example_vectors(_ROUTE_TERNARY_EXAMPLES, instruct)
+        labels, example_vecs = self._semantic_example_vectors(_ROUTE_QUATERNARY_EXAMPLES, instruct)
         scores = reason.label_scores_topk(query_vec, labels, example_vecs, top_k=_SEMANTIC_LABEL_TOP_K)
 
         if not _AGENTIC_MODE_ON:
@@ -554,6 +581,7 @@ class AikoThink:
             # webchat-vs-localchat decision — no separate code path needed.
             scores.pop("agentic", None)
       
+        greeting_score = scores.get("greeting", 0.0)
         agentic_score = scores.get("agentic", 0.0)
         webchat_score = scores.get("webchat", 0.0)
     
@@ -563,11 +591,15 @@ class AikoThink:
     
         agentic_threshold = float(os.getenv("ROUTE_AGENTIC_THRESHOLD", "0.65"))
         webchat_threshold = float(os.getenv("ROUTE_WEBCHAT_THRESHOLD", "0.60"))
+        greeting_threshold = float(os.getenv("ROUTE_GREETING_THRESHOLD", "0.60"))
     
         log.debug(
-            "[route] ternary scores: agentic=%.3f webchat=%.3f best=%s gap=%.3f for: %r",
-            agentic_score, webchat_score, best_label, gap, user_input
+            "[route] quaternary scores: greeting=%.3f agentic=%.3f webchat=%.3f best=%s gap=%.3f for: %r",
+            greeting_score, agentic_score, webchat_score, best_label, gap, user_input
         )
+
+        if best_label == "greeting" and greeting_score >= greeting_threshold and (gap >= _SEMANTIC_ROUTE_MIN_GAP or _is_greeting_only(user_input)):
+            return "greeting"
     
         if best_label == "agentic" and agentic_score >= agentic_threshold and gap >= _SEMANTIC_ROUTE_MIN_GAP:
             return "agentic"
@@ -576,16 +608,18 @@ class AikoThink:
     
         # Above threshold but too close to call cleanly.
         ambiguous = (
-            (agentic_score >= agentic_threshold or webchat_score >= webchat_threshold)
+            (agentic_score >= agentic_threshold or webchat_score >= webchat_threshold or greeting_score >= greeting_threshold)
             and gap < _SEMANTIC_ROUTE_MIN_GAP
         )
         if ambiguous:
+            if _is_greeting_only(user_input):
+                return "greeting"
             if _ROUTE_MODE == "semantic_only":
                 # Deterministic mode: no LLM call on ambiguity.
                 log.debug("[route] semantic_only: ambiguous gap, defaulting localchat")
                 return "localchat"
             if _ROUTE_MODE == "llm":
-                return self._classify_ternary_intent_llm(user_input, allow_agentic=_AGENTIC_MODE_ON)
+                return self._classify_quaternary_intent_llm(user_input, allow_agentic=_AGENTIC_MODE_ON)
             # "semantic" mode's original binary tie-break. If agentic is
             # off, there's nothing left for this binary check to decide
             # (it only ever distinguishes agentic vs chat), so skip the
@@ -594,6 +628,9 @@ class AikoThink:
                 return "localchat"
             llm_label = self._classify_agent_intent(user_input)
             return "agentic" if llm_label == "agentic" else "localchat"
+
+        if _is_greeting_only(user_input):
+            return "greeting"
     
         return "localchat"
 
@@ -696,7 +733,7 @@ class AikoThink:
             log.warning("Intent routing failed: %s", e)
             return "chat"
 
-    def _classify_ternary_intent_llm(self, user_input: str, allow_agentic: bool = True) -> str:
+    def _classify_quaternary_intent_llm(self, user_input: str, allow_agentic: bool = True) -> str:
         """LLM classify for ROUTE_MODE=llm (ambiguity tie-break) and
         ROUTE_MODE=llm_only (sole routing decision, every turn).
 
@@ -708,8 +745,10 @@ class AikoThink:
             return "agentic"
 
         if allow_agentic:
-            labels_line = "Labels: [agentic, webchat, chat]"
+            labels_line = "Labels: [greeting, agentic, webchat, chat]"
             guidance = (
+                "greeting = the entire message is only a salutation, thanks, "
+                "or small acknowledgement with no substantive request.\n"
                 "agentic = the message asks for an action/task (write, save, "
                 "schedule, debug, plan, remind, research-and-report).\n"
                 "webchat = the message needs current/external information "
@@ -717,6 +756,10 @@ class AikoThink:
                 "is not itself a task.\n"
                 "chat = casual conversation, opinions, or something answerable "
                 "from general/persona knowledge alone.\n\n"
+                "Message: 'hey Aiko'\n"
+                "Label: greeting\n\n"
+                "Message: 'thanks'\n"
+                "Label: greeting\n\n"
                 "Message: 'set a reminder for 9pm'\n"
                 "Label: agentic\n\n"
                 "Message: 'debug why asyncio.run() hangs'\n"
@@ -730,14 +773,18 @@ class AikoThink:
                 "Message: 'explain semaphores from memory'\n"
                 "Label: chat\n\n"
             )
-            valid = {"agentic", "webchat", "chat"}
+            valid = {"greeting", "agentic", "webchat", "chat"}
         else:
-            labels_line = "Labels: [webchat, chat]"
+            labels_line = "Labels: [greeting, webchat, chat]"
             guidance = (
+                "greeting = the entire message is only a salutation, thanks, "
+                "or small acknowledgement with no substantive request.\n"
                 "webchat = the message needs current/external information "
                 "(news, prices, scores, recent releases, real-time facts).\n"
                 "chat = casual conversation, opinions, or something answerable "
                 "from general/persona knowledge alone.\n\n"
+                "Message: 'hello there'\n"
+                "Label: greeting\n\n"
                 "Message: 'what's the weather in Vancouver right now'\n"
                 "Label: webchat\n\n"
                 "Message: 'who won the game last night'\n"
@@ -747,7 +794,7 @@ class AikoThink:
                 "Message: 'explain semaphores from memory'\n"
                 "Label: chat\n\n"
             )
-            valid = {"webchat", "chat"}
+            valid = {"greeting", "webchat", "chat"}
 
         try:
             resp = self._client.chat.completions.create(
@@ -767,8 +814,12 @@ class AikoThink:
                 return "localchat"
             return "localchat" if label == "chat" else label
         except Exception as e:
-            log.warning("Ternary LLM routing failed: %s", e)
+            log.warning("Quaternary LLM routing failed: %s", e)
             return "localchat"
+
+    def _classify_ternary_intent_llm(self, user_input: str, allow_agentic: bool = True) -> str:
+        """Backward-compatible wrapper for tests/extensions using the old name."""
+        return self._classify_quaternary_intent_llm(user_input, allow_agentic=allow_agentic)
   
     def agentic_chat(self, user_input: str, token_callback=None, mem_kb_future=None, query_vec: np.ndarray | None = None) -> str:
         """Delegate task-mode execution to agentic.agentic."""
@@ -916,29 +967,35 @@ class AikoThink:
 
     # ── proactive idle check-in loop ──────────────────────────────────────────
 
-    def chat(self, user_input: str, token_callback=None, _skip_search: bool = True, _history_label: str | None = None, mem_kb_future=None) -> str:
-        """Standard chat: local knowledge only (persona + memory + KB)."""
+    def chat(self, user_input: str, token_callback=None, _skip_search: bool = True, _history_label: str | None = None, mem_kb_future=None, *, skip_memory: bool = False, store_turn: bool = True) -> str:
+        """Standard chat: persona plus optional memory/KB context."""
         speak = self._get_speak()
         if speak and speak.is_playing():
             speak.stop()
         
-        # Memory + KB — either resolved from route()'s pre-intent future,
-        # or fetched directly if this was called standalone.
-        memories, knowledge_block = self._resolve_mem_kb(user_input, mem_kb_future)
-        memory_block = self._get_memorize().format_for_context(memories)
-        
-        system = self._current_system_prompt()
-        system += "\n\n" + bioclock.current_datetime_block()
-        if memory_block:
-            system = f"{system}\n\n{memory_block}"
+        if skip_memory:
+            memories = []
+            knowledge_block = ""
+            memory_block = ""
         else:
-            system += "\n\n<memory_context>\nNo relevant memories found.\n</memory_context>"
-        system = f"{system}\n\n{knowledge_block}"
+            # Memory + KB — either resolved from route()'s post-intent future,
+            # or fetched directly if this was called standalone.
+            memories, knowledge_block = self._resolve_mem_kb(user_input, mem_kb_future)
+            memory_block = self._get_memorize().format_for_context(memories)
+        
+        system = self._current_system_prompt(user_input)
+        system += "\n\n" + bioclock.current_datetime_block()
+        if not skip_memory:
+            if memory_block:
+                system = f"{system}\n\n{memory_block}"
+            else:
+                system += "\n\n<memory_context>\nNo relevant memories found.\n</memory_context>"
+            system = f"{system}\n\n{knowledge_block}"
         
         # Additional narrower wiki lookup — only when the user is asking
         # about Aiko's own architecture/docs, distinct from the general KB
         # fetch above. Gated so casual chat doesn't pay for it every turn.
-        if _should_use_local_knowledge(user_input):
+        if not skip_memory and _should_use_local_knowledge(user_input):
             try:
                 wiki_context = wiki_knowledge_context_for(
                     user_input, limit=3, max_chars=3000,
@@ -965,7 +1022,7 @@ class AikoThink:
         
         # Log debug
         self.last_prompt_debug = {
-            "mode": "localchat",
+            "mode": "greeting" if skip_memory else "localchat",
             "system_prompt": system,
             "memory_prompt": memory_block or "<memory_context>\nNo memories.\n</memory_context>",
             "knowledge_prompt": knowledge_block,
@@ -981,7 +1038,8 @@ class AikoThink:
         with self._history_lock:
             self._history.append({"role": "assistant", "content": raw_response})
         
-        self._store_async(user_input, raw_response)
+        if store_turn:
+            self._store_async(user_input, raw_response)
         self._reasoning = False
         return raw_response
 

--- a/cognition/think.py
+++ b/cognition/think.py
@@ -282,14 +282,16 @@ def _play_beep() -> None:
 # load route examples (quaternary intent only - tools/capability moved to agentic/router)
 _EXAMPLES_PATH = Path(__file__).resolve().parent.parent / "agentic" / "router" / "intent_prompts.json"
 
-def _load_route_examples() -> dict:
+def _load_route_examples(*, include_greeting: bool = True) -> dict:
     with open(_EXAMPLES_PATH, encoding="utf-8") as f:
         data = json.load(f)
-    raw = data.get("quaternary") or data.get("ternary") or {}
+    raw = dict(data.get("quaternary") or data.get("ternary") or {})
+    if not include_greeting:
+        raw.pop("greeting", None)
     return {k: tuple(v) for k, v in raw.items()}
 
 _ROUTE_QUATERNARY_EXAMPLES = _load_route_examples()
-_ROUTE_TERNARY_EXAMPLES = _ROUTE_QUATERNARY_EXAMPLES  # backwards-compatible alias for wakeup/tests
+_ROUTE_TERNARY_EXAMPLES = _load_route_examples(include_greeting=False)
 
 _AGENTIC_ROUTE_RE = re.compile(
     r"\b("
@@ -733,69 +735,60 @@ class AikoThink:
             log.warning("Intent routing failed: %s", e)
             return "chat"
 
-    def _classify_quaternary_intent_llm(self, user_input: str, allow_agentic: bool = True) -> str:
-        """LLM classify for ROUTE_MODE=llm (ambiguity tie-break) and
-        ROUTE_MODE=llm_only (sole routing decision, every turn).
+    def _intent_llm_prompt_parts(self, *, allow_agentic: bool, include_greeting: bool) -> tuple[str, str, set[str]]:
+        labels = []
+        guidance_parts: list[str] = []
+        examples: list[str] = []
+        valid: set[str] = set()
 
-        allow_agentic=False collapses this to a binary webchat/chat
-        classification — agentic is never offered as a label, so
-        AGENTIC_MODE_ON=0 holds regardless of which ROUTE_MODE is active.
-        """
-        if allow_agentic and _AGENTIC_ROUTE_RE.search(user_input):
-            return "agentic"
+        if include_greeting:
+            labels.append("greeting")
+            valid.add("greeting")
+            guidance_parts.append(
+                "greeting = the entire message is only a salutation, thanks, "
+                "or small acknowledgement with no substantive request.\n"
+            )
+            examples.extend([
+                "Message: 'hey Aiko'\nLabel: greeting\n",
+                "Message: 'thanks'\nLabel: greeting\n",
+            ])
 
         if allow_agentic:
-            labels_line = "Labels: [greeting, agentic, webchat, chat]"
-            guidance = (
-                "greeting = the entire message is only a salutation, thanks, "
-                "or small acknowledgement with no substantive request.\n"
+            labels.append("agentic")
+            valid.add("agentic")
+            guidance_parts.append(
                 "agentic = the message asks for an action/task (write, save, "
                 "schedule, debug, plan, remind, research-and-report).\n"
-                "webchat = the message needs current/external information "
-                "(news, prices, scores, recent releases, real-time facts) but "
-                "is not itself a task.\n"
-                "chat = casual conversation, opinions, or something answerable "
-                "from general/persona knowledge alone.\n\n"
-                "Message: 'hey Aiko'\n"
-                "Label: greeting\n\n"
-                "Message: 'thanks'\n"
-                "Label: greeting\n\n"
-                "Message: 'set a reminder for 9pm'\n"
-                "Label: agentic\n\n"
-                "Message: 'debug why asyncio.run() hangs'\n"
-                "Label: agentic\n\n"
-                "Message: 'what's the weather in Vancouver right now'\n"
-                "Label: webchat\n\n"
-                "Message: 'who won the game last night'\n"
-                "Label: webchat\n\n"
-                "Message: 'what do you think about minimalism'\n"
-                "Label: chat\n\n"
-                "Message: 'explain semaphores from memory'\n"
-                "Label: chat\n\n"
             )
-            valid = {"greeting", "agentic", "webchat", "chat"}
-        else:
-            labels_line = "Labels: [greeting, webchat, chat]"
-            guidance = (
-                "greeting = the entire message is only a salutation, thanks, "
-                "or small acknowledgement with no substantive request.\n"
-                "webchat = the message needs current/external information "
-                "(news, prices, scores, recent releases, real-time facts).\n"
-                "chat = casual conversation, opinions, or something answerable "
-                "from general/persona knowledge alone.\n\n"
-                "Message: 'hello there'\n"
-                "Label: greeting\n\n"
-                "Message: 'what's the weather in Vancouver right now'\n"
-                "Label: webchat\n\n"
-                "Message: 'who won the game last night'\n"
-                "Label: webchat\n\n"
-                "Message: 'what do you think about minimalism'\n"
-                "Label: chat\n\n"
-                "Message: 'explain semaphores from memory'\n"
-                "Label: chat\n\n"
-            )
-            valid = {"greeting", "webchat", "chat"}
+            examples.extend([
+                "Message: 'set a reminder for 9pm'\nLabel: agentic\n",
+                "Message: 'debug why asyncio.run() hangs'\nLabel: agentic\n",
+            ])
 
+        labels.extend(["webchat", "chat"])
+        valid.update({"webchat", "chat"})
+        guidance_parts.extend([
+            "webchat = the message needs current/external information "
+            "(news, prices, scores, recent releases, real-time facts) but "
+            "is not itself a task.\n",
+            "chat = casual conversation, opinions, or something answerable "
+            "from general/persona knowledge alone.\n",
+        ])
+        examples.extend([
+            "Message: 'what's the weather in Vancouver right now'\nLabel: webchat\n",
+            "Message: 'who won the game last night'\nLabel: webchat\n",
+            "Message: 'what do you think about minimalism'\nLabel: chat\n",
+            "Message: 'explain semaphores from memory'\nLabel: chat\n",
+        ])
+        return f"Labels: [{', '.join(labels)}]", "\n".join(guidance_parts + examples), valid
+
+    def _classify_intent_llm(self, user_input: str, *, allow_agentic: bool, include_greeting: bool, log_name: str) -> str:
+        if allow_agentic and _AGENTIC_ROUTE_RE.search(user_input):
+            return "agentic"
+        labels_line, guidance, valid = self._intent_llm_prompt_parts(
+            allow_agentic=allow_agentic,
+            include_greeting=include_greeting,
+        )
         try:
             resp = self._client.chat.completions.create(
                 model=self._router_model,
@@ -814,12 +807,26 @@ class AikoThink:
                 return "localchat"
             return "localchat" if label == "chat" else label
         except Exception as e:
-            log.warning("Quaternary LLM routing failed: %s", e)
+            log.warning("%s LLM routing failed: %s", log_name, e)
             return "localchat"
 
+    def _classify_quaternary_intent_llm(self, user_input: str, allow_agentic: bool = True) -> str:
+        """LLM classify with greeting/agentic/webchat/chat labels."""
+        return self._classify_intent_llm(
+            user_input,
+            allow_agentic=allow_agentic,
+            include_greeting=True,
+            log_name="Quaternary",
+        )
+
     def _classify_ternary_intent_llm(self, user_input: str, allow_agentic: bool = True) -> str:
-        """Backward-compatible wrapper for tests/extensions using the old name."""
-        return self._classify_quaternary_intent_llm(user_input, allow_agentic=allow_agentic)
+        """Backward-compatible LLM classifier with no greeting label."""
+        return self._classify_intent_llm(
+            user_input,
+            allow_agentic=allow_agentic,
+            include_greeting=False,
+            log_name="Ternary",
+        )
   
     def agentic_chat(self, user_input: str, token_callback=None, mem_kb_future=None, query_vec: np.ndarray | None = None) -> str:
         """Delegate task-mode execution to agentic.agentic."""

--- a/tests/unit/test_agentic_graph_engine.py
+++ b/tests/unit/test_agentic_graph_engine.py
@@ -32,6 +32,7 @@ from agentic.graph_engine import (
     _default_playbooks,
     load_playbooks,
     _score_plan,
+    _SEMANTIC_TRIGGER_CACHE,
     _title,
     _heuristic_items,
     _placeholder_extras,
@@ -229,6 +230,30 @@ class TestPlanScoring:
         score = _score_plan(plan, "I want a thorough research report on this topic", ["research"], embedder)
         # Should get semantic boost (cosine similarity high -> +5)
         assert score >= 8  # 3 trigger + 3 cap + semantic boost
+
+
+    def test_semantic_triggers_are_cached(self):
+        class CountingEmbedder:
+            def __init__(self):
+                self.calls = []
+
+            def embed_query(self, text: str, instruct: str = "") -> np.ndarray:
+                self.calls.append(text)
+                return np.array([1.0, 0.0], dtype=np.float32)
+
+        _SEMANTIC_TRIGGER_CACHE.clear()
+        plan = {
+            "triggers": [],
+            "requires_any": [],
+            "capabilities": [],
+            "semantic_triggers": ["static semantic trigger"],
+        }
+        embedder = CountingEmbedder()
+        prompt_vec = np.array([1.0, 0.0], dtype=np.float32)
+
+        assert _score_plan(plan, "prompt", embedder=embedder, prompt_vec=prompt_vec) == 5
+        assert _score_plan(plan, "prompt", embedder=embedder, prompt_vec=prompt_vec) == 5
+        assert embedder.calls == ["static semantic trigger"]
 
     def test_compare_playbook_rejected_without_subjects(self):
         """compare_and_report should be rejected if no comparison subjects found."""
@@ -672,6 +697,16 @@ class TestGraphStateMethods:
         state.record_tool_execution("tool1", {"arg": "val"}, "res")
         executions = state.get_tool_executions()
         assert len(executions) == 1
+
+    def test_graph_state_tool_execution_log_is_capped(self, monkeypatch):
+        monkeypatch.setattr(schema, "GRAPH_TOOL_EXECUTION_LOG_MAX", 2)
+        state = GraphState()
+
+        for idx in range(4):
+            state.record_tool_execution(f"tool{idx}", {}, f"result{idx}")
+
+        executions = state.get_tool_executions()
+        assert [entry["tool"] for entry in executions] == ["tool2", "tool3"]
 
 
 class TestPlanNodeNewFields:

--- a/tests/unit/test_agentic_graph_engine.py
+++ b/tests/unit/test_agentic_graph_engine.py
@@ -33,6 +33,7 @@ from agentic.graph_engine import (
     load_playbooks,
     _score_plan,
     _SEMANTIC_TRIGGER_CACHE,
+    _trim_node_content,
     _title,
     _heuristic_items,
     _placeholder_extras,
@@ -707,6 +708,19 @@ class TestGraphStateMethods:
 
         executions = state.get_tool_executions()
         assert [entry["tool"] for entry in executions] == ["tool2", "tool3"]
+
+    def test_trim_node_content_respects_max_chars(self, monkeypatch):
+        monkeypatch.setattr(schema, "GRAPH_NODE_RESULT_MAX_CHARS", 64)
+
+        result = _trim_node_content("x" * 200)
+
+        assert len(result) <= 64
+        assert result.endswith("[truncated by GRAPH_NODE_RESULT_MAX_CHARS]")
+
+    def test_trim_node_content_respects_short_max_chars(self, monkeypatch):
+        monkeypatch.setattr(schema, "GRAPH_NODE_RESULT_MAX_CHARS", 8)
+
+        assert len(_trim_node_content("x" * 200)) == 8
 
 
 class TestPlanNodeNewFields:

--- a/tests/unit/test_agentic_synthesize.py
+++ b/tests/unit/test_agentic_synthesize.py
@@ -166,14 +166,23 @@ class TestCombineEvidence:
         assert combine_evidence([]) == ""
 
     def test_truncates_parts_before_join(self):
-        result = combine_evidence(["a" * 10, "b" * 10], part_max_chars=4, max_chars=0)
-        assert result.startswith("aaaa\n[part truncated")
-        assert "bbbb\n[part truncated" in result
+        result = combine_evidence(["a" * 80, "b" * 80], part_max_chars=64, max_chars=0)
+        parts = result.split("\n\n---\n\n")
+
+        assert all(len(part) <= 64 for part in parts)
+        assert parts[0].endswith("[part truncated by GRAPH_COMBINE_PART_MAX_CHARS]")
+        assert parts[1].endswith("[part truncated by GRAPH_COMBINE_PART_MAX_CHARS]")
 
     def test_truncates_joined_output(self):
-        result = combine_evidence(["a" * 10, "b" * 10], part_max_chars=0, max_chars=12)
-        assert result.startswith("aaaaaaaaaa")
+        result = combine_evidence(["a" * 80, "b" * 80], part_max_chars=0, max_chars=72)
+
+        assert len(result) <= 72
         assert result.endswith("[combined evidence truncated by GRAPH_COMBINE_MAX_CHARS]")
+
+    def test_truncates_with_short_cap(self):
+        result = combine_evidence(["a" * 80], part_max_chars=8, max_chars=0)
+
+        assert len(result) == 8
 
 
 class TestCondenseText:

--- a/tests/unit/test_agentic_synthesize.py
+++ b/tests/unit/test_agentic_synthesize.py
@@ -165,6 +165,16 @@ class TestCombineEvidence:
     def test_empty_list_returns_empty(self):
         assert combine_evidence([]) == ""
 
+    def test_truncates_parts_before_join(self):
+        result = combine_evidence(["a" * 10, "b" * 10], part_max_chars=4, max_chars=0)
+        assert result.startswith("aaaa\n[part truncated")
+        assert "bbbb\n[part truncated" in result
+
+    def test_truncates_joined_output(self):
+        result = combine_evidence(["a" * 10, "b" * 10], part_max_chars=0, max_chars=12)
+        assert result.startswith("aaaaaaaaaa")
+        assert result.endswith("[combined evidence truncated by GRAPH_COMBINE_MAX_CHARS]")
+
 
 class TestCondenseText:
     """Tests for condense_text semantic condensation."""

--- a/tests/unit/test_think_routing.py
+++ b/tests/unit/test_think_routing.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import threading
+from types import SimpleNamespace
 
 import numpy as np
 
@@ -45,6 +46,12 @@ def test_route_examples_include_greeting_label():
 
     assert "greeting" in examples
     assert any("hello" in example.lower() for example in examples["greeting"])
+
+
+def test_ternary_route_examples_exclude_greeting_label():
+    examples = _load_route_examples(include_greeting=False)
+
+    assert set(examples) == {"agentic", "webchat", "localchat"}
 
 
 def test_route_intent_can_return_greeting_from_semantic_scores(monkeypatch):
@@ -98,3 +105,41 @@ def test_non_greeting_route_starts_memory_after_intent(monkeypatch):
 
     assert think.route("tell me about routers") == "ok"
     assert events == ["intent", "submit_mem_kb"]
+
+
+class FakeCompletions:
+    def __init__(self, label: str):
+        self.label = label
+        self.last_messages = None
+
+    def create(self, **kwargs):
+        self.last_messages = kwargs["messages"]
+        message = SimpleNamespace(content=self.label)
+        return SimpleNamespace(choices=[SimpleNamespace(message=message)])
+
+
+class FakeClient:
+    def __init__(self, label: str):
+        self.chat = SimpleNamespace(completions=FakeCompletions(label))
+
+
+def test_ternary_llm_classifier_preserves_three_way_labels():
+    think = _bare_think()
+    think._client = FakeClient("greeting")
+    think._router_model = "router"
+
+    assert think._classify_ternary_intent_llm("hello") == "localchat"
+    prompt = think._client.chat.completions.last_messages[0]["content"]
+    assert "Labels: [agentic, webchat, chat]" in prompt
+    assert "Label: greeting" not in prompt
+
+
+def test_quaternary_llm_classifier_allows_greeting_label():
+    think = _bare_think()
+    think._client = FakeClient("greeting")
+    think._router_model = "router"
+
+    assert think._classify_quaternary_intent_llm("hello") == "greeting"
+    prompt = think._client.chat.completions.last_messages[0]["content"]
+    assert "Labels: [greeting, agentic, webchat, chat]" in prompt
+    assert "Label: greeting" in prompt

--- a/tests/unit/test_think_routing.py
+++ b/tests/unit/test_think_routing.py
@@ -1,0 +1,100 @@
+"""Unit tests for cognition.think intent routing shortcuts."""
+from __future__ import annotations
+
+import threading
+
+import numpy as np
+
+from cognition import think as think_module
+from cognition.think import AikoThink, _load_route_examples
+
+
+class FakeEmbedder:
+    def __init__(self):
+        self.calls: list[tuple[str, str]] = []
+
+    def embed_query(self, text: str, instruct: str = ""):
+        self.calls.append((text, instruct))
+        return np.array([1.0, 0.0], dtype=np.float32)
+
+
+class FakeMemoryInner:
+    def __init__(self, embedder):
+        self._embedder = embedder
+
+
+class FakeMemorize:
+    def __init__(self, embedder):
+        self._mem = FakeMemoryInner(embedder)
+
+
+def _bare_think(embedder: FakeEmbedder | None = None) -> AikoThink:
+    think = object.__new__(AikoThink)
+    think._memorize = FakeMemorize(embedder or FakeEmbedder())
+    think._memorize_lock = threading.Lock()
+    think._active_user_ids = set()
+    think._active_users_lock = threading.Lock()
+    think._last_chat_time = 0.0
+    think._proactive_lock = threading.Lock()
+    think._proactive_resting = False
+    return think
+
+
+def test_route_examples_include_greeting_label():
+    examples = _load_route_examples()
+
+    assert "greeting" in examples
+    assert any("hello" in example.lower() for example in examples["greeting"])
+
+
+def test_route_intent_can_return_greeting_from_semantic_scores(monkeypatch):
+    embedder = FakeEmbedder()
+    think = _bare_think(embedder)
+    monkeypatch.setattr(think, "_semantic_example_vectors", lambda examples, instruct: (["greeting"], np.array([[1.0, 0.0]], dtype=np.float32)))
+    monkeypatch.setattr(think_module.reason, "label_scores_topk", lambda *a, **kw: {"greeting": 0.95, "localchat": 0.10})
+
+    assert think._route_intent("hello there") == "greeting"
+    assert embedder.calls == [("hello there", think_module._ROUTE_INSTRUCT_QUATERNARY)]
+
+
+def test_greeting_route_skips_memory_recall_and_writeback(monkeypatch):
+    think = _bare_think()
+    calls = {}
+
+    monkeypatch.setattr(think, "_route_intent", lambda user_input: "greeting")
+    monkeypatch.setattr(think, "_fetch_memory_and_knowledge", lambda *a, **kw: calls.setdefault("fetch", True))
+
+    def fake_chat(user_input, **kwargs):
+        calls["chat_kwargs"] = kwargs
+        return "hi!"
+
+    monkeypatch.setattr(think, "chat", fake_chat)
+
+    assert think.route("hi") == "hi!"
+    assert "fetch" not in calls
+    assert calls["chat_kwargs"]["skip_memory"] is True
+    assert calls["chat_kwargs"]["store_turn"] is False
+
+
+def test_non_greeting_route_starts_memory_after_intent(monkeypatch):
+    think = _bare_think()
+    events: list[str] = []
+
+    monkeypatch.setattr(think, "_route_intent", lambda user_input: events.append("intent") or "localchat")
+
+    class ImmediatePool:
+        def submit(self, fn, *args):
+            events.append("submit_mem_kb")
+
+            class Future:
+                def result(self_inner):
+                    return fn(*args)
+
+            return Future()
+
+    monkeypatch.setattr(think_module, "CONTEXT_POOL", ImmediatePool())
+    monkeypatch.setattr(think, "_fetch_memory_and_knowledge", lambda *a, **kw: ([], "<knowledge_context />"))
+    monkeypatch.setattr(think, "chat", lambda *a, **kw: "ok")
+
+    assert think.route("tell me about routers") == "ok"
+    assert events == ["intent", "submit_mem_kb"]


### PR DESCRIPTION
### Motivation
- Improve intent routing to recognize short greeting-only turns and make them cheap by skipping memory/KB recall and writeback.
- Speed up and stabilize playbook semantic scoring by caching semantic trigger embeddings and avoiding redundant embedder calls.
- Prevent oversized node/tool outputs and long execution logs from blowing up memory or prompts by truncating results and capping logs.
- Make evidence combination safer for LLM inputs by truncating large parts and overall combined size.

### Description
- Extend routing from ternary to quaternary intent handling, adding a `greeting` label and short-circuiting greetings in `AikoThink.route` to call `chat` with `skip_memory=True` and `store_turn=False`.
- Update `_load_route_examples` and the `intent_prompts.json` structure to include a `quaternary` key with `greeting` examples and keep backward-compatible aliases (`_ROUTE_TERNARY_EXAMPLES` → `_ROUTE_QUATERNARY_EXAMPLES` with aliasing).
- Add `_GREETING_ONLY_RE` and `_is_greeting_only` to detect greeting-only inputs and integrate into `_route_intent` and ambiguity handling; add LLM tie-break method renaming with compatibility wrappers (`_classify_quaternary_intent_llm` and `_classify_ternary_intent_llm`).
- Add semantic trigger caching machinery: `_SEMANTIC_TRIGGER_CACHE`, `_SEMANTIC_TRIGGER_LOCK`, and `_semantic_trigger_matrix` to compute/vstack normalized trigger vectors and reuse them; refactor `_score_plan` to accept a precomputed `prompt_vec` and use the cached matrix to compute best cosine matches.
- Add result/log trimming helpers and limits: `GRAPH_TOOL_EXECUTION_LOG_MAX`, `GRAPH_NODE_RESULT_MAX_CHARS`, and `_trim_node_content`; apply trimming in `GraphState.record_tool_execution`, `_run_node` return paths, and fallback node result handling.
- Reduce default `GRAPH_MAX_WORKERS` from `4` to `2`.
- Enhance `combine_evidence` in `agentic.toolkit.synthesize` to accept `part_max_chars` and `max_chars` (driven by `GRAPH_COMBINE_PART_MAX_CHARS` and `GRAPH_COMBINE_MAX_CHARS`) and truncate individual parts and the final joined string when configured.
- Add new and updated unit tests: semantic trigger caching and log-capping tests in `tests/unit/test_agentic_graph_engine.py`, combine/truncation tests in `tests/unit/test_agentic_synthesize.py`, and a new `tests/unit/test_think_routing.py` to validate quaternary routing and greeting short-circuit behavior.

### Testing
- Ran unit tests covering graph engine changes in `tests/unit/test_agentic_graph_engine.py`, including `test_semantic_triggers_are_cached` and `test_graph_state_tool_execution_log_is_capped`, which passed.
- Ran synthesize tests in `tests/unit/test_agentic_synthesize.py`, including `test_truncates_parts_before_join` and `test_truncates_joined_output`, which passed.
- Added and ran routing tests in `tests/unit/test_think_routing.py` validating greeting examples, semantic scoring routing to `greeting`, and that greeting routes skip memory fetch; these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67c7a72d5c8332852f828ed39750ea)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated greeting handling for faster, more natural responses.
  - Greeting-only messages now bypass unnecessary memory and knowledge lookups.
  - Added configurable limits for generated results, evidence, and execution history.
- **Performance**
  - Improved semantic matching efficiency through reusable cached calculations.
  - Reduced default parallel processing to improve stability and resource usage.
- **Bug Fixes**
  - Improved handling of oversized outputs and failed operations by preventing excessive content growth.
  - Added truncation notices when combined evidence exceeds configured limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->