### PR TITLE
Use catalog ToolSpec lookup for tool decorators

### DIFF
--- a/agentic/agentic.py
+++ b/agentic/agentic.py
@@ -580,7 +580,7 @@ def tool_schemas() -> list[dict]:
     return [schema for schema, _handler in _TOOLS.values()]
 
 
-from agentic.registry import registry, register_tool_schema, tool
+from agentic.registry import TOOLS, registry, register_tool_schema, tool
 
 
 def _bootstrap_tool_registry() -> None:
@@ -589,13 +589,7 @@ def _bootstrap_tool_registry() -> None:
     from agentic.toolkit import synthesize  # noqa: F401
 
 
-@tool(
-    name="final_answer",
-    description="Final answer.",
-    props={"answer": {"type": "string", "description": "The final answer text."}},
-    required=["answer"],
-    always_on=True,
-)
+@tool(TOOLS["final_answer"])
 def final_answer(answer: str) -> str:
     return answer
 

--- a/agentic/graph_engine.py
+++ b/agentic/graph_engine.py
@@ -1780,16 +1780,10 @@ def append_playbook_from_experience(goal: str, steps: list[dict[str, Any]], *, n
         tmp_path.replace(path)
 
 
-from agentic.registry import register_tool_schema, tool
+from agentic.registry import TOOLS, register_tool_schema, tool
 
 
-@tool(
-    name="list_playbooks",
-    description="List graph/playbook workflows available to the model-free graph executor.",
-    props={},
-    domain="graph",
-    always_on=True,
-)
+@tool(TOOLS["list_playbooks"])
 def list_playbooks() -> str:
     return list_playbooks_json()
 

--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -10,10 +10,13 @@ Graph execution loops.
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass, field
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from system.config import load_yaml
+
+log = logging.getLogger(__name__)
 
 
 @dataclass
@@ -55,6 +58,7 @@ def load_tool_catalog(path: str = "tools.yaml") -> Dict[str, ToolSpec]:
     catalog: Dict[str, ToolSpec] = {}
     for item in raw_tools:
         if not isinstance(item, dict) or not item.get("name"):
+            log.warning("Skipping invalid tools.yaml entry: %r", item)
             continue
         tool_data = {k: v for k, v in item.items() if k != "handler"}
         spec = ToolSpec(**tool_data)

--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -46,6 +46,25 @@ class ToolSpec:
         return s
 
 
+def load_tool_catalog(path: str = "tools.yaml") -> Dict[str, ToolSpec]:
+    """Load declarative tool metadata keyed by tool name from config/tools.yaml."""
+    data = load_yaml(path)
+    raw_tools = data.get("tools", [])
+    if not isinstance(raw_tools, list):
+        raise ValueError("tools.yaml must contain a 'tools' list")
+    catalog: Dict[str, ToolSpec] = {}
+    for item in raw_tools:
+        if not isinstance(item, dict) or not item.get("name"):
+            continue
+        tool_data = {k: v for k, v in item.items() if k != "handler"}
+        spec = ToolSpec(**tool_data)
+        catalog[spec.name] = spec
+    return catalog
+
+
+TOOLS = load_tool_catalog()
+
+
 class ToolRegistry:
     """Singleton registry tracking all declared agentic tools."""
 
@@ -178,8 +197,8 @@ registry = ToolRegistry()
 
 
 def tool(
-    name: str,
-    description: str,
+    spec_or_name: ToolSpec | str,
+    description: Optional[str] = None,
     *,
     props: Optional[Dict[str, Any]] = None,
     required: Optional[List[str]] = None,
@@ -192,31 +211,45 @@ def tool(
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator to register a function as an agentic tool.
 
-    Args:
-        name: Tool name for OpenAI schema and registry lookup
-        description: Human-readable description for LLM tool selection
-        props: Parameter schema dict
-        required: List of required parameter names
-        domain: Capability domain for routing (research, scheduling, etc.)
-        always_on: Always include in tool list regardless of capability match
-        react: Available in ReAct loop (default: True)
-        graph: Available in graph_engine playbook (default: True)
-        wiki: Available in wiki workflow (default: False)
-        skill: Available in skill workflow (default: False)
+    Prefer passing a catalog spec loaded once from config/tools.yaml:
+
+        @tool(TOOLS["repo_file_tree"])
+        def repo_file_tree(...): ...
+
+    The legacy ``@tool(name, description, ...)`` form is still supported for
+    non-catalog callers and tests.
     """
-    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
-        registry.register(
-            name=name,
+    if isinstance(spec_or_name, ToolSpec):
+        spec = spec_or_name
+    else:
+        if description is None:
+            raise TypeError("description is required when registering by name")
+        spec = ToolSpec(
+            name=spec_or_name,
             description=description,
-            handler=fn,
-            props=props,
-            required=required,
+            props=props or {},
+            required=required or [],
             domain=domain,
             always_on=always_on,
             react=react,
             graph=graph,
             wiki=wiki,
             skill=skill,
+        )
+
+    def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+        registry.register(
+            name=spec.name,
+            description=spec.description,
+            handler=fn,
+            props=spec.props,
+            required=spec.required,
+            domain=spec.domain,
+            always_on=spec.always_on,
+            react=spec.react,
+            graph=spec.graph,
+            wiki=spec.wiki,
+            skill=spec.skill,
         )
         return fn
     return decorator

--- a/agentic/skills.py
+++ b/agentic/skills.py
@@ -27,7 +27,7 @@ import numpy as np
 
 from cognition import reason
 from system.userspace import user_state_dir
-from agentic.registry import tool
+from agentic.registry import TOOLS, tool
 
 DEFAULT_SKILLS_PATH = Path(__file__).resolve().parent.parent / "skills" / "SKILLS.md"
 SKILL_ROOT = Path(__file__).resolve().parent.parent / "skills"
@@ -278,12 +278,7 @@ def discover_skill_docs() -> list[SkillDoc]:
     return docs
 
 
-@tool(
-    name="list_skillsets",
-    description="List Aiko's predefined local workflow skillsets.",
-    props={},
-    domain="skills",
-)
+@tool(TOOLS["list_skillsets"])
 def list_skillsets() -> str:
     """Return available skill workflows as JSON text for agent tools."""
     return json.dumps({"skills": [doc.as_dict() for doc in discover_skill_docs()]}, ensure_ascii=False, indent=2)
@@ -329,13 +324,7 @@ def search_skillsets(query: str, limit: int = 3, embedder: Embedder | None = Non
     return [doc for _score, doc in scored[:limit]]
 
 
-@tool(
-    name="search_skillsets",
-    description="Search Aiko's predefined workflow skillsets by task/query.",
-    props={"query": {"type": "string"}, "limit": {"type": "integer"}},
-    required=["query"],
-    domain="skills",
-)
+@tool(TOOLS["search_skillsets"])
 def search_skillsets_json(query: str, limit: int = 3, embedder: Embedder | None = None) -> str:
     """Return matching skill workflows as JSON text for agent tools.
 
@@ -349,13 +338,7 @@ def search_skillsets_json(query: str, limit: int = 3, embedder: Embedder | None 
     }, ensure_ascii=False, indent=2)
 
 
-@tool(
-    name="load_skillset",
-    description="Load the full markdown instructions for one predefined skillset by id.",
-    props={"skill_id": {"type": "string"}},
-    required=["skill_id"],
-    domain="skills",
-)
+@tool(TOOLS["load_skillset"])
 def load_skillset(skill_id: str, max_chars: int = 12_000) -> str:
     """Load one full skill workflow document by id. Used for explicit
     on-demand full loads — not injected automatically into every turn."""

--- a/agentic/toolkit/ingest.py
+++ b/agentic/toolkit/ingest.py
@@ -28,7 +28,7 @@ import tempfile
 import time
 from urllib.parse import urlparse
 
-from agentic.registry import tool
+from agentic.registry import TOOLS, tool
 
 FETCH_URL_USER_AGENT = os.getenv(
     "FETCH_URL_USER_AGENT",
@@ -223,19 +223,7 @@ def _extract_with_markitdown(data: bytes, content_type: str, max_chars: int) -> 
     return text[:max_chars]
 
 
-@tool(
-    name="fetch_from_url",
-    description="Download and extract text from any URL. Handles HTML pages, PDFs, DOCX, PPTX, XLSX, EPUB, CSV, XML, ZIP, IPYNB, MSG. Lightweight alternative to deep_read — no JS rendering, no relevance filtering, no Crawl4AI escalation. Use when you have a known URL and want its plain text.",
-    props={
-        "url": {"type": "string", "description": "The exact URL to fetch and read."},
-        "max_chars": {"type": "integer", "description": "Maximum characters to return (default FETCH_FROM_URL_MAX_CHARS)."},
-    },
-    required=["url"],
-    domain="research",
-    react=True,
-    graph=True,
-    wiki=True,
-)
+@tool(TOOLS["fetch_from_url"])
 def fetch_from_url(url: str, max_chars: int = FETCH_FROM_URL_MAX_CHARS) -> str:
     """Download and extract text from any URL.
 

--- a/agentic/toolkit/job_hunt.py
+++ b/agentic/toolkit/job_hunt.py
@@ -34,7 +34,7 @@ from typing import Any
 
 import requests
 
-from agentic.registry import tool
+from agentic.registry import TOOLS, tool
 from system.bioclock import local_now
 from agentic.toolkit.websearch import SEARXNG_MAX_RESULTS as MAX_RESULTS, web_fetch, web_search
 
@@ -334,15 +334,7 @@ def dedupe_postings(postings: list[dict], title_threshold: float = 0.7) -> list[
 
 # ── Composed convenience (backwards-compatible) ──
 
-@tool(
-    name="search_jobs",
-    description="Search configured job boards for a role. If location is omitted, uses the job_hunt skill default location. Deduped automatically.",
-    props={"query": {"type": "string"}, "location": {"type": "string", "description": "Optional override. Defaults to the job_hunt skill location."}, "max_results": {"type": "integer"}, "max_age_days": {"type": "integer"}, "job_type": {"type": "string", "description": "Optional employment type filter from the user prompt, e.g. full-time, contract, remote."}},
-    required=["query"],
-    domain="jobs",
-    react=False,
-    graph=True,
-)
+@tool(TOOLS["search_jobs"])
 def search_jobs(
     query: str,
     location: str = "",

--- a/agentic/toolkit/organize.py
+++ b/agentic/toolkit/organize.py
@@ -26,18 +26,10 @@ from system.schedule import (
     schedule_reminder_record,
 )
 from agentic.toolkit.common import json_block
-from agentic.registry import tool
+from agentic.registry import TOOLS, tool
 
 
-@tool(
-    name="schedule_job",
-    description="Schedule local job/alarm. HH:MM. Frequencies: once,hourly,daily,weekdays,weekly,biweekly,monthly,custom_weekdays. Supports relative_days for today/tomorrow/day-after-tomorrow offsets.",
-    props={"title": {"type": "string"}, "task": {"type": "string"}, "time_of_day": {"type": "string", "description": "24-hour local time, e.g. 06:00"}, "frequency": {"type": "string", "enum": ["once", "hourly", "daily", "weekdays", "weekly", "biweekly", "monthly", "custom_weekdays"]}, "timezone": {"type": "string"}, "days_of_week": {"type": "string", "description": "Optional weekdays, e.g. Monday Wednesday Friday"}, "relative_days": {"type": "string", "description": "Optional day offset/phrase for the first due date, e.g. 0/today, 1/tomorrow, 2/day after tomorrow"}, "action": {"type": "string", "enum": ["announce", "agentic", "tool"], "description": "announce, agentic task, or direct registered tool invocation"}, "tool_call": {"type": "object", "description": "Required for action=tool: {name: registered tool name, arguments: object}"}, "skill": {"type": "string", "description": "Optional custom SKILL.md-style instructions for an agentic job"}},
-    required=["title", "task", "time_of_day"],
-    domain="scheduling",
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["schedule_job"])
 def schedule_job(
     title: str,
     task: str,
@@ -74,29 +66,14 @@ def schedule_job(
         return f"[schedule failed: {e}]"
 
 
-@tool(
-    name="list_schedule",
-    description="List schedule.",
-    props={"include_disabled": {"type": "boolean"}},
-    domain="scheduling",
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["list_schedule"])
 def list_schedule(include_disabled: bool = False, user_id: str | None = None) -> str:
     """List local scheduled jobs from Aiko's schedule file."""
     jobs = list_schedule_records(include_disabled=include_disabled, user_id=user_id)
     return json_block("schedule", {"count": len(jobs), "items": jobs})
 
 
-@tool(
-    name="cancel_schedule",
-    description="Cancel schedule item.",
-    props={"job_id": {"type": "string"}},
-    required=["job_id"],
-    domain="scheduling",
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["cancel_schedule"])
 def cancel_schedule(job_id: str, user_id: str | None = None) -> str:
     """Cancel/disable a local scheduled job by id."""
     if cancel_schedule_record(job_id, user_id=user_id):
@@ -104,15 +81,7 @@ def cancel_schedule(job_id: str, user_id: str | None = None) -> str:
     return f"[scheduled job not found: {job_id}]"
 
 
-@tool(
-    name="schedule_reminder",
-    description="Simple once/daily reminder.",
-    props={"title": {"type": "string"}, "message": {"type": "string"}, "time_of_day": {"type": "string"}, "repeat": {"type": "string", "enum": ["once", "daily"]}, "timezone": {"type": "string"}},
-    required=["title", "message", "time_of_day"],
-    domain="scheduling",
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["schedule_reminder"])
 def schedule_reminder(
     title: str,
     message: str,
@@ -132,29 +101,14 @@ def schedule_reminder(
         return f"[reminder failed: {e}]"
 
 
-@tool(
-    name="list_reminders",
-    description="List reminders.",
-    props={"include_disabled": {"type": "boolean"}},
-    domain="scheduling",
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["list_reminders"])
 def list_reminders(include_disabled: bool = False, user_id: str | None = None) -> str:
     """List reminders stored in Aiko's local reminder file."""
     reminders = list_reminder_records(include_disabled=include_disabled, user_id=user_id)
     return json_block("reminders", {"count": len(reminders), "items": reminders})
 
 
-@tool(
-    name="cancel_reminder",
-    description="Cancel reminder by id.",
-    props={"reminder_id": {"type": "string"}},
-    required=["reminder_id"],
-    domain="scheduling",
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["cancel_reminder"])
 def cancel_reminder(reminder_id: str, user_id: str | None = None) -> str:
     """Cancel/disable a local reminder by id."""
     if cancel_reminder_record(reminder_id, user_id=user_id):

--- a/agentic/toolkit/photography.py
+++ b/agentic/toolkit/photography.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 from system.bioclock import local_now
 from agentic.toolkit.common import json_block, now_stamp, safe_path, slugify, workspace_root
-from agentic.registry import tool
+from agentic.registry import TOOLS, tool
 
 IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".tif", ".tiff", ".webp", ".heic", ".dng", ".cr2", ".cr3", ".nef", ".arw", ".orf", ".rw2"}
 VIDEO_EXTENSIONS = {".mp4", ".mov", ".webm", ".mkv", ".avi", ".m4v"}
@@ -46,14 +46,7 @@ def _image_files(root: Path, limit: int | None = None) -> list[Path]:
     return _files_with_extensions(root, IMAGE_EXTENSIONS, limit)
 
 
-@tool(
-    name="scan_photo_workspace",
-    description="Scan a workspace photo inbox for wildlife/nature/astro image files.",
-    props={"inbox": {"type": "string", "description": "Workspace-relative inbox path, default photos/inbox."}, "limit": {"type": "integer"}},
-    domain="photo",
-    react=True,
-    graph=False,
-)
+@tool(TOOLS["scan_photo_workspace"])
 def scan_photo_workspace(inbox: str = DEFAULT_PHOTO_INBOX, limit: int = 100) -> str:
     """Scan a workspace photo inbox for image files Aiko can ingest."""
     try:
@@ -96,14 +89,7 @@ def scan_video_workspace(inbox: str = DEFAULT_VIDEO_INBOX, limit: int = 100) -> 
         return f"[video scan failed: {e}]"
 
 
-@tool(
-    name="propose_photo_ingestion",
-    description="Create a safe dry-run ingestion plan for photo files without moving or editing metadata.",
-    props={"inbox": {"type": "string"}, "library_root": {"type": "string"}, "rating_rule": {"type": "string"}},
-    domain="photo",
-    react=False,
-    graph=True,
-)
+@tool(TOOLS["propose_photo_ingestion"])
 def propose_photo_ingestion(inbox: str = DEFAULT_PHOTO_INBOX, library_root: str = "photos/library", rating_rule: str = "manual-review-first") -> str:
     """Create a safe dry-run ingestion plan for untracked photos."""
     try:
@@ -134,14 +120,7 @@ def propose_photo_ingestion(inbox: str = DEFAULT_PHOTO_INBOX, library_root: str 
         return f"[photo ingestion proposal failed: {e}]"
 
 
-@tool(
-    name="write_photo_ingestion_report",
-    description="Write a photo workflow report under the workspace reports folder.",
-    props={"title": {"type": "string"}, "content": {"type": "string"}, "report_dir": {"type": "string"}},
-    domain="photo",
-    react=False,
-    graph=True,
-)
+@tool(TOOLS["write_photo_ingestion_report"])
 def write_photo_ingestion_report(title: str = "photo-ingestion", content: str = "", report_dir: str = DEFAULT_PHOTO_REPORTS) -> str:
     """Write a photo workflow report under the workspace report folder."""
     try:

--- a/agentic/toolkit/plan.py
+++ b/agentic/toolkit/plan.py
@@ -21,19 +21,10 @@ from datetime import datetime
 
 from system.bioclock import local_now
 from agentic.toolkit.common import MAX_READ_CHARS, MAX_WRITE_CHARS, json_block, notes_dir, now_stamp, safe_path, slugify
-from agentic.registry import tool
+from agentic.registry import TOOLS, tool
 
 
-@tool(
-    name="make_plan",
-    description="Make plan.",
-    props={"goal": {"type": "string"}, "constraints": {"type": "string"}, "max_steps": {"type": "integer"}},
-    required=["goal"],
-    domain="planning",
-    always_on=True,
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["make_plan"])
 def make_plan(goal: str, constraints: str = "", max_steps: int = 8) -> str:
     """Create a pragmatic step-by-step plan for a real-world or digital task."""
     max_steps = max(3, min(max_steps, 12))
@@ -55,16 +46,7 @@ def make_plan(goal: str, constraints: str = "", max_steps: int = 8) -> str:
     })
 
 
-@tool(
-    name="create_checklist",
-    description="Make checklist.",
-    props={"title": {"type": "string"}, "items": {"type": "string", "description": "Newline-separated checklist items."}},
-    required=["title", "items"],
-    domain="planning",
-    always_on=True,
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["create_checklist"])
 def create_checklist(title: str, items: list[str] | str) -> str:
     """Build a markdown checklist from a list or newline-separated string."""
     if isinstance(items, str):
@@ -78,16 +60,7 @@ def create_checklist(title: str, items: list[str] | str) -> str:
     return "\n".join(markdown)
 
 
-@tool(
-    name="save_note",
-    description="Save a note to a workspace file. content MUST be plain text only, under 400 characters. No markdown tables, no bullet lists, no backticks, no quotes. Write a brief plain-text summary only.",
-    props={"title": {"type": "string", "description": "Short filename title."}, "content": {"type": "string", "description": "Plain text only. Max 400 chars. No markdown."}, "folder": {"type": "string", "description": "Subfolder, default: notes"}},
-    required=["title", "content"],
-    domain="planning",
-    always_on=True,
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["save_note"])
 def save_note(title: str, content: str, folder: str = "notes") -> str:
     """Save a note, plan, draft, or task artifact under WORKSPACE_ROOT."""
     base = notes_dir() if folder == "notes" else safe_path(folder)
@@ -99,16 +72,7 @@ def save_note(title: str, content: str, folder: str = "notes") -> str:
     return json_block("note saved", {"path": str(path), "chars": len(body)})
 
 
-@tool(
-    name="read_workspace_file",
-    description="Read workspace file.",
-    props={"relative_path": {"type": "string"}},
-    required=["relative_path"],
-    domain="planning",
-    always_on=True,
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["read_workspace_file"])
 def read_workspace_file(relative_path: str, max_chars: int = MAX_READ_CHARS) -> str:
     """Read a text file from WORKSPACE_ROOT for continuation or review."""
     try:
@@ -120,16 +84,7 @@ def read_workspace_file(relative_path: str, max_chars: int = MAX_READ_CHARS) -> 
         return f"[read failed: {e}]"
 
 
-@tool(
-    name="summarize_task_state",
-    description="Summarize task state.",
-    props={"goal": {"type": "string"}, "done": {"type": "string"}, "next_action": {"type": "string"}, "risks": {"type": "string"}},
-    required=["goal"],
-    domain="planning",
-    always_on=True,
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["summarize_task_state"])
 def summarize_task_state(goal: str, done: str = "", next_action: str = "", risks: str = "") -> str:
     """Produce a compact task-state snapshot."""
     return textwrap.dedent(f"""

--- a/agentic/toolkit/reports.py
+++ b/agentic/toolkit/reports.py
@@ -20,7 +20,7 @@ from pathlib import Path
 
 from agentic.toolkit.common import json_block
 from system.userspace import user_state_dir
-from agentic.registry import tool
+from agentic.registry import TOOLS, tool
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
@@ -50,27 +50,7 @@ def _report_path(title: str, report_dir: str) -> Path:
     return folder / f"{_slugify(title)}.md"
 
 
-@tool(
-    name="write_report",
-    description=(
-        "Write (or append a section to) one polished long-form markdown report "
-        "under the workspace reports folder. Use for a single coherent "
-        "deliverable — architecture review, paper comparison, improvement "
-        "proposal — not short scratch notes (save_note) or retrievable knowledge "
-        "(learn_knowledge). For arxiv_style, call once per section across "
-        "multiple turns with append=true, using the same title each time."
-    ),
-    props={
-        "title": {"type": "string"}, "content": {"type": "string"},
-        "report_dir": {"type": "string"}, "arxiv_style": {"type": "boolean"},
-        "section": {"type": "string", "description": "abstract|introduction|related_work|architecture|discussion|limitations|conclusion|references"},
-        "append": {"type": "boolean"},
-    },
-    required=["title"],
-    domain="reports",
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["write_report"])
 def write_report(
     title: str,
     content: str = "",

--- a/agentic/toolkit/research.py
+++ b/agentic/toolkit/research.py
@@ -45,7 +45,7 @@ import numpy as np
 
 from system.log import get_logger
 from agentic.graph_engine import PlanGraph, PlanNode, execute_graph
-from agentic.registry import tool
+from agentic.registry import TOOLS, tool
 from agentic.toolkit.websearch import (
     web_search,
     web_fetch,
@@ -428,16 +428,7 @@ def _build_adaptive_search_subgraph(query: str, tier: str, max_rounds: int | Non
     return PlanGraph(id="adaptive_search", name="Adaptive search", goal=query, nodes=tuple(nodes))
 
 
-@tool(
-    name="adaptive_search",
-    description="The default tool for any internet lookup. Adaptively searches, judges if snippets suffice, and only fetches full pages if needed.",
-    props={"query": {"type": "string"}},
-    required=["query"],
-    domain="research",
-    react=True,
-    graph=True,
-    wiki=True,
-)
+@tool(TOOLS["adaptive_search"])
 def adaptive_search(query: str, embedder=None, client=None, model: str | None = None,
                      max_rounds: int | None = None) -> str:
     if not query or not query.strip():
@@ -547,16 +538,7 @@ def _crawl4ai_fetch_many(urls: list[str], max_chars: int) -> dict[str, str]:
         return {}
 
 
-@tool(
-    name="deep_read",
-    description="Fetch and extract content from one EXACT known URL. Handles HTML pages (with JS-render escalation), PDFs, DOCX, PPTX, XLSX, EPUB, CSV, and more. Use when you already have the specific URL to read — not for discovery (use adaptive_search for that).",
-    props={"url": {"type": "string", "description": "The exact URL to fetch and read."}, "query": {"type": "string", "description": "Optional focus query — if given, content is relevance-filtered to what matters for this question."}},
-    required=["url"],
-    domain="research",
-    react=True,
-    graph=True,
-    wiki=True,
-)
+@tool(TOOLS["deep_read"])
 def deep_read(
     url: str,
     query: str = "",
@@ -1157,16 +1139,7 @@ def _build_deep_research_subgraph(query: str, session_id: str,
     return PlanGraph(id="deep_research", name="Deep research", goal=query, nodes=tuple(nodes))
 
 
-@tool(
-    name="deep_research",
-    description="Research tool that fetches and synthesizes full source pages from discovered URLs. Use when the research itself is the deliverable or for deep/thorough self-learning.",
-    props={"query": {"type": "string", "description": "The research question. Can be broader/less scoped since the tool refines it internally."}},
-    required=["query"],
-    domain="research",
-    react=True,
-    graph=True,
-    wiki=True,
-)
+@tool(TOOLS["deep_research"])
 def deep_research(query: str, embedder=None, client=None, model: str | None = None,
                          max_rounds: int = DEEP_RESEARCH_MAX_ROUNDS, tool_mode: bool = False) -> str:
     """Public entry point — drop-in replacement for research.py's

--- a/agentic/toolkit/self_improve.py
+++ b/agentic/toolkit/self_improve.py
@@ -18,7 +18,7 @@ from itertools import islice
 from pathlib import Path
 
 from agentic.toolkit.common import json_block
-from agentic.registry import tool
+from agentic.registry import TOOLS, tool
 
 REPO_ROOT = Path(__file__).resolve().parents[2]    # repo directory (the first 2 hierachy directories of this file)
 MAX_REPO_READ_CHARS = 20_000                       # the characters allowed to be read in the repo
@@ -28,14 +28,7 @@ _SKIP_DIRS = {".git", ".venv", "venv", "__pycache__", ".pytest_cache", "node_mod
 
 # ── Public API ──────────────────────────────────────────────────────────
 
-@tool(
-    name="repo_file_tree",
-    description="List repository text files for Aiko architecture/code navigation.",
-    props={"prefix": {"type": "string"}, "limit": {"type": "integer"}},
-    domain="repo",
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["repo_file_tree"])
 def repo_file_tree(prefix: str = "", limit: int = 200) -> str:
     """List repository text files for architecture/code navigation."""
     try:
@@ -56,15 +49,7 @@ def repo_file_tree(prefix: str = "", limit: int = 200) -> str:
         return f"[repo tree failed: {e}]"
 
 
-@tool(
-    name="repo_read_file",
-    description="Read one repository text file for architecture/code work.",
-    props={"relative_path": {"type": "string"}, "max_chars": {"type": "integer"}},
-    required=["relative_path"],
-    domain="repo",
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["repo_read_file"])
 def repo_read_file(relative_path: str, max_chars: int = MAX_REPO_READ_CHARS) -> str:
     """Read one repository text file without permitting path traversal."""
     try:
@@ -78,15 +63,7 @@ def repo_read_file(relative_path: str, max_chars: int = MAX_REPO_READ_CHARS) -> 
         return f"[repo read failed: {e}]"
 
 
-@tool(
-    name="repo_search_text",
-    description="Search repository text files with simple substring matching.",
-    props={"query": {"type": "string"}, "prefix": {"type": "string"}, "limit": {"type": "integer"}},
-    required=["query"],
-    domain="repo",
-    react=True,
-    graph=True,
-)
+@tool(TOOLS["repo_search_text"])
 def repo_search_text(query: str, prefix: str = "", limit: int = 50) -> str:
     """Search repository text files with simple case-insensitive substring matching."""
     try:

--- a/agentic/toolkit/social.py
+++ b/agentic/toolkit/social.py
@@ -1886,32 +1886,16 @@ def _resolve_contained_draft_dir(draft_dir: str | Path, allowed_root: Path) -> P
     return resolved
 
 
-from agentic.registry import tool
+from agentic.registry import TOOLS, tool
 
 
-@tool(
-    name="draft_job_post_social",
-    description="Create a Vancouver-area daily job-post draft for Meta Threads review. Does NOT post anything.",
-    props={"force": {"type": "boolean", "description": "Create a new draft even if one already exists for today."}},
-    domain="social",
-    react=True,
-    graph=False,
-)
+@tool(TOOLS["draft_job_post_social"])
 def draft_job_post_social(*, force: bool = False) -> dict[str, Any]:
     """Create a daily Vancouver-area job-post draft for Meta Threads review."""
     return generate_daily_job_post_draft(force=force)
 
 
-@tool(
-    name="post_job_post_social",
-    description="Post an ALREADY HUMAN-APPROVED daily job-post draft to Meta Threads only. Will refuse unless a person has approved this exact draft outside this conversation.",
-    props={"draft_dir": {"type": "string", "description": "The draft_dir path returned by draft_job_post_social or given by the user."}},
-    required=["draft_dir"],
-    domain="social",
-    react=True,
-    graph=True,
-    wiki=True,
-)
+@tool(TOOLS["post_job_post_social"])
 def post_job_post_social(draft_dir: str) -> dict[str, Any]:
     """Post a human-approved daily job-post draft to Meta Threads only."""
     try:
@@ -1940,29 +1924,13 @@ def post_weekly_social(draft_dir: str, providers: tuple[str, ...] | None = None)
     return post_draft(path, providers=providers)
 
 
-@tool(
-    name="draft_photo_social",
-    description="Scan the photo inbox, caption and curate candidates, and create an Instagram photo draft bundle for human review. Does NOT post anything.",
-    props={"inbox": {"type": "string", "description": "Optional workspace-relative photo inbox override."}, "force": {"type": "boolean", "description": "Create a new draft even if one already exists for this run."}},
-    domain="social",
-    react=True,
-    graph=False,
-)
+@tool(TOOLS["draft_photo_social"])
 def draft_photo_social(*, inbox: str | None = None, force: bool = False) -> dict[str, Any]:
     """Agent-tool wrapper for Lane B draft generation."""
     return generate_photo_draft(inbox=inbox, force=force)
 
 
-@tool(
-    name="post_photo_social",
-    description="Post an ALREADY HUMAN-APPROVED photo draft to Instagram. Will refuse (ok=false) unless a person has approved this exact draft outside this conversation, and refuses to post the same draft twice. Only call when the user explicitly asks to publish/post the draft now.",
-    props={"draft_dir": {"type": "string", "description": "The draft_dir path returned by draft_photo_social or given by the user."}, "providers": {"type": "array", "items": {"type": "string", "enum": ["instagram"]}}},
-    required=["draft_dir"],
-    domain="social",
-    react=True,
-    graph=True,
-    wiki=True,
-)
+@tool(TOOLS["post_photo_social"])
 def post_photo_social(draft_dir: str, providers: tuple[str, ...] | None = None) -> dict[str, Any]:
     """Agent-tool wrapper for Lane B posting. Refuses unless the draft at
     draft_dir has already been human-approved outside this conversation."""
@@ -1974,30 +1942,14 @@ def post_photo_social(draft_dir: str, providers: tuple[str, ...] | None = None) 
     return post_photo_draft(path, providers=providers)
 
 
-@tool(
-    name="draft_video_social",
-    description="Queue the oldest not-yet-drafted video in the video inbox that already has a matching NAME.md description file, polishing it into a YouTube title/description for human review. Does NOT post, and does NOT choose which video — dropping the file with its description IS the selection.",
-    props={"inbox": {"type": "string", "description": "Optional workspace-relative video inbox override."}},
-    domain="social",
-    react=True,
-    graph=False,
-)
+@tool(TOOLS["draft_video_social"])
 def draft_video_social(*, inbox: str | None = None) -> dict[str, Any]:
     """Agent-tool wrapper for Lane C draft generation (queues the oldest
     described video in the inbox)."""
     return generate_video_draft(inbox=inbox)
 
 
-@tool(
-    name="post_video_social",
-    description="Post an ALREADY HUMAN-APPROVED video draft to YouTube. Will refuse (ok=false) unless a person has approved this exact draft outside this conversation, and refuses to post the same draft twice. Only call when the user explicitly asks to publish/post the draft now.",
-    props={"draft_dir": {"type": "string", "description": "The draft_dir path returned by draft_video_social or given by the user."}, "providers": {"type": "array", "items": {"type": "string", "enum": ["youtube"]}}},
-    required=["draft_dir"],
-    domain="social",
-    react=True,
-    graph=True,
-    wiki=True,
-)
+@tool(TOOLS["post_video_social"])
 def post_video_social(draft_dir: str, providers: tuple[str, ...] | None = None) -> dict[str, Any]:
     """Agent-tool wrapper for Lane C posting. Refuses unless the draft at
     draft_dir has already been human-approved outside this conversation."""

--- a/agentic/toolkit/synthesize.py
+++ b/agentic/toolkit/synthesize.py
@@ -67,7 +67,7 @@ import re
 
 from system.log import get_logger
 from agentic.toolkit.research import condense_evidence
-from agentic.registry import tool
+from agentic.registry import TOOLS, tool
 
 log = get_logger(__name__)
 
@@ -209,14 +209,7 @@ def split_subjects(prompt: str) -> list[str]:
     return parts[:6] if len(parts) >= 2 else []
 
 
-@tool(
-    name="combine_evidence",
-    description="Concatenate non-empty evidence blocks with a visible separator.",
-    props={"parts": {"type": "array", "items": {"type": "string"}}, "separator": {"type": "string"}},
-    domain="reports",
-    react=False,
-    graph=True,
-)
+@tool(TOOLS["combine_evidence"])
 def combine_evidence(parts: list[str], separator: str = "\n\n---\n\n", *, part_max_chars: int = DEFAULT_COMBINE_PART_MAX_CHARS, max_chars: int = DEFAULT_COMBINE_MAX_CHARS) -> str:
     """Concatenate non-empty evidence blocks with a visible separator.
 
@@ -243,14 +236,7 @@ def combine_evidence(parts: list[str], separator: str = "\n\n---\n\n", *, part_m
     )
 
 
-@tool(
-    name="condense_text",
-    description="Condense a long evidence block to its most query-relevant chunks.",
-    props={"text": {"type": "string"}, "query": {"type": "string"}, "max_chars": {"type": "integer"}},
-    domain="reports",
-    react=False,
-    graph=True,
-)
+@tool(TOOLS["condense_text"])
 def condense_text(
     text: str,
     query: str,
@@ -296,15 +282,7 @@ def condense_text(
         return text[:max_chars]
 
 
-@tool(
-    name="kb_search",
-    description="Search Aiko's learned-knowledge RAG store for relevant context.",
-    props={"query": {"type": "string"}, "max_chars": {"type": "integer"}},
-    required=["query"],
-    domain="kb",
-    react=False,
-    graph=True,
-)
+@tool(TOOLS["kb_search"])
 def kb_search(
     query: str,
     *,
@@ -349,15 +327,7 @@ def kb_search(
     return result
 
 
-@tool(
-    name="learn_report",
-    description="Ingest a synthesized report into Aiko's learned-knowledge RAG store.",
-    props={"title": {"type": "string"}, "text": {"type": "string"}, "kind": {"type": "string"}},
-    required=["title", "text"],
-    domain="kb",
-    react=False,
-    graph=True,
-)
+@tool(TOOLS["learn_report"])
 def learn_report(
     title: str,
     text: str,
@@ -447,19 +417,7 @@ def _format_comparison_block(subjects: list[str]) -> str:
     )
 
 
-@tool(
-    name="synthesize_report",
-    description="Produce a synthesized long-form report from combined evidence.",
-    props={
-        "evidence": {"type": "string"},
-        "prompt": {"type": "string"},
-        "style": {"type": "string"},
-        "max_tokens": {"type": "integer"},
-    },
-    domain="reports",
-    react=False,
-    graph=True,
-)
+@tool(TOOLS["synthesize_report"])
 def synthesize_report(
     evidence: str,
     prompt: str,
@@ -570,14 +528,7 @@ def synthesize_report(
     return text
 
 
-@tool(
-    name="polish_text",
-    description="Rewrite an already-synthesized draft in the requested style.",
-    props={"text": {"type": "string"}, "style": {"type": "string"}, "max_tokens": {"type": "integer"}},
-    domain="reports",
-    react=False,
-    graph=True,
-)
+@tool(TOOLS["polish_text"])
 def polish_text(
     text: str,
     *,

--- a/agentic/tools.py
+++ b/agentic/tools.py
@@ -3,12 +3,10 @@ agentic/tools.py
 
 Compatibility facade for Aiko's autonomous toolkit.
 
-This module provides a stable import surface for all tools. The @tool
-decorator in each toolkit module is the runtime source of truth for tool
-metadata and handlers; this file imports those modules so their decorators run.
-
-config/tools.yaml is generated documentation only. Do not load it at runtime,
-because doing so creates a second registry path that can drift from decorators.
+This module provides a stable import surface for all tools. Tool metadata is
+loaded from config/tools.yaml by agentic.registry, and each toolkit module binds
+that metadata to its Python handler with @tool(TOOLS["tool_name"]). Importing
+this facade imports those modules so their decorators run.
 """
 from __future__ import annotations
 

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -1,6 +1,6 @@
-# Generated tool catalog for Aiko's agentic toolkit.
-# Runtime source of truth: @tool decorators.
-# Regenerate with: python util/export_tools_catalog.py
+# Declarative tool catalog for Aiko's agentic toolkit.
+# Runtime source of truth for @tool decorator metadata.
+# Normalize with: python util/export_tools_catalog.py
 {
   "tools": [
     {

--- a/system/config.py
+++ b/system/config.py
@@ -77,13 +77,17 @@ def _load_yaml_mapping(path: Path) -> dict[str, Any]:
     if yaml is not None:
         data = yaml.safe_load(text)
     else:
-        uncommented = "\n".join(
-            line for line in text.splitlines()
-            if not line.lstrip().startswith("#")
-        )
-        stripped = uncommented.lstrip()
+        lines = text.splitlines()
+        start = 0
+        for index, line in enumerate(lines):
+            stripped_line = line.lstrip()
+            if stripped_line and not stripped_line.startswith("#"):
+                start = index
+                break
+        body = "\n".join(lines[start:])
+        stripped = body.lstrip()
         if stripped.startswith("{") or stripped.startswith("["):
-            data = json.loads(uncommented)
+            data = json.loads(body)
         else:
             data = _simple_yaml_load(text)
     return data or {}

--- a/system/config.py
+++ b/system/config.py
@@ -42,12 +42,7 @@ def _strip_comment(line: str) -> str:
 
 
 def _simple_yaml_load(text: str) -> dict[str, Any]:
-    """Tiny fallback parser for Aiko's simple config/*.yaml files.
-
-    It supports top-level KEY: VALUE pairs and the config/index.yaml list used
-    during bootstrap. Full YAML support is still provided by PyYAML when
-    installed, which is the normal runtime path.
-    """
+    """Tiny fallback parser for Aiko's simple config/*.yaml files."""
     data: dict[str, Any] = {}
     current_key: str | None = None
     pending_empty: set[str] = set()
@@ -58,7 +53,6 @@ def _simple_yaml_load(text: str) -> dict[str, Any]:
         stripped = line.strip()
         if stripped.startswith("-") and current_key:
             if current_key in pending_empty:
-                # First list item seen: this key was a list all along.
                 data[current_key] = []
                 pending_empty.discard(current_key)
             data.setdefault(current_key, []).append(stripped[1:].strip().strip('"\''))
@@ -70,9 +64,6 @@ def _simple_yaml_load(text: str) -> dict[str, Any]:
         value = value.strip()
         current_key = key
         if value == "":
-            # Ambiguous: could be an unset scalar or the start of a list.
-            # Default to "unset" (empty string) and only promote to a list
-            # if `-` items actually follow.
             data[key] = ""
             pending_empty.add(key)
         else:
@@ -83,118 +74,30 @@ def _simple_yaml_load(text: str) -> dict[str, Any]:
 
 def _load_yaml_mapping(path: Path) -> dict[str, Any]:
     text = path.read_text(encoding="utf-8")
-    data = yaml.safe_load(text) if yaml is not None else _simple_yaml_load(text)
+    if yaml is not None:
+        data = yaml.safe_load(text)
+    else:
+        uncommented = "\n".join(
+            line for line in text.splitlines()
+            if not line.lstrip().startswith("#")
+        )
+        stripped = uncommented.lstrip()
+        if stripped.startswith("{") or stripped.startswith("["):
+            data = json.loads(uncommented)
+        else:
+            data = _simple_yaml_load(text)
     return data or {}
 
 
-def load_yaml(path: Path) -> dict[str, Any]:
-    """Load a YAML file from the given path.
-    
-    Args:
-        path: Path to the YAML file (absolute or relative to config dir).
-        
-    Returns:
-        Parsed YAML content as a dictionary.
-        
-    Raises:
-        FileNotFoundError: If the file doesn't exist.
-        ValueError: If the YAML is invalid.
-    """
+def load_yaml(path: str | Path) -> dict[str, Any]:
+    """Load a YAML file from the given path."""
     path = Path(path)
     if not path.is_absolute():
-        # Default to config directory
         path = Path(__file__).parent.parent / "config" / path
     return _load_yaml_mapping(path)
 
 
 def _stringify(value: Any) -> str:
-    if value is None:
-        return ""
-    if isinstance(value, bool):
-        return "1" if value else "0"
-    if isinstance(value, (list, tuple)):
-        return json.dumps([str(item) for item in value], ensure_ascii=False)
-    return str(value)
-
-
-def load_tools_from_yaml(yaml_path: str, tool_handlers: Dict[str, Callable[..., Any]] | None = None) -> int:
-    """Load tool definitions from YAML file and register them in the global registry.
-
-    Args:
-        yaml_path: Path to tools.yaml file (relative to config dir or absolute)
-        tool_handlers: Optional dict mapping tool names to handler functions.
-                       If provided, functions are bound from here instead of
-                       importing modules dynamically.
-
-    Returns:
-        Number of tools successfully registered.
-
-    YAML format:
-    tools:
-      - name: "tool_name"
-        description: "Tool description"
-        handler: "module.path:function_name"  # optional, if not in tool_handlers
-        props: {...}
-        required: [...]
-        domain: "research"
-        react: true
-        graph: false
-        wiki: false
-        skill: false
-        always_on: false
-    """
-    from agentic.registry import registry, register_tool_schema
-
-    # Use config's load_yaml which handles path resolution
-    data = load_yaml(yaml_path)
-
-    if "tools" not in data:
-        raise ValueError("YAML must contain a 'tools' list")
-
-    tool_handlers = tool_handlers or {}
-    registered = 0
-
-    for tool_def in data["tools"]:
-        name = tool_def.get("name")
-        if not name:
-            continue
-
-        # Get handler
-        handler = None
-        if name in tool_handlers:
-            handler = tool_handlers[name]
-        elif "handler" in tool_def:
-            handler_path = tool_def["handler"]
-            try:
-                module_path, func_name = handler_path.rsplit(":", 1)
-                module = __import__(module_path, fromlist=[func_name])
-                handler = getattr(module, func_name)
-            except (ImportError, AttributeError, ValueError) as e:
-                print(f"Warning: Could not load handler for {name}: {e}")
-                continue
-
-        # Register
-        from agentic.registry import register_tool_schema
-        register_tool_schema(
-            name=tool_def["name"],
-            description=tool_def["description"],
-            props=tool_def.get("props"),
-            required=tool_def.get("required"),
-            domain=tool_def.get("domain"),
-            always_on=tool_def.get("always_on", False),
-            react=tool_def.get("react", True),
-            graph=tool_def.get("graph", False),
-            wiki=tool_def.get("wiki", False),
-            skill=tool_def.get("skill", False),
-        )
-        # If we have a handler, bind it to the registry
-        if handler is not None:
-            from agentic.registry import registry
-            registry._tools[tool_def["name"]].handler = handler
-
-        registered += 1
-
-    return registered
     if value is None:
         return ""
     if isinstance(value, bool):

--- a/util/export_tools_catalog.py
+++ b/util/export_tools_catalog.py
@@ -1,9 +1,9 @@
-"""Export decorated tool metadata to config/tools.yaml without importing runtime deps."""
+"""Normalize declarative tool metadata from config/tools.yaml."""
 from __future__ import annotations
 
 import argparse
-import ast
 import json
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -13,70 +13,45 @@ except ImportError:  # pragma: no cover
     yaml = None
 
 ROOT = Path(__file__).resolve().parents[1]
-
-
-def _literal(node: ast.AST) -> Any:
-    try:
-        return ast.literal_eval(node)
-    except Exception:
-        return ast.unparse(node)
-
-
-def _decorator_name(dec: ast.AST) -> str | None:
-    if isinstance(dec, ast.Call):
-        dec = dec.func
-    if isinstance(dec, ast.Name):
-        return dec.id
-    if isinstance(dec, ast.Attribute):
-        return dec.attr
-    return None
-
-
-def _module_path(path: Path) -> str:
-    return ".".join(path.relative_to(ROOT).with_suffix("").parts)
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
 
 
 def discover_tools() -> dict[str, Any]:
-    tools: list[dict[str, Any]] = []
-    for path in sorted((ROOT / "agentic").rglob("*.py")):
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        module = _module_path(path)
-        for node in ast.walk(tree):
-            if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
-                continue
-            for dec in node.decorator_list:
-                if not isinstance(dec, ast.Call) or _decorator_name(dec) != "tool":
-                    continue
-                entry: dict[str, Any] = {"handler": f"{module}:{node.name}"}
-                positional = list(dec.args)
-                if positional:
-                    entry["name"] = _literal(positional.pop(0))
-                if positional:
-                    entry["description"] = _literal(positional.pop(0))
-                for kw in dec.keywords:
-                    if kw.arg is not None:
-                        entry[kw.arg] = _literal(kw.value)
-                entry.setdefault("react", True)
-                entry.setdefault("graph", False)
-                entry.setdefault("wiki", False)
-                entry.setdefault("skill", False)
-                entry.setdefault("name", node.name)
-                tools.append(entry)
-    tools.sort(key=lambda item: item["name"])
-    return {"tools": tools}
+    """Load and sort the declarative tool catalog.
+
+    Tool metadata now lives in config/tools.yaml and toolkit decorators consume
+    that metadata with @tool(TOOLS["tool_name"]). This utility remains useful
+    as a normalizer/drift-safe formatter after editing the YAML by hand.
+    """
+    from system.config import load_yaml
+
+    data = load_yaml("tools.yaml")
+    tools = data.get("tools", [])
+    if not isinstance(tools, list):
+        raise ValueError("config/tools.yaml must contain a 'tools' list")
+    normalized: list[dict[str, Any]] = []
+    for entry in tools:
+        if not isinstance(entry, dict) or not entry.get("name"):
+            continue
+        item = dict(entry)
+        item.setdefault("react", True)
+        item.setdefault("graph", False)
+        item.setdefault("wiki", False)
+        item.setdefault("skill", False)
+        normalized.append(item)
+    normalized.sort(key=lambda item: item["name"])
+    return {"tools": normalized}
 
 
 def _dump(data: dict[str, Any]) -> str:
     header = (
-        "# Generated tool catalog for Aiko's agentic toolkit.\n"
-        "# Runtime source of truth: @tool decorators.\n"
-        "# Regenerate with: python util/export_tools_catalog.py\n"
+        "# Declarative tool catalog for Aiko's agentic toolkit.\n"
+        "# Runtime source of truth for @tool decorator metadata.\n"
+        "# Normalize with: python util/export_tools_catalog.py\n"
     )
     if yaml is None:
-        raise RuntimeError(
-            "PyYAML is required to generate config/tools.yaml. "
-            "Install with: pip install pyyaml"
-        )
+        return header + json.dumps(data, indent=2, ensure_ascii=False) + "\n"
     return header + yaml.safe_dump(data, sort_keys=False, allow_unicode=True)
 
 


### PR DESCRIPTION
### Motivation
- Reduce per-tool boilerplate by using a single declarative catalog loaded at runtime and let toolkit modules look up metadata by name. 
- Make adding new tools simpler: add a YAML entry + implement a handler, instead of creating per-tool Python constants.

### Description
- Load the declarative tool catalog from `config/tools.yaml` inside `agentic/registry.py` via `load_tool_catalog()` and expose a name-keyed `TOOLS: dict[str, ToolSpec]` for runtime lookup.  
- Extend the `@tool` decorator to accept either a `ToolSpec` (preferred) — e.g. `@tool(TOOLS["make_plan"])` — or the legacy `@tool(name, description, ...)` form for compatibility.  
- Replace generated per-tool uppercase config constants/usages with direct `@tool(TOOLS["..."])` decorator lookups across toolkit modules and update the tools facade and exporter comments to reflect the new workflow.  
- Remove the temporary `ToolConfig` dataclass and the uppercase per-tool globals from `system.config`, keeping `system.config` focused on YAML loading utilities, and update `util/export_tools_catalog.py` to be a normalizer for the declarative `config/tools.yaml`.

### Testing
- `python -m py_compile system/config.py agentic/registry.py $(rg --files agentic -g '*.py') util/export_tools_catalog.py` — succeeded.  
- Small runtime validation: ran a Python snippet that loaded `TOOLS['make_plan']` and confirmed the registry bound `make_plan` handler to the function — succeeded.  
- `python util/export_tools_catalog.py` — ran the normalizer which wrote/normalized `config/tools.yaml` successfully.  
- `pytest tests/unit/test_config.py tests/unit/test_agentic_registry.py -q` — could not run to completion due to environment limitations (`numpy` missing) and an unavailable local wheel, so unit tests were blocked by the test environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a67f4fa95b483288ce35d3b1d490a4d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool metadata is now managed through a centralized declarative catalog.
  * Tool configuration can be loaded from YAML with broader format support.

* **Improvements**
  * Updated tool registrations across agent capabilities to use consistent shared metadata.
  * Catalog export tooling now preserves declarative definitions and supports fallback output formatting.

* **Documentation**
  * Updated descriptions and headers to reflect the declarative tool catalog workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->