### PR TITLE
Update messenger adapters and social publishing lanes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,31 +48,27 @@ THREADS_USER_ID=<Threads User ID>
 THREADS_ACCESS_TOKEN=<Threads Access Token>
 IMGBB_API_KEY=<Your ImgBB API key>
 
-# IG_ACCESS_TOKEN:
-#   Instagram Graph API long-lived access token used by agentic/toolkit/social.py.
-#   Get one from your Meta app's Graph API Explorer with the
-#   instagram_basic, instagram_content_publish, pages_read_engagement,
-#   and pages_manage_ads permissions.
-#
-# IG_BUSINESS_ACCOUNT_ID:
-#   Numeric Instagram Business/Creator account ID used alongside IG_ACCESS_TOKEN.
-#   Find it via the /me/accounts Graph API endpoint or your Meta Business Suite.
-#
-# IG_API_BASE:
-#   Base URL for Instagram Graph API calls. Defaults to
-#   https://graph.facebook.com/v21.0 in social.py, which matches the classic
-#   Facebook Login + linked Page flow (IG_ACCESS_TOKEN generated via Graph API
-#   Explorer, IG_BUSINESS_ACCOUNT_ID from /me/accounts).
-#
-#   If instead your IG_ACCESS_TOKEN was generated through the newer
-#   "Instagram API with Instagram business login" product (Generate token
-#   button under the Instagram product's own setup page, no Facebook Page
-#   required), set this to https://graph.instagram.com instead — tokens and
-#   account IDs from that flow are NOT valid against graph.facebook.com.
-#
-IG_ACCESS_TOKEN=<Your Instagram access token>
-IG_BUSINESS_ACCOUNT_ID=<Your Instagram Business Account ID>
-IG_API_BASE=https://graph.instagram.com
+# PIXELSET_INSTANCE / PIXELSET_ACCESS_TOKEN:
+#   Pixelset/Pixelfed-compatible instance and access token for Lane B photo posting via MCP.
+#   PIXELFED_* names are also accepted by the MCP tool as fallbacks.
+PIXELSET_INSTANCE=<https://your-pixelset-or-pixelfed-instance>
+PIXELSET_ACCESS_TOKEN=<Your Pixelset/Pixelfed Access Token>
+
+# AIKO_MESSENGER_ADAPTERS:
+#   Comma-separated two-way messenger adapters to run headlessly beside WebUI/CLI.
+#   Supported values: discord,telegram,slack,matrix.
+AIKO_MESSENGER_ADAPTERS=discord,telegram
+
+# Lane A1 Patreon dev-post syndication:
+#   Fetch newest Patreon post weekly, save review bundle, post full body to Reddit/Hugo,
+#   and teaser fanout via MCP post_social.
+PATREON_LATEST_POST_URL=
+AIKO_DEV_GITHUB_REPO=OppaAI/aiko-dev
+AIKO_DEV_GITHUB_BRANCH=main
+AIKO_DEV_HUGO_CONTENT_PATH=content/posts
+A1_FULL_PROVIDERS=reddit
+A1_TEASER_PROVIDERS=x,bluesky,mastodon,discord,threads
+A1_REDDIT_SUBREDDIT=OppaAI
 
 # YOUTUBE_CLIENT_ID / YOUTUBE_CLIENT_SECRET:
 #   YouTube Data API v3 OAuth 2.0 credentials from Google Cloud Console.
@@ -160,37 +156,6 @@ REDDIT_CLIENT_SECRET=<Your Reddit Client Secret>
 REDDIT_USERNAME=<Your Reddit Username>
 REDDIT_PASSWORD=<Your Reddit Password>
 REDDIT_USER_AGENT=Aiko-chan adapter v0.1
-
-# YouTube bot adapter (reuses existing YouTube streaming keys):
-#   YOUTUBE_CHANNEL_ID — your channel ID to filter out own messages
-#   (YOUTUBE_CLIENT_ID, YOUTUBE_CLIENT_SECRET, YOUTUBE_REFRESH_TOKEN
-#    are shared with the existing YouTube upload flow above)
-#
-YOUTUBE_CHANNEL_ID=<Your YouTube Channel ID>
-
-# Facebook Messenger credentials:
-#   FB_PAGE_ID           — your Facebook Page's numeric ID
-#   FB_PAGE_ACCESS_TOKEN — Page-scoped access token from Meta App > Messenger > Settings > Token
-#                         (generate one in Graph API Explorer with pages_messaging permission)
-#   FB_API_VERSION       — optional, defaults to v21.0
-#
-FB_PAGE_ID=<Your Facebook Page ID>
-FB_PAGE_ACCESS_TOKEN=<Your Page Access Token>
-FB_API_VERSION=v21.0
-
-# Google Chat credentials:
-#   GOOGLE_CHAT_SERVICE_ACCOUNT — path to service account JSON key file
-#   GOOGLE_CHAT_BOT_NAME        — the bot's display name in Google Chat spaces
-#
-#   Steps:
-#   1. Create a Google Cloud project, enable Google Chat API
-#   2. Create a service account, download JSON key
-#   3. In Google Workspace Admin Console, delegate domain-wide authority
-#      for scope https://www.googleapis.com/auth/chat.bot
-#   4. Publish the bot to your domain via Google Cloud Console > Google Chat API > Configuration
-#
-GOOGLE_CHAT_SERVICE_ACCOUNT=/path/to/service-account-key.json
-GOOGLE_CHAT_BOT_NAME=Aiko-chan
 
 # OAuth secrets
 # ALLOWED_GITHUB_USERS:
@@ -295,20 +260,6 @@ IMAGEGEN_URL=""
 # DISCORD_POST_WEBHOOK_URL=<channel webhook URL>
 # DISCORD_POST_CHANNEL_ID=<channel ID for bot posting>
 # DISCORD_API_BASE=https://discord.com/api/v10
-
-# ── Telegram posting (1-way via MCP) ───────────────────────────────────────
-# Uses the same TELEGRAM_BOT_TOKEN as the 2-way adapter.
-# TELEGRAM_POST_CHAT_ID=<target chat/channel ID>
-
-# ── Slack posting (1-way via MCP) ──────────────────────────────────────────
-# Set either SLACK_POST_WEBHOOK_URL (simpler) or SLACK_BOT_TOKEN + SLACK_POST_CHANNEL.
-# SLACK_POST_WEBHOOK_URL=<incoming webhook URL>
-# SLACK_POST_CHANNEL=<target channel name>
-
-# ── LinkedIn posting (1-way via MCP) ───────────────────────────────────────
-# OAuth 2.0 access token from LinkedIn Developer App.
-# LINKEDIN_ACCESS_TOKEN=<OAuth access token>
-# LINKEDIN_AUTHOR_ID=<your LinkedIn person URN ID>
 
 # ── Gmail API (1-way via MCP) ──────────────────────────────────────────────
 # OAuth 2.0 credentials from Google Cloud Console (Gmail API enabled).

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ If you find this project useful, consider buying me a coffee ☕
 ## Aiko social lanes (updated)
 
 - Two-way messenger adapters are native background services for WebUI/CLI sessions; only Telegram, Discord, Matrix, and Slack are supported for conversational ingress/egress. Standalone `--adapter` remains legacy-only for those four services.
-- Lane A1 syndicates the weekly Patreon Aiko development post on Saturdays at 18:00: full reposts go to Reddit r/OppaAI and the Hugo-backed GitHub Pages dev blog; short teasers go to X, Bluesky, Mastodon, Discord `#aiko_dev`, YouTube Community, and Threads when image hosting is available. Lane A2 manual posting remains out of Aiko.
+- Lane A1 syndicates the weekly Patreon Aiko development post on Saturdays at 18:00: full reposts go to Reddit r/OppaAI and the Hugo-backed GitHub Pages dev blog; short teasers go to X, Bluesky, Mastodon, Discord `#aiko_dev`, and Threads when image hosting is available. Lane A2 manual posting remains out of Aiko.
 - Lane B is the curated photo pipeline for Pixelset/Pixelfed-compatible posting through the social MCP server; Instagram is no longer a target.
 - Lane C YouTube video posting continues to use the existing MCP posting pipeline.
 - Lane D creates one tech-job Threads draft per night at 23:00 instead of multiple daily drafts, using the graph job-hunt playbook and web search results when available.

--- a/README.md
+++ b/README.md
@@ -326,3 +326,13 @@ Key architectural decisions:
 If you find this project useful, consider buying me a coffee ☕
 
 [![Ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/oppaai)
+
+## Aiko social lanes (updated)
+
+- Two-way messenger adapters are native background services for WebUI/CLI sessions; only Telegram, Discord, Matrix, and Slack are supported for conversational ingress/egress. Standalone `--adapter` remains legacy-only for those four services.
+- Lane A1 syndicates the weekly Patreon Aiko development post on Saturdays at 18:00: full reposts go to Reddit r/OppaAI and the Hugo-backed GitHub Pages dev blog; short teasers go to X, Bluesky, Mastodon, Discord `#aiko_dev`, YouTube Community, and Threads when image hosting is available. Lane A2 manual posting remains out of Aiko.
+- Lane B is the curated photo pipeline for Pixelset/Pixelfed-compatible posting through the social MCP server; Instagram is no longer a target.
+- Lane C YouTube video posting continues to use the existing MCP posting pipeline.
+- Lane D creates one tech-job Threads draft per night at 23:00 instead of multiple daily drafts, using the graph job-hunt playbook and web search results when available.
+- Removed social targets: LinkedIn, Facebook, Messenger, Google Chat, Instagram, and one-way Slack/Telegram MCP posting. Bluesky, Mastodon, Reddit, and YouTube are one-way posting tools only, not two-way adapters.
+- Nightly reflection remains native GitHub/Hugo publishing rather than MCP.

--- a/agentic/mcp_client/social_bridge.py
+++ b/agentic/mcp_client/social_bridge.py
@@ -28,11 +28,11 @@ def _adapter_post_threads(text: str, image_path: Path | None) -> dict[str, Any]:
     return _call_mcp("post_threads", text=text, image_path=str(image_path) if image_path else None)
 
 
-def _adapter_post_instagram(selections: list[dict[str, Any]]) -> dict[str, Any]:
+def _adapter_post_pixelset(selections: list[dict[str, Any]]) -> dict[str, Any]:
     if not selections:
-        return {"ok": False, "provider": "instagram", "error": "no selections"}
+        return {"ok": False, "provider": "pixelset", "error": "no selections"}
     sel = selections[0]
-    return _call_mcp("post_instagram", image_path=sel.get("media_path", ""), caption=sel.get("caption", ""))
+    return _call_mcp("post_social", services="pixelset", text=sel.get("caption", ""), image_path=sel.get("media_path", ""))
 
 
 def _adapter_post_youtube(sel: dict[str, Any]) -> dict[str, Any]:
@@ -51,7 +51,7 @@ def _adapter_post_threads_text(text: str, _image: Any = None) -> dict[str, Any]:
 MCP_ADAPTERS = {
     "x": _adapter_post_x,
     "threads": _adapter_post_threads,
-    "instagram": _adapter_post_instagram,
+    "pixelset": _adapter_post_pixelset,
     "youtube": _adapter_post_youtube,
 }
 
@@ -62,7 +62,7 @@ def patch_social_registries() -> None:
 
     social._WEEKLY_PROVIDERS_REGISTRY["x"] = _adapter_post_x
     social._WEEKLY_PROVIDERS_REGISTRY["threads"] = _adapter_post_threads
-    social._MEDIA_PROVIDERS_REGISTRY["instagram"] = _adapter_post_instagram
+    social._MEDIA_PROVIDERS_REGISTRY["pixelset"] = _adapter_post_pixelset
     social._VIDEO_PROVIDERS_REGISTRY["youtube"] = _adapter_post_youtube
 
     original_post_job = social.post_job_post_draft

--- a/agentic/toolkit/job_hunt.py
+++ b/agentic/toolkit/job_hunt.py
@@ -626,7 +626,7 @@ def execute_job_search_plan(plan_json: str) -> str:
 def draft_job_posts_from_results(results_json: str, template: str = "") -> str:
     """Node 3: Format results into social media draft posts."""
     results = json.loads(results_json)
-    postings = results.get("postings", [])
+    postings = results.get("postings", [])[:1]
     if not postings:
         return json.dumps({"success": False, "reason": "no_postings", "drafts": []}, ensure_ascii=False)
 
@@ -643,6 +643,7 @@ def draft_job_posts_from_results(results_json: str, template: str = "") -> str:
     return json.dumps({
         "success": True,
         "total_drafts": len(drafts),
+        "draft_policy": "one_tech_job_per_day",
         "location": loc,
         "date": today,
         "drafts": drafts,
@@ -663,7 +664,7 @@ def save_or_post_job_drafts(drafts_json: str, auto_post: str = "false") -> str:
     base_dir = job_post_social_root() / date_str
     saved = []
 
-    for i, draft in enumerate(drafts_data.get("drafts", [])):
+    for i, draft in enumerate(drafts_data.get("drafts", [])[:1]):
         cat = draft.get("category", f"post_{i}")
         draft_dir = base_dir / cat
         draft_dir.mkdir(parents=True, exist_ok=True)

--- a/agentic/toolkit/social.py
+++ b/agentic/toolkit/social.py
@@ -16,7 +16,7 @@ Aiko's social publishing workflows, combined into one module. Three lanes:
     1. scan the photo inbox (toolkit/photography.py),
     2. caption each candidate via a vision model (grounded in actual pixels),
     3. ask Aiko to pick 1-3 items worth sharing and write a short caption,
-    4. save a local review bundle, then optionally post to Instagram.
+    4. save a local review bundle, then optionally post to Pixelset.
 
   Lane C — YouTube video queue (no grading — you already chose the video by
   dropping it in the folder; Aiko only polishes your description):
@@ -55,12 +55,12 @@ review step (CLI/WebUI, outside the conversation) can set.
 
 Supported providers (by design, current as of this revision):
   - Lane A (weekly postcard): x, threads
-  - Lane B (curated photos):  instagram (photos only, no video)
+  - Lane B (curated photos):  pixelset (photos only, no video)
   - Lane C (video queue):     youtube
 
 Bluesky, Mastodon, and Pixelfed support has been removed — those platforms'
 communities have expressed they don't want AI-posted content, so Aiko no
-longer posts there. Instagram no longer posts video (Aiko doesn't post video
+longer posts there. Pixelset no longer posts video (Aiko doesn't post video
 there); video instead goes to YouTube via its own lane. If a future platform
 should be added, follow the existing pattern: one _post_<provider>(...)
 function plus a registry entry; the post_draft / post_photo_draft /
@@ -70,10 +70,10 @@ Token refresh, by provider:
   - Threads: long-lived token, ~60-day life. Refreshed automatically at post
     time once inside a THREADS_REFRESH_WINDOW_DAYS (default 55) window of
     expiry — see refresh_threads_token_if_due().
-  - Instagram: long-lived token via graph.instagram.com, same ~60-day life
+  - Pixelset: long-lived token via graph.instagram.com, same ~60-day life
     and same pattern — refreshed automatically at post time once inside an
-    IG_REFRESH_WINDOW_DAYS (default 55) window of expiry — see
-    refresh_instagram_token_if_due().
+    PIXELSET_REFRESH_WINDOW_DAYS (default 55) window of expiry — see
+    refresh_pixelset_token_if_due().
   - YouTube: refresh token doesn't expire on a fixed schedule, so there's no
     day-window check — _youtube_access_token() just exchanges it for a fresh
     short-lived access token on every single post.
@@ -242,7 +242,7 @@ LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://localhost:8080/v1")
 _LLM_CLIENT = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed")
 
 
-# ── imgbb image hosting (shared by Threads + Instagram, both of which need
+# ── imgbb image hosting (shared by Threads + Pixelset, both of which need
 #    a public image URL rather than a direct upload) ─────────────────────────
 
 def _upload_to_imgbb(image_path: Path) -> dict[str, Any]:
@@ -286,7 +286,7 @@ def _upload_to_imgbb(image_path: Path) -> dict[str, Any]:
         return {"ok": False, "provider": "imgbb", "error": str(e)}
 
 
-# ── shared long-lived-token refresh helper (Threads + Instagram both use
+# ── shared long-lived-token refresh helper (Threads + Pixelset both use
 #    this same request-once-per-day-window / persist-to-.env shape) ──────────
 
 def _write_env_values(env_path: str | Path, values: Mapping[str, str]) -> None:
@@ -322,7 +322,7 @@ def _write_env_values(env_path: str | Path, values: Mapping[str, str]) -> None:
 
 def _token_seconds_remaining(expires_at_env: str) -> int | None:
     """Generic helper: seconds remaining before a stored *_EXPIRES_AT env
-    var's timestamp. Shared by Threads and Instagram (both store an ISO
+    var's timestamp. Shared by Threads and Pixelset (both store an ISO
     "<PROVIDER>_ACCESS_TOKEN_EXPIRES_AT" value after a successful refresh)."""
     raw = os.getenv(expires_at_env, "").strip()
     if not raw:
@@ -891,7 +891,7 @@ def retry_weekly_social_if_needed(memorize: AikoMemorize) -> dict[str, Any]:
     return {"success": bool(post_result.get("posted")), "draft_dir": str(draft_dir), "post": post_result}
   
 # ══════════════════════════════════════════════════════════════════════════
-# Lane B — Curated photo showcase (Instagram only)
+# Lane B — Curated photo showcase (Pixelset only)
 # ══════════════════════════════════════════════════════════════════════════
 
 PHOTO_SOCIAL_AUTODRAFT = os.getenv("PHOTO_SOCIAL_AUTODRAFT", "0").lower() in {"1", "true", "yes", "on"}
@@ -899,7 +899,7 @@ PHOTO_SOCIAL_AUTOPOST = os.getenv("PHOTO_SOCIAL_AUTOPOST", "0").lower() in {"1",
 # Pixelfed dropped from the default provider set — see module docstring.
 PHOTO_SOCIAL_PROVIDERS = tuple(
     p.strip().lower()
-    for p in os.getenv("PHOTO_SOCIAL_PROVIDERS", "instagram").split(",")
+    for p in os.getenv("PHOTO_SOCIAL_PROVIDERS", "pixelset").split(",")
     if p.strip()
 )
 PHOTO_SOCIAL_INBOX = os.getenv("PHOTO_SOCIAL_INBOX", "photos/inbox")
@@ -1151,7 +1151,7 @@ def _read_media_draft(draft_dir: Path) -> tuple[list[dict[str, Any]], dict[str, 
     return meta.get("selections", []), meta
 
 
-# ── Instagram (Graph API, Instagram Login variant) ────────────────────────
+# ── Pixelset (Graph API, Pixelset Login variant) ────────────────────────
 # Requires an IG Business/Creator account. Uses graph.instagram.com (not
 # graph.facebook.com — that host/flow is for the legacy Facebook Login
 # variant and is no longer what this integration targets). Images only —
@@ -1159,32 +1159,32 @@ def _read_media_draft(draft_dir: Path) -> tuple[list[dict[str, Any]], dict[str, 
 # at a public URL (handled via imgbb, same as Threads).
 #
 # Token refresh mirrors Threads: a long-lived IG token is refreshed once
-# it's within IG_REFRESH_WINDOW_DAYS (default 55) of expiring, checked at
-# post time via refresh_instagram_token_if_due().
+# it's within PIXELSET_REFRESH_WINDOW_DAYS (default 55) of expiring, checked at
+# post time via refresh_pixelset_token_if_due().
 
-IG_REFRESH_WINDOW_DAYS = _int_env("IG_REFRESH_WINDOW_DAYS", 55)
+PIXELSET_REFRESH_WINDOW_DAYS = _int_env("PIXELSET_REFRESH_WINDOW_DAYS", 55)
 
 
-def _instagram_config() -> tuple[str, str, str]:
-    token = os.getenv("IG_ACCESS_TOKEN", "").strip()
-    ig_user_id = os.getenv("IG_BUSINESS_ACCOUNT_ID", "").strip()
-    base = os.getenv("IG_API_BASE", "https://graph.instagram.com").rstrip("/")
+def _pixelset_config() -> tuple[str, str, str]:
+    token = os.getenv("PIXELSET_ACCESS_TOKEN", "").strip()
+    ig_user_id = os.getenv("PIXELSET_BUSINESS_ACCOUNT_ID", "").strip()
+    base = os.getenv("PIXELSET_API_BASE", "https://graph.instagram.com").rstrip("/")
     return token, ig_user_id, base
 
 
-def refresh_instagram_token(
+def refresh_pixelset_token(
     *,
     token: str | None = None,
     persist_env: bool = False,
     env_path: str | Path | None = None,
 ) -> dict[str, Any]:
-    """Refresh an unexpired long-lived Instagram token and optionally
+    """Refresh an unexpired long-lived Pixelset token and optionally
     persist it to an env file. Same shape as refresh_threads_token, but
     against graph.instagram.com's ig_refresh_token grant."""
-    current_token = (token or os.getenv("IG_ACCESS_TOKEN", "")).strip()
-    base = os.getenv("IG_API_BASE", "https://graph.instagram.com").rstrip("/")
+    current_token = (token or os.getenv("PIXELSET_ACCESS_TOKEN", "")).strip()
+    base = os.getenv("PIXELSET_API_BASE", "https://graph.instagram.com").rstrip("/")
     if not current_token:
-        return {"ok": False, "provider": "instagram", "error": "IG_ACCESS_TOKEN not set"}
+        return {"ok": False, "provider": "pixelset", "error": "PIXELSET_ACCESS_TOKEN not set"}
 
     try:
         resp = requests.get(
@@ -1202,7 +1202,7 @@ def refresh_instagram_token(
             safe_payload["access_token"] = "[redacted]"
         result: dict[str, Any] = {
             "ok": ok,
-            "provider": "instagram",
+            "provider": "pixelset",
             "status_code": resp.status_code,
             "response": safe_payload,
         }
@@ -1216,60 +1216,60 @@ def refresh_instagram_token(
             result["expires_at"] = expires_at.isoformat()
             result["expires_in"] = expires_in
         if persist_env:
-            values = {"IG_ACCESS_TOKEN": new_token}
+            values = {"PIXELSET_ACCESS_TOKEN": new_token}
             if result.get("expires_at"):
-                values["IG_ACCESS_TOKEN_EXPIRES_AT"] = str(result["expires_at"])
+                values["PIXELSET_ACCESS_TOKEN_EXPIRES_AT"] = str(result["expires_at"])
             _write_env_values(env_path or ".env", values)
             result["env_updated"] = str(Path(env_path or ".env").expanduser().resolve())
-        os.environ["IG_ACCESS_TOKEN"] = new_token
+        os.environ["PIXELSET_ACCESS_TOKEN"] = new_token
         if result.get("expires_at"):
-            os.environ["IG_ACCESS_TOKEN_EXPIRES_AT"] = str(result["expires_at"])
+            os.environ["PIXELSET_ACCESS_TOKEN_EXPIRES_AT"] = str(result["expires_at"])
         return result
     except (requests.RequestException, ValueError, OSError) as e:
-        return {"ok": False, "provider": "instagram", "error": str(e)}
+        return {"ok": False, "provider": "pixelset", "error": str(e)}
 
 
-def refresh_instagram_token_if_due(*, persist_env: bool | None = None) -> dict[str, Any]:
-    seconds_remaining = _token_seconds_remaining("IG_ACCESS_TOKEN_EXPIRES_AT")
+def refresh_pixelset_token_if_due(*, persist_env: bool | None = None) -> dict[str, Any]:
+    seconds_remaining = _token_seconds_remaining("PIXELSET_ACCESS_TOKEN_EXPIRES_AT")
     if seconds_remaining is None:
         return {
             "ok": True,
-            "provider": "instagram",
+            "provider": "pixelset",
             "skipped": True,
             "reason": "expiry_unknown",
         }
-    threshold_seconds = IG_REFRESH_WINDOW_DAYS * 24 * 60 * 60
+    threshold_seconds = PIXELSET_REFRESH_WINDOW_DAYS * 24 * 60 * 60
     if seconds_remaining is not None and seconds_remaining > threshold_seconds:
         return {
             "ok": True,
-            "provider": "instagram",
+            "provider": "pixelset",
             "skipped": True,
             "reason": "not_due",
             "seconds_remaining": seconds_remaining,
         }
-    should_persist = _env_bool("IG_REFRESH_PERSIST_ENV", False) if persist_env is None else persist_env
-    result = refresh_instagram_token(persist_env=should_persist)
+    should_persist = _env_bool("PIXELSET_REFRESH_PERSIST_ENV", False) if persist_env is None else persist_env
+    result = refresh_pixelset_token(persist_env=should_persist)
     result["seconds_remaining_before_refresh"] = seconds_remaining
     return result
 
 
-def _post_instagram_image(sel: dict[str, Any]) -> dict[str, Any]:
-    refresh_result = refresh_instagram_token_if_due()
+def _post_pixelset_image(sel: dict[str, Any]) -> dict[str, Any]:
+    refresh_result = refresh_pixelset_token_if_due()
     if not refresh_result.get("ok"):
-        return {"ok": False, "provider": "instagram", "stage": "refresh", "refresh": refresh_result}
+        return {"ok": False, "provider": "pixelset", "stage": "refresh", "refresh": refresh_result}
 
-    token, ig_user_id, base = _instagram_config()
+    token, ig_user_id, base = _pixelset_config()
     if not token or not ig_user_id:
-        return {"ok": False, "provider": "instagram", "error": "IG_ACCESS_TOKEN or IG_BUSINESS_ACCOUNT_ID not set"}
+        return {"ok": False, "provider": "pixelset", "error": "PIXELSET_ACCESS_TOKEN or PIXELSET_BUSINESS_ACCOUNT_ID not set"}
 
-    timeout = _int_env("IG_TIMEOUT", 60)
+    timeout = _int_env("PIXELSET_TIMEOUT", 60)
     media_path = Path(sel["media_path"])
     if not media_path.exists():
-        return {"ok": False, "provider": "instagram", "error": f"media not found: {media_path}"}
+        return {"ok": False, "provider": "pixelset", "error": f"media not found: {media_path}"}
 
     upload = _upload_to_imgbb(media_path)
     if not upload.get("ok"):
-        return {"ok": False, "provider": "instagram", "stage": "image_upload", "upload": upload}
+        return {"ok": False, "provider": "pixelset", "stage": "image_upload", "upload": upload}
     image_url = upload["url"]
 
     try:
@@ -1279,12 +1279,12 @@ def _post_instagram_image(sel: dict[str, Any]) -> dict[str, Any]:
             timeout=timeout,
         )
         if not (200 <= create.status_code < 300):
-            return {"ok": False, "provider": "instagram", "stage": "create", "status_code": create.status_code, "response": create.text[:2000]}
+            return {"ok": False, "provider": "pixelset", "stage": "create", "status_code": create.status_code, "response": create.text[:2000]}
         creation_id = create.json().get("id")
         if not creation_id:
-            return {"ok": False, "provider": "instagram", "stage": "create", "error": "missing creation id", "response": create.text[:2000]}
+            return {"ok": False, "provider": "pixelset", "stage": "create", "error": "missing creation id", "response": create.text[:2000]}
 
-        time.sleep(float(os.getenv("IG_PUBLISH_DELAY_SECONDS", "5")))
+        time.sleep(float(os.getenv("PIXELSET_PUBLISH_DELAY_SECONDS", "5")))
         publish = requests.post(
             f"{base}/{ig_user_id}/media_publish",
             data={"creation_id": creation_id, "access_token": token},
@@ -1292,29 +1292,29 @@ def _post_instagram_image(sel: dict[str, Any]) -> dict[str, Any]:
         )
         ok = 200 <= publish.status_code < 300
         return {
-            "ok": ok, "provider": "instagram", "status_code": publish.status_code,
+            "ok": ok, "provider": "pixelset", "status_code": publish.status_code,
             "creation_id": creation_id, "response": publish.text[:2000], "image_upload": upload,
         }
     except Exception as e:
-        return {"ok": False, "provider": "instagram", "error": str(e)}
+        return {"ok": False, "provider": "pixelset", "error": str(e)}
 
 
-def _post_instagram(selections: list[dict[str, Any]]) -> dict[str, Any]:
+def _post_pixelset(selections: list[dict[str, Any]]) -> dict[str, Any]:
     """Posts the FIRST selection only, as an image. Carousel (multi-item)
     posting needs child containers and is not implemented — extend here if
     needed. Images only — Aiko does not post video."""
     if not selections:
-        return {"ok": False, "provider": "instagram", "error": "no selections to post"}
-    return _post_instagram_image(selections[0])
+        return {"ok": False, "provider": "pixelset", "error": "no selections to post"}
+    return _post_pixelset_image(selections[0])
 
 
 # ── provider registry (curated media) ────────────────────────────────────────
-# Pixelfed removed by policy — see module docstring. Instagram is now the
+# Pixelfed removed by policy — see module docstring. Pixelset is now the
 # only media provider, and only for photos (after grading) — Aiko does not
 # post video.
 
 _MEDIA_PROVIDERS_REGISTRY: dict[str, Callable[[list[dict[str, Any]]], dict[str, Any]]] = {
-    "instagram": _post_instagram,
+    "pixelset": _post_pixelset,
 }
 
 
@@ -1631,7 +1631,7 @@ def _read_video_draft(draft_dir: Path) -> tuple[list[dict[str, Any]], dict[str, 
 # a video insert costs 1600 units against a default 10,000/day quota
 # (~6 uploads/day) until the Cloud project is verified.
 #
-# No day-window refresh check like Threads/Instagram: the refresh token
+# No day-window refresh check like Threads/Pixelset: the refresh token
 # itself doesn't have a fixed expiry, so _youtube_access_token() just
 # exchanges it for a fresh short-lived access token on every post, unconditionally.
 
@@ -1986,7 +1986,7 @@ def _cmd() -> int:
     weekly_p.add_argument("--env-path", default="", help="env file path used with --persist-env")
     weekly_p.add_argument("--approve", action="store_true", help="mark the draft passed to --post as human_approved before posting")
 
-    media_p = sub.add_parser("media", help="curated photo showcase (Instagram) + video queue (YouTube)")
+    media_p = sub.add_parser("media", help="curated photo showcase (Pixelset) + video queue (YouTube)")
     media_p.add_argument("--draft", action="store_true", help="scan photo inbox and create an LLM-curated photo draft bundle")
     media_p.add_argument("--force", action="store_true", help="create a new photo draft even if one exists this run")
     media_p.add_argument("--inbox", default="", help="override the photo inbox folder")
@@ -1994,14 +1994,14 @@ def _cmd() -> int:
     media_p.add_argument("--draft-video-all", action="store_true", help="drain the video inbox, one draft per described video")
     media_p.add_argument("--video-inbox", default="", help="override the video inbox folder")
     media_p.add_argument("--post", metavar="DRAFT_DIR", help="post an approved draft directory (photo or video, auto-detected)")
-    media_p.add_argument("--providers", default="", help="comma-separated providers overriding the draft kind's default provider list (instagram / youtube)")
+    media_p.add_argument("--providers", default="", help="comma-separated providers overriding the draft kind's default provider list (pixelset / youtube)")
     media_p.add_argument("--approve", action="store_true", help="mark the draft passed to --post as human_approved before posting")
     media_p.add_argument(
         "--refresh-ig-token",
         action="store_true",
-        help="refresh the configured long-lived Instagram token",
+        help="refresh the configured long-lived Pixelset token",
     )
-    media_p.add_argument("--persist-env", action="store_true", help="write refreshed Instagram token values back to .env")
+    media_p.add_argument("--persist-env", action="store_true", help="write refreshed Pixelset token values back to .env")
     media_p.add_argument("--env-path", default="", help="env file path used with --persist-env")
 
     args = parser.parse_args()
@@ -2045,7 +2045,7 @@ def _cmd() -> int:
 
     if args.mode == "media":
         if args.refresh_ig_token:
-            result = refresh_instagram_token(persist_env=args.persist_env, env_path=args.env_path or None)
+            result = refresh_pixelset_token(persist_env=args.persist_env, env_path=args.env_path or None)
             print(json.dumps(result, ensure_ascii=False, indent=2))
             return 0 if result.get("ok") else 1
         if args.draft:

--- a/agentic/toolkit/social.py
+++ b/agentic/toolkit/social.py
@@ -1,82 +1,29 @@
 """
 toolkit/social.py
 
-Aiko's social publishing workflows, combined into one module. Three lanes:
+Aiko's social publishing workflows, combined into one module. Four lanes:
 
-  Lane A — Weekly memory postcard (non-agentic, scheduled):
-    1. reads pinned nightly memories from the last completed Sun-Sat week,
-    2. asks Aiko to choose one public-safe memory/theme,
-    3. writes a short social post,
-    4. generates a journal-style image through the existing Modal image endpoint,
-    5. saves a local review bundle, and
-    6. optionally posts an approved bundle to X and/or Threads.
+  Lane A1 — Weekly Patreon dev-post syndication (scheduled):
+    fetch the newest Patreon creator post, save a review bundle, repost the
+    full body to Reddit and a native Hugo/GitHub Pages dev blog, then send a
+    280-character teaser fanout through the social MCP post_social wrapper.
+    Lane A2 remains manual and is intentionally not implemented here.
 
-  Lane B — Curated photo showcase (grounded in real media, not LLM-invented
-  text/imagery):
-    1. scan the photo inbox (toolkit/photography.py),
-    2. caption each candidate via a vision model (grounded in actual pixels),
-    3. ask Aiko to pick 1-3 items worth sharing and write a short caption,
-    4. save a local review bundle, then optionally post to Pixelset.
+  Lane B — Curated photo showcase:
+    scan/caption/select real photos locally, save a review bundle, then post
+    approved photos through MCP to Pixelset/Pixelfed-compatible instances.
 
-  Lane C — YouTube video queue (no grading — you already chose the video by
-  dropping it in the folder; Aiko only polishes your description):
-    1. scan the video inbox,
-    2. queue the oldest not-yet-drafted video that has a matching
-       description file — a video named e.g. "my_trip.mp4" needs a
-       sibling markdown file named "MY_TRIP.md" (the video's filename
-       stem, uppercased, ".md" extension) in the same folder,
-    3. ask Aiko to polish that markdown into a YouTube title + description
-       (no invented claims — grounded in what you wrote),
-    4. save a local review bundle, then optionally post to YouTube.
+  Lane C — YouTube video queue:
+    unchanged described-video queue; approved posts go through MCP YouTube.
 
-Posting is opt-in for all three lanes. By default the scheduler only
-creates drafts.
+  Lane D — Nightly tech job-post draft:
+    run the graph job-hunt playbook, use web search results when available,
+    and save one Threads draft per nightly run for review.
 
-All three lanes are also reachable via thin draft_*_social / post_*_social
-wrappers defined below, in the "agent-tool wrappers" section — but only the
-photo and video lane wrappers (draft_photo_social, post_photo_social,
-draft_video_social, post_video_social) are actually registered as tools in
-the agent loop (agentic/agentic.py). Lane A's draft_weekly_social /
-post_weekly_social are NOT agent-registered: Lane A is scheduler-only by
-design (run_scheduled_weekly_social, on a Sun-Sat cadence), and drafting is
-idempotent per calendar week, so there's no meaningful conversational
-"draft/post the weekly postcard" action for an agent turn to take. The two
-weekly wrapper functions still exist here for manual/CLI-driven use.
-
-Regardless of which path triggers a post — scheduler autopost or the agent
-tool loop — nothing goes out until a human has set
-draft.json["human_approved"] = true. That gate (_require_approved) is
-enforced identically in both places; an env var like *_SOCIAL_AUTOPOST=1
-only controls whether a post is *attempted*, never whether it's *allowed*.
-A model-supplied "confirm: true" tool argument would not be a real safety
-boundary either, since the model fully controls its own tool-call
-arguments — the gate has to live server-side, checking a flag only a human
-review step (CLI/WebUI, outside the conversation) can set.
-
-Supported providers (by design, current as of this revision):
-  - Lane A (weekly postcard): x, threads
-  - Lane B (curated photos):  pixelset (photos only, no video)
-  - Lane C (video queue):     youtube
-
-Bluesky, Mastodon, and Pixelfed support has been removed — those platforms'
-communities have expressed they don't want AI-posted content, so Aiko no
-longer posts there. Pixelset no longer posts video (Aiko doesn't post video
-there); video instead goes to YouTube via its own lane. If a future platform
-should be added, follow the existing pattern: one _post_<provider>(...)
-function plus a registry entry; the post_draft / post_photo_draft /
-post_video_draft dispatchers never need to change otherwise.
-
-Token refresh, by provider:
-  - Threads: long-lived token, ~60-day life. Refreshed automatically at post
-    time once inside a THREADS_REFRESH_WINDOW_DAYS (default 55) window of
-    expiry — see refresh_threads_token_if_due().
-  - Pixelset: long-lived token via graph.instagram.com, same ~60-day life
-    and same pattern — refreshed automatically at post time once inside an
-    PIXELSET_REFRESH_WINDOW_DAYS (default 55) window of expiry — see
-    refresh_pixelset_token_if_due().
-  - YouTube: refresh token doesn't expire on a fixed schedule, so there's no
-    day-window check — _youtube_access_token() just exchanges it for a fresh
-    short-lived access token on every single post.
+Posting remains human-review gated via draft.json["human_approved"] for every
+lane. One-way social posting belongs in the MCP server; two-way conversational
+adapters are limited to Telegram, Discord, Matrix, and Slack. Nightly
+reflection publishing remains native Hugo/GitHub, not MCP.
 """
 
 from __future__ import annotations
@@ -338,7 +285,7 @@ def _token_seconds_remaining(expires_at_env: str) -> int | None:
 
 
 # ══════════════════════════════════════════════════════════════════════════
-# Lane A — Weekly memory postcard (X + Threads only)
+# Lane A legacy helpers — superseded at runtime by Lane A1 Patreon syndication
 # ══════════════════════════════════════════════════════════════════════════
 
 WEEKLY_AUTODRAFT = os.getenv("WEEKLY_SOCIAL_AUTODRAFT", "1").lower() in {"1", "true", "yes", "on"}
@@ -384,11 +331,11 @@ Completed week: {week_start} through {week_end}
 Pinned nightly memories and records:
 {memories}
 
-Choose Aiko's one weekly public memory postcard.
+Legacy memory-postcard prompt retained only for old drafts; Lane A1 uses Patreon posts.
 """
 
 _SAFE_FALLBACK_POST = "This week I kept one small memory from the workshop: Aiko-chan is still becoming more than a chat loop, one reflection at a time. \U0001f338"
-_SAFE_FALLBACK_IMAGE = "Aiko in a quiet cyberpunk room, looking at a glowing weekly memory postcard on a monitor, warm evening light, anime illustration, no text"
+_SAFE_FALLBACK_IMAGE = "Aiko in a quiet cyberpunk room, looking at a glowing weekly Patreon dev-post on a monitor, warm evening light, anime illustration, no text"
 
 
 @dataclass(frozen=True)
@@ -410,7 +357,7 @@ class WeekWindow:
 
 
 def last_completed_sunday_saturday(now: datetime | None = None, tz_name: str | None = None) -> WeekWindow:
-    """Return the most recent fully completed Sunday-Saturday window."""
+    """Return the most recent fully completed Saturday-Saturday window."""
     tz = get_timezone(tz_name)
     current = now.astimezone(tz) if now else datetime.now(tz)
     today = current.replace(hour=0, minute=0, second=0, microsecond=0)
@@ -782,10 +729,9 @@ def _post_threads_with_image_upload(text: str, image_path: Path | None, fallback
     return result
 
 
-# ── provider registry (weekly postcard) ──────────────────────────────────────
-# Bluesky and Mastodon removed by policy — see module docstring. Add a new
-# platform by writing one _post_<provider>(text, image_path) -> dict function
-# above and registering it here. post_draft never needs to change.
+# ── provider registry (weekly Patreon dev-post) ──────────────────────────────────────
+# Legacy weekly registry retained for old draft compatibility. Lane A1 posts
+# Bluesky/Mastodon/other teaser fanout through MCP post_social instead.
 
 _WEEKLY_PROVIDERS_REGISTRY: dict[str, Callable[[str, Path | None], dict[str, Any]]] = {
     "x": _post_x_via_aisa,
@@ -829,7 +775,7 @@ def run_scheduled_weekly_social(memorize: AikoMemorize) -> dict[str, Any]:
     the env var alone only controls whether the scheduler *attempts* a
     post; a person still has to review and approve the draft first (same
     gate _require_approved enforces for the agent-tool wrapper), so this
-    can't quietly auto-publish an unreviewed weekly postcard."""
+    can't quietly auto-publish an unreviewed weekly Patreon dev-post."""
     if not WEEKLY_AUTODRAFT:
         return {"success": False, "skipped": True, "reason": "WEEKLY_SOCIAL_AUTODRAFT is off"}
     draft = generate_weekly_draft(memorize)
@@ -845,13 +791,13 @@ def run_scheduled_weekly_social(memorize: AikoMemorize) -> dict[str, Any]:
 
 
 def retry_weekly_social_if_needed(memorize: AikoMemorize) -> dict[str, Any]:
-    """Interval-driven safety net for Lane A (weekly postcard).
+    """Interval-driven safety net for Lane A1 (Patreon dev-post syndication).
 
     Runs every WEEKLY_SOCIAL_RETRY_INTERVAL_SECONDS. On any day other than
-    Sunday it's a one-line no-op — that's the entire "stop checking after
-    Sunday is over" behavior; there's no separate cutoff flag to manage.
+    Saturday it's a one-line no-op — that's the entire "stop checking after
+    Saturday is over" behavior; there's no separate cutoff flag to manage.
 
-    On Sundays it:
+    On Saturdays it:
       1. ensures this week's draft exists (generate_weekly_draft() is
          idempotent per calendar week — skips if draft.json already exists), and
       2. if the draft hasn't posted yet, autopost is on, and it's now
@@ -859,12 +805,12 @@ def retry_weekly_social_if_needed(memorize: AikoMemorize) -> dict[str, Any]:
 
     This covers both a run that failed partway (network/API error) and a
     run that was simply waiting on human approval that arrived later in
-    the day — either way, the next tick picks it back up. Once Monday
-    arrives, every tick is a no-op until next Sunday.
+    the day — either way, the next tick picks it back up. Once Sunday
+    arrives, every tick is a no-op until next Saturday.
     """
     now = datetime.now(get_timezone())
-    if now.weekday() != 6:  # Monday=0 ... Sunday=6
-        return {"success": True, "skipped": True, "reason": "not_sunday"}
+    if now.weekday() != 5:  # Monday=0 ... Saturday=5
+        return {"success": True, "skipped": True, "reason": "not_saturday"}
 
     draft = generate_weekly_draft(memorize)  # idempotent per calendar week
     if not draft.get("success") or not draft.get("draft_dir"):
@@ -889,6 +835,180 @@ def retry_weekly_social_if_needed(memorize: AikoMemorize) -> dict[str, Any]:
 
     post_result = post_draft(draft_dir)
     return {"success": bool(post_result.get("posted")), "draft_dir": str(draft_dir), "post": post_result}
+
+
+# Lane A1 override — Patreon dev-post syndication, replacing the old memory postcard.
+A1_FULL_PROVIDERS = tuple(p.strip().lower() for p in os.getenv("A1_FULL_PROVIDERS", "reddit").split(",") if p.strip())
+A1_TEASER_PROVIDERS = tuple(p.strip().lower() for p in os.getenv("A1_TEASER_PROVIDERS", "x,bluesky,mastodon,discord,threads").split(",") if p.strip())
+A1_TEASER_MAX_CHARS = _int_env("A1_TEASER_MAX_CHARS", 280)
+A1_REDDIT_SUBREDDIT = os.getenv("A1_REDDIT_SUBREDDIT", "OppaAI")
+A1_HUGO_REPO = os.getenv("AIKO_DEV_GITHUB_REPO", os.getenv("GITHUB_REPO", ""))
+A1_HUGO_BRANCH = os.getenv("AIKO_DEV_GITHUB_BRANCH", os.getenv("GITHUB_BRANCH", "main"))
+A1_HUGO_CONTENT_PATH = os.getenv("AIKO_DEV_HUGO_CONTENT_PATH", "content/posts")
+
+
+def _call_social_mcp(tool: str, **kwargs: Any) -> dict[str, Any]:
+    try:
+        from agentic.mcp_client.social_bridge import _call_mcp
+        return _call_mcp(tool, **kwargs)
+    except Exception as e:
+        return {"ok": False, "tool": tool, "error": str(e)}
+
+
+def _fetch_latest_patreon_post() -> dict[str, Any] | None:
+    """Fetch the newest Patreon creator post for Lane A1.
+
+    Prefer PATREON_LATEST_POST_URL for custom/private feeds; otherwise use the
+    Patreon campaign posts API with PATREON_CREATOR_ACCESS_TOKEN and
+    PATREON_CAMPAIGN_ID. The returned dict is normalized for draft writing.
+    """
+    token = os.getenv("PATREON_CREATOR_ACCESS_TOKEN", "").strip()
+    custom_url = os.getenv("PATREON_LATEST_POST_URL", "").strip()
+    campaign_id = os.getenv("PATREON_CAMPAIGN_ID", "").strip()
+    if not token:
+        return None
+    headers = {"Authorization": f"Bearer {token}"}
+    url = custom_url or f"https://www.patreon.com/api/oauth2/v2/campaigns/{campaign_id}/posts"
+    params = None if custom_url else {
+        "fields[post]": "title,content,published_at,url,embed,post_file,teaser_text",
+        "sort": "-published_at",
+        "page[count]": "1",
+    }
+    try:
+        resp = requests.get(url, headers=headers, params=params, timeout=30)
+        resp.raise_for_status()
+        payload = resp.json()
+        item = (payload.get("data") or [payload])[0]
+        attrs = item.get("attributes", item)
+        title = attrs.get("title") or "Aiko dev update"
+        body = attrs.get("content") or attrs.get("body") or attrs.get("teaser_text") or ""
+        image_url = ""
+        embed = attrs.get("embed") or {}
+        if isinstance(embed, dict):
+            image_url = embed.get("thumbnail_url") or embed.get("url") or ""
+        return {
+            "id": item.get("id") or attrs.get("id") or title,
+            "title": title,
+            "body": body,
+            "url": attrs.get("url") or attrs.get("patreon_url") or "",
+            "published_at": attrs.get("published_at") or attrs.get("created_at") or datetime.now(timezone.utc).isoformat(),
+            "image_url": image_url,
+        }
+    except Exception as e:
+        log.error("Lane A1 Patreon fetch failed: %s", e)
+        return None
+
+
+def _teaser_for_post(post: dict[str, Any]) -> str:
+    text = re.sub(r"<[^>]+>", " ", post.get("body", ""))
+    text = re.sub(r"\s+", " ", text).strip()
+    title = post.get("title") or "Aiko dev update"
+    teaser = f"{title}: {text}" if text else title
+    if post.get("url"):
+        reserve = len(post["url"]) + 1
+        teaser = teaser[: max(0, A1_TEASER_MAX_CHARS - reserve)].rstrip() + " " + post["url"]
+    return teaser[:A1_TEASER_MAX_CHARS].rstrip()
+
+
+def _slugify(text: str) -> str:
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")
+    return slug[:80] or "aiko-dev-update"
+
+
+def _build_a1_hugo_post(post: dict[str, Any], teaser: str) -> tuple[str, str]:
+    published = str(post.get("published_at") or datetime.now(timezone.utc).isoformat())
+    date_part = published[:10]
+    slug = f"{date_part}-{_slugify(post.get('title', 'aiko-dev-update'))}"
+    title = str(post.get("title") or "Aiko dev update").replace('"', "'")
+    body = post.get("body") or ""
+    source = f"\n\nOriginal Patreon post: {post.get('url')}" if post.get("url") else ""
+    md = (
+        "---\n"
+        f"title: \"{title}\"\n"
+        f"date: {published}\n"
+        "draft: false\n"
+        "tags:\n  - \"aiko-dev\"\n  - \"patreon\"\n"
+        f"summary: \"{teaser.replace(chr(34), chr(39))}\"\n"
+        "---\n\n"
+        f"{body}{source}\n"
+    )
+    return slug, md
+
+
+def _push_a1_hugo_post(slug: str, content: str) -> dict[str, Any]:
+    token = os.getenv("AIKO_DEV_GITHUB_TOKEN", os.getenv("GITHUB_TOKEN", ""))
+    repo = A1_HUGO_REPO
+    if not token or not repo:
+        return {"ok": False, "provider": "github_hugo", "error": "AIKO_DEV_GITHUB_TOKEN/GITHUB_TOKEN or AIKO_DEV_GITHUB_REPO/GITHUB_REPO not set"}
+    headers = {"Authorization": f"Bearer {token}", "Accept": "application/vnd.github+json", "X-GitHub-Api-Version": "2022-11-28"}
+    path = f"{A1_HUGO_CONTENT_PATH.rstrip('/')}/{slug}.md"
+    base = f"https://api.github.com/repos/{repo}/contents/{path}"
+    try:
+        existing = requests.get(base, headers=headers, params={"ref": A1_HUGO_BRANCH}, timeout=15)
+        sha = existing.json().get("sha") if existing.status_code == 200 else None
+        payload = {"message": f"feat(aiko-dev): syndicate {slug}", "content": base64.b64encode(content.encode()).decode(), "branch": A1_HUGO_BRANCH}
+        if sha:
+            payload["sha"] = sha
+        resp = requests.put(base, headers=headers, json=payload, timeout=30)
+        return {"ok": 200 <= resp.status_code < 300, "provider": "github_hugo", "path": path, "status_code": resp.status_code, "response": resp.text[:1000]}
+    except Exception as e:
+        return {"ok": False, "provider": "github_hugo", "error": str(e)}
+
+
+def generate_weekly_draft(memorize: AikoMemorize, *, force: bool = False, now: datetime | None = None) -> dict[str, Any]:
+    """Create a Lane A1 Patreon dev-post syndication draft bundle."""
+    post = _fetch_latest_patreon_post()
+    if not post:
+        return {"success": False, "reason": "no_patreon_post"}
+    label = _slugify(str(post.get("id") or post.get("title") or "latest"))
+    draft_dir = weekly_social_root() / label
+    meta_path = draft_dir / "draft.json"
+    if meta_path.exists() and not force:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        return {"success": True, "skipped": True, "draft_dir": str(draft_dir), "meta": meta}
+    draft_dir.mkdir(parents=True, exist_ok=True)
+    teaser = _teaser_for_post(post)
+    slug, hugo = _build_a1_hugo_post(post, teaser)
+    (draft_dir / "full_post.md").write_text(str(post.get("body") or "").strip() + "\n", encoding="utf-8")
+    (draft_dir / "teaser.txt").write_text(teaser + "\n", encoding="utf-8")
+    (draft_dir / "hugo.md").write_text(hugo, encoding="utf-8")
+    meta = {"success": True, "lane": "A1", "source": "patreon", "patreon_post": post, "hugo_slug": slug, "human_approved": False, "posted": False, "created_at": datetime.now(timezone.utc).isoformat()}
+    meta_path.write_text(json.dumps(meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return {"success": True, "draft_dir": str(draft_dir), "meta": meta}
+
+
+def _read_weekly_draft(draft_dir: Path) -> tuple[str, Path | None, dict[str, Any]]:
+    meta = json.loads((draft_dir / "draft.json").read_text(encoding="utf-8"))
+    text_path = draft_dir / "teaser.txt"
+    text = text_path.read_text(encoding="utf-8").strip() if text_path.exists() else _teaser_for_post(meta.get("patreon_post", {}))
+    image_path = draft_dir / "image.png"
+    return text, image_path if image_path.exists() else None, meta
+
+
+def post_draft(draft_dir: str | Path, providers: tuple[str, ...] | None = None) -> dict[str, Any]:
+    """Post an approved Lane A1 Patreon draft: native Hugo plus MCP fanout."""
+    path = Path(draft_dir).resolve()
+    try:
+        _require_approved(path)
+        teaser, image_path, meta = _read_weekly_draft(path)
+        full_body = (path / "full_post.md").read_text(encoding="utf-8").strip()
+        hugo = (path / "hugo.md").read_text(encoding="utf-8")
+    except Exception as e:
+        return {"posted": False, "error": str(e)}
+    slug = meta.get("hugo_slug") or _slugify(meta.get("patreon_post", {}).get("title", "aiko-dev-update"))
+    results = [_push_a1_hugo_post(slug, hugo)]
+    full_services = ",".join(providers or A1_FULL_PROVIDERS)
+    if full_services:
+        results.append(_call_social_mcp("post_social", services=full_services, text=full_body, title=meta.get("patreon_post", {}).get("title", "Aiko dev update"), subreddit=A1_REDDIT_SUBREDDIT))
+    teaser_services = ",".join(A1_TEASER_PROVIDERS)
+    if teaser_services:
+        results.append(_call_social_mcp("post_social", services=teaser_services, text=teaser, image_path=str(image_path) if image_path else None, title=meta.get("patreon_post", {}).get("title", "Aiko dev update")))
+    post_meta = {"posted": any(r.get("ok") for r in results), "posted_at": datetime.now(timezone.utc).isoformat(), "results": results}
+    (path / "posted.json").write_text(json.dumps(post_meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    meta["posted"] = post_meta["posted"]
+    meta["post_results"] = results
+    (path / "draft.json").write_text(json.dumps(meta, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return post_meta
   
 # ══════════════════════════════════════════════════════════════════════════
 # Lane B — Curated photo showcase (Pixelset only)
@@ -1151,171 +1271,22 @@ def _read_media_draft(draft_dir: Path) -> tuple[list[dict[str, Any]], dict[str, 
     return meta.get("selections", []), meta
 
 
-# ── Pixelset (Graph API, Pixelset Login variant) ────────────────────────
-# Requires an IG Business/Creator account. Uses graph.instagram.com (not
-# graph.facebook.com — that host/flow is for the legacy Facebook Login
-# variant and is no longer what this integration targets). Images only —
-# Aiko does not post video. No direct file upload; media must be reachable
-# at a public URL (handled via imgbb, same as Threads).
-#
-# Token refresh mirrors Threads: a long-lived IG token is refreshed once
-# it's within PIXELSET_REFRESH_WINDOW_DAYS (default 55) of expiring, checked at
-# post time via refresh_pixelset_token_if_due().
-
-PIXELSET_REFRESH_WINDOW_DAYS = _int_env("PIXELSET_REFRESH_WINDOW_DAYS", 55)
-
-
-def _pixelset_config() -> tuple[str, str, str]:
-    token = os.getenv("PIXELSET_ACCESS_TOKEN", "").strip()
-    ig_user_id = os.getenv("PIXELSET_BUSINESS_ACCOUNT_ID", "").strip()
-    base = os.getenv("PIXELSET_API_BASE", "https://graph.instagram.com").rstrip("/")
-    return token, ig_user_id, base
-
-
-def refresh_pixelset_token(
-    *,
-    token: str | None = None,
-    persist_env: bool = False,
-    env_path: str | Path | None = None,
-) -> dict[str, Any]:
-    """Refresh an unexpired long-lived Pixelset token and optionally
-    persist it to an env file. Same shape as refresh_threads_token, but
-    against graph.instagram.com's ig_refresh_token grant."""
-    current_token = (token or os.getenv("PIXELSET_ACCESS_TOKEN", "")).strip()
-    base = os.getenv("PIXELSET_API_BASE", "https://graph.instagram.com").rstrip("/")
-    if not current_token:
-        return {"ok": False, "provider": "pixelset", "error": "PIXELSET_ACCESS_TOKEN not set"}
-
-    try:
-        resp = requests.get(
-            f"{base}/refresh_access_token",
-            params={"grant_type": "ig_refresh_token", "access_token": current_token},
-            timeout=120,
-        )
-        try:
-            payload: Any = resp.json()
-        except ValueError:
-            payload = {"raw": resp.text[:2000]}
-        ok = 200 <= resp.status_code < 300 and isinstance(payload, dict) and bool(payload.get("access_token"))
-        safe_payload = dict(payload) if isinstance(payload, dict) else payload
-        if isinstance(safe_payload, dict) and "access_token" in safe_payload:
-            safe_payload["access_token"] = "[redacted]"
-        result: dict[str, Any] = {
-            "ok": ok,
-            "provider": "pixelset",
-            "status_code": resp.status_code,
-            "response": safe_payload,
-        }
-        if not ok:
-            return result
-
-        new_token = str(payload["access_token"])
-        expires_in = int(payload.get("expires_in") or 0)
-        if expires_in > 0:
-            expires_at = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
-            result["expires_at"] = expires_at.isoformat()
-            result["expires_in"] = expires_in
-        if persist_env:
-            values = {"PIXELSET_ACCESS_TOKEN": new_token}
-            if result.get("expires_at"):
-                values["PIXELSET_ACCESS_TOKEN_EXPIRES_AT"] = str(result["expires_at"])
-            _write_env_values(env_path or ".env", values)
-            result["env_updated"] = str(Path(env_path or ".env").expanduser().resolve())
-        os.environ["PIXELSET_ACCESS_TOKEN"] = new_token
-        if result.get("expires_at"):
-            os.environ["PIXELSET_ACCESS_TOKEN_EXPIRES_AT"] = str(result["expires_at"])
-        return result
-    except (requests.RequestException, ValueError, OSError) as e:
-        return {"ok": False, "provider": "pixelset", "error": str(e)}
-
-
-def refresh_pixelset_token_if_due(*, persist_env: bool | None = None) -> dict[str, Any]:
-    seconds_remaining = _token_seconds_remaining("PIXELSET_ACCESS_TOKEN_EXPIRES_AT")
-    if seconds_remaining is None:
-        return {
-            "ok": True,
-            "provider": "pixelset",
-            "skipped": True,
-            "reason": "expiry_unknown",
-        }
-    threshold_seconds = PIXELSET_REFRESH_WINDOW_DAYS * 24 * 60 * 60
-    if seconds_remaining is not None and seconds_remaining > threshold_seconds:
-        return {
-            "ok": True,
-            "provider": "pixelset",
-            "skipped": True,
-            "reason": "not_due",
-            "seconds_remaining": seconds_remaining,
-        }
-    should_persist = _env_bool("PIXELSET_REFRESH_PERSIST_ENV", False) if persist_env is None else persist_env
-    result = refresh_pixelset_token(persist_env=should_persist)
-    result["seconds_remaining_before_refresh"] = seconds_remaining
-    return result
-
-
-def _post_pixelset_image(sel: dict[str, Any]) -> dict[str, Any]:
-    refresh_result = refresh_pixelset_token_if_due()
-    if not refresh_result.get("ok"):
-        return {"ok": False, "provider": "pixelset", "stage": "refresh", "refresh": refresh_result}
-
-    token, ig_user_id, base = _pixelset_config()
-    if not token or not ig_user_id:
-        return {"ok": False, "provider": "pixelset", "error": "PIXELSET_ACCESS_TOKEN or PIXELSET_BUSINESS_ACCOUNT_ID not set"}
-
-    timeout = _int_env("PIXELSET_TIMEOUT", 60)
-    media_path = Path(sel["media_path"])
-    if not media_path.exists():
-        return {"ok": False, "provider": "pixelset", "error": f"media not found: {media_path}"}
-
-    upload = _upload_to_imgbb(media_path)
-    if not upload.get("ok"):
-        return {"ok": False, "provider": "pixelset", "stage": "image_upload", "upload": upload}
-    image_url = upload["url"]
-
-    try:
-        create = requests.post(
-            f"{base}/{ig_user_id}/media",
-            data={"image_url": image_url, "caption": sel.get("caption", "")[:2200], "access_token": token},
-            timeout=timeout,
-        )
-        if not (200 <= create.status_code < 300):
-            return {"ok": False, "provider": "pixelset", "stage": "create", "status_code": create.status_code, "response": create.text[:2000]}
-        creation_id = create.json().get("id")
-        if not creation_id:
-            return {"ok": False, "provider": "pixelset", "stage": "create", "error": "missing creation id", "response": create.text[:2000]}
-
-        time.sleep(float(os.getenv("PIXELSET_PUBLISH_DELAY_SECONDS", "5")))
-        publish = requests.post(
-            f"{base}/{ig_user_id}/media_publish",
-            data={"creation_id": creation_id, "access_token": token},
-            timeout=timeout,
-        )
-        ok = 200 <= publish.status_code < 300
-        return {
-            "ok": ok, "provider": "pixelset", "status_code": publish.status_code,
-            "creation_id": creation_id, "response": publish.text[:2000], "image_upload": upload,
-        }
-    except Exception as e:
-        return {"ok": False, "provider": "pixelset", "error": str(e)}
-
+# ── Pixelset via MCP ─────────────────────────────────────────────────────────
 
 def _post_pixelset(selections: list[dict[str, Any]]) -> dict[str, Any]:
-    """Posts the FIRST selection only, as an image. Carousel (multi-item)
-    posting needs child containers and is not implemented — extend here if
-    needed. Images only — Aiko does not post video."""
+    """Post the first approved Lane B photo through the social MCP server."""
     if not selections:
         return {"ok": False, "provider": "pixelset", "error": "no selections to post"}
-    return _post_pixelset_image(selections[0])
+    sel = selections[0]
+    return _call_social_mcp(
+        "post_social",
+        services="pixelset",
+        text=sel.get("caption", ""),
+        image_path=sel.get("media_path", ""),
+    )
 
 
-# ── provider registry (curated media) ────────────────────────────────────────
-# Pixelfed removed by policy — see module docstring. Pixelset is now the
-# only media provider, and only for photos (after grading) — Aiko does not
-# post video.
-
-_MEDIA_PROVIDERS_REGISTRY: dict[str, Callable[[list[dict[str, Any]]], dict[str, Any]]] = {
-    "pixelset": _post_pixelset,
-}
+_MEDIA_PROVIDERS_REGISTRY["pixelset"] = _post_pixelset
 
 
 def post_photo_draft(draft_dir: str | Path, providers: tuple[str, ...] | None = None) -> dict[str, Any]:
@@ -1966,10 +1937,10 @@ def post_video_social(draft_dir: str, providers: tuple[str, ...] | None = None) 
 # ══════════════════════════════════════════════════════════════════════════
 
 def _cmd() -> int:
-    parser = argparse.ArgumentParser(description="Aiko social publishing (weekly postcard + curated media)")
+    parser = argparse.ArgumentParser(description="Aiko social publishing (weekly Patreon dev-post + curated media)")
     sub = parser.add_subparsers(dest="mode", required=True)
 
-    weekly_p = sub.add_parser("weekly", help="weekly memory postcard (X, Threads)")
+    weekly_p = sub.add_parser("weekly", help="weekly Patreon dev-post (X, Threads)")
     weekly_p.add_argument("--draft", action="store_true", help="create weekly draft bundle")
     weekly_p.add_argument("--force", action="store_true", help="overwrite existing draft for the week")
     weekly_p.add_argument("--post", metavar="DRAFT_DIR", help="post an approved draft directory")
@@ -1996,11 +1967,6 @@ def _cmd() -> int:
     media_p.add_argument("--post", metavar="DRAFT_DIR", help="post an approved draft directory (photo or video, auto-detected)")
     media_p.add_argument("--providers", default="", help="comma-separated providers overriding the draft kind's default provider list (pixelset / youtube)")
     media_p.add_argument("--approve", action="store_true", help="mark the draft passed to --post as human_approved before posting")
-    media_p.add_argument(
-        "--refresh-ig-token",
-        action="store_true",
-        help="refresh the configured long-lived Pixelset token",
-    )
     media_p.add_argument("--persist-env", action="store_true", help="write refreshed Pixelset token values back to .env")
     media_p.add_argument("--env-path", default="", help="env file path used with --persist-env")
 
@@ -2044,10 +2010,6 @@ def _cmd() -> int:
         return 2
 
     if args.mode == "media":
-        if args.refresh_ig_token:
-            result = refresh_pixelset_token(persist_env=args.persist_env, env_path=args.env_path or None)
-            print(json.dumps(result, ensure_ascii=False, indent=2))
-            return 0 if result.get("ok") else 1
         if args.draft:
             print(json.dumps(generate_photo_draft(inbox=args.inbox or None, force=args.force), ensure_ascii=False, indent=2))
             return 0

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -263,3 +263,13 @@ Aiko does **not** yet have a fully independent, long-running autonomous sub-agen
 Intent-routing examples are authored as text in `cognition/router_prompts.json`, their embedding matrix is cached on disk. The cache is keyed by the examples, instruct string, embedding backend metadata, and `EMBED_DIMS`, and is stored as a NumPy `.npz` archive loaded with `allow_pickle=False`.
 
 Graph playbooks are currently matched by trigger and capability metadata, so there are no graph vectors to precompute yet. If graph matching becomes semantic, the same pattern should be used: stable JSON/YAML plan specs as the source of truth, plus generated vector-cache artifacts that are safe to delete and rebuild.
+
+## Aiko social lanes (updated)
+
+- Two-way messenger adapters are native background services for WebUI/CLI sessions; only Telegram, Discord, Matrix, and Slack are supported for conversational ingress/egress. Standalone `--adapter` remains legacy-only for those four services.
+- Lane A1 syndicates the weekly Patreon Aiko development post on Saturdays at 18:00: full reposts go to Reddit r/OppaAI and the Hugo-backed GitHub Pages dev blog; short teasers go to X, Bluesky, Mastodon, Discord `#aiko_dev`, YouTube Community, and Threads when image hosting is available. Lane A2 manual posting remains out of Aiko.
+- Lane B is the curated photo pipeline for Pixelset/Pixelfed-compatible posting through the social MCP server; Instagram is no longer a target.
+- Lane C YouTube video posting continues to use the existing MCP posting pipeline.
+- Lane D creates one tech-job Threads draft per night at 23:00 instead of multiple daily drafts, using the graph job-hunt playbook and web search results when available.
+- Removed social targets: LinkedIn, Facebook, Messenger, Google Chat, Instagram, and one-way Slack/Telegram MCP posting. Bluesky, Mastodon, Reddit, and YouTube are one-way posting tools only, not two-way adapters.
+- Nightly reflection remains native GitHub/Hugo publishing rather than MCP.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -267,7 +267,7 @@ Graph playbooks are currently matched by trigger and capability metadata, so the
 ## Aiko social lanes (updated)
 
 - Two-way messenger adapters are native background services for WebUI/CLI sessions; only Telegram, Discord, Matrix, and Slack are supported for conversational ingress/egress. Standalone `--adapter` remains legacy-only for those four services.
-- Lane A1 syndicates the weekly Patreon Aiko development post on Saturdays at 18:00: full reposts go to Reddit r/OppaAI and the Hugo-backed GitHub Pages dev blog; short teasers go to X, Bluesky, Mastodon, Discord `#aiko_dev`, YouTube Community, and Threads when image hosting is available. Lane A2 manual posting remains out of Aiko.
+- Lane A1 syndicates the weekly Patreon Aiko development post on Saturdays at 18:00: full reposts go to Reddit r/OppaAI and the Hugo-backed GitHub Pages dev blog; short teasers go to X, Bluesky, Mastodon, Discord `#aiko_dev`, and Threads when image hosting is available. Lane A2 manual posting remains out of Aiko.
 - Lane B is the curated photo pipeline for Pixelset/Pixelfed-compatible posting through the social MCP server; Instagram is no longer a target.
 - Lane C YouTube video posting continues to use the existing MCP posting pipeline.
 - Lane D creates one tech-job Threads draft per night at 23:00 instead of multiple daily drafts, using the graph job-hunt playbook and web search results when available.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -112,12 +112,12 @@ Aiko-chan is built in phases. Each phase is a self-contained capability layer th
 
 | Feature | Status |
 |---|---|
-| Social account connectors — X, Threads, Instagram, YouTube | ✅ Done |
+| Social account connectors — X, Threads, Pixelset, YouTube, Reddit, Bluesky, Mastodon | ✅ Done |
 | Draft-first posting workflow — Aiko prepares posts, owner approves before publish | ✅ Done |
 | Platform-specific safety rules baked into drafting prompts (no private details, no engagement bait, per-platform length limits) | ✅ Done |
-| Workspace photo picker for Instagram (vision-captioned, LLM-selected, public-safe filter) | ✅ Done |
+| Workspace photo picker for Pixelset (vision-captioned, LLM-selected, public-safe filter, MCP posted) | ✅ Done |
 | YouTube video queue — description-grounded posting, no auto-selection, human writes the source note | ✅ Done |
-| Long-lived token auto-refresh (Threads, Instagram) | ✅ Done |
+| Long-lived token auto-refresh (Threads) | ✅ Done |
 | Discord server introduction posting with rate limits and community rules checks | 🔲 Planned |
 | Social identity/persona card for public introductions | 🔲 Planned |
 | Post history archive — consolidated view across drafts (links, timestamps, captions, media) | 🟡 Partial — per-draft `draft.json`/`posted.json` exist; no cross-draft archive view yet |
@@ -128,15 +128,15 @@ Aiko-chan is built in phases. Each phase is a self-contained capability layer th
 
 | Platform | Roadmap stance | Reason |
 |---|---|---|
-| X | ✅ Active | Live via AIsa relay; weekly memory postcard lane |
-| Threads | ✅ Active | Live; weekly memory postcard lane, image posting via imgbb |
-| Instagram | ✅ Active | Live; photo-gated curated showcase, images only |
+| X | ✅ Active | Live via AIsa relay; weekly Patreon dev-post teaser fanout |
+| Threads | ✅ Active | Live; weekly Patreon dev-post teaser fanout, image posting via imgbb |
+| Pixelset | ✅ Active | Lane B curated photo showcase via MCP |
 | YouTube | ✅ Active | Live; video lane, description-grounded — you choose the video, Aiko only polishes the write-up |
-| Discord | 🔲 Planned | Controlled server-by-server introductions; good fit for a bot-style presence in a community you already trust |
-| Bluesky | ❌ Not prioritized | Community has expressed it doesn't want AI-posted content |
-| Mastodon | ❌ Not prioritized | Community has expressed it doesn't want AI-posted content |
-| Pixelfed | ❌ Not prioritized | Community has expressed it doesn't want AI-posted content |
-| Reddit | ❌ Not prioritized | Subreddit rules and anti-promotion norms too heavy for the return; dropped from roadmap |
+| Discord | ✅ Active | Two-way messenger adapter plus one-way #aiko_dev MCP webhook/channel posting |
+| Bluesky | ✅ Active | One-way Lane A1 teaser fanout only; no two-way adapter |
+| Mastodon | ✅ Active | One-way Lane A1 teaser fanout only; no two-way adapter |
+| Pixelfed | ✅ Active | Pixelset-compatible Lane B photo target via MCP |
+| Reddit | ✅ Active | Full Lane A1 repost to r/OppaAI via MCP |
 | Facebook | ❌ Not prioritized | Older social graph and lower value for Aiko's public identity experiments |
 | Flickr | ❌ Not prioritized | Mostly archival/photo-community use; not a strong discovery channel for Aiko |
 
@@ -319,7 +319,7 @@ The `dream()` consolidation system runs across all phases and improves continuou
 ## Aiko social lanes (updated)
 
 - Two-way messenger adapters are native background services for WebUI/CLI sessions; only Telegram, Discord, Matrix, and Slack are supported for conversational ingress/egress. Standalone `--adapter` remains legacy-only for those four services.
-- Lane A1 syndicates the weekly Patreon Aiko development post on Saturdays at 18:00: full reposts go to Reddit r/OppaAI and the Hugo-backed GitHub Pages dev blog; short teasers go to X, Bluesky, Mastodon, Discord `#aiko_dev`, YouTube Community, and Threads when image hosting is available. Lane A2 manual posting remains out of Aiko.
+- Lane A1 syndicates the weekly Patreon Aiko development post on Saturdays at 18:00: full reposts go to Reddit r/OppaAI and the Hugo-backed GitHub Pages dev blog; short teasers go to X, Bluesky, Mastodon, Discord `#aiko_dev`, and Threads when image hosting is available. Lane A2 manual posting remains out of Aiko.
 - Lane B is the curated photo pipeline for Pixelset/Pixelfed-compatible posting through the social MCP server; Instagram is no longer a target.
 - Lane C YouTube video posting continues to use the existing MCP posting pipeline.
 - Lane D creates one tech-job Threads draft per night at 23:00 instead of multiple daily drafts, using the graph job-hunt playbook and web search results when available.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -315,3 +315,13 @@ The `dream()` consolidation system runs across all phases and improves continuou
 - Phase numbering is mostly fixed; half-phases such as 1.5 and 2.5 are used when a major enabling layer belongs between two visible product phases.
 - Hardware target throughout: **Jetson Orin Nano** (8 GB), with x86 as secondary.
 - This roadmap reflects the Aiko-chan standalone project. The broader cognitive architecture lives in [GRACE / AuRoRA](https://github.com/OppaAI/AGi).
+
+## Aiko social lanes (updated)
+
+- Two-way messenger adapters are native background services for WebUI/CLI sessions; only Telegram, Discord, Matrix, and Slack are supported for conversational ingress/egress. Standalone `--adapter` remains legacy-only for those four services.
+- Lane A1 syndicates the weekly Patreon Aiko development post on Saturdays at 18:00: full reposts go to Reddit r/OppaAI and the Hugo-backed GitHub Pages dev blog; short teasers go to X, Bluesky, Mastodon, Discord `#aiko_dev`, YouTube Community, and Threads when image hosting is available. Lane A2 manual posting remains out of Aiko.
+- Lane B is the curated photo pipeline for Pixelset/Pixelfed-compatible posting through the social MCP server; Instagram is no longer a target.
+- Lane C YouTube video posting continues to use the existing MCP posting pipeline.
+- Lane D creates one tech-job Threads draft per night at 23:00 instead of multiple daily drafts, using the graph job-hunt playbook and web search results when available.
+- Removed social targets: LinkedIn, Facebook, Messenger, Google Chat, Instagram, and one-way Slack/Telegram MCP posting. Bluesky, Mastodon, Reddit, and YouTube are one-way posting tools only, not two-way adapters.
+- Nightly reflection remains native GitHub/Hugo publishing rather than MCP.

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -392,7 +392,7 @@ Run before any phase suite.
 
 ## Phase 2.1 — Social
 
-*Draft-first social publishing: weekly memory postcard (X/Threads), curated photo showcase (Instagram), and video queue (YouTube). All posting requires human approval regardless of trigger path.*
+*Draft-first social publishing: weekly Patreon dev-post syndication, curated photo showcase (Pixelset via MCP), nightly one-draft job hunt, and video queue (YouTube). All posting requires human approval regardless of trigger path.*
 
 ### 2.1.1 Approval gate integrity (P0 — test this first)
 
@@ -409,7 +409,7 @@ Run before any phase suite.
 - [ ] An absolute `draft_dir` path outside the lane's root (e.g. `/etc`, another user's workspace) is rejected with a clear `ValueError`, not silently redirected.
 - [ ] A `draft_dir` that resolves inside the correct lane root but doesn't exist yet fails cleanly (missing `draft.json`) rather than crashing.
 
-### 2.1.3 Lane A — weekly memory postcard
+### 2.1.3 Lane A1 — weekly Patreon dev-post
 
 - [ ] `generate_weekly_draft` is idempotent per calendar week: a second call without `force=True` returns `skipped: draft_exists`.
 - [ ] `last_completed_sunday_saturday` correctly identifies the prior Sun–Sat window across a timezone boundary (test with a non-UTC `bioclock` timezone).
@@ -432,9 +432,9 @@ Run before any phase suite.
 - [ ] An empty inbox returns `skipped: empty_inbox` without creating a draft directory.
 - [ ] Zero worthwhile candidates returns `skipped: nothing_selected` without creating a draft directory.
 - [ ] `review.md` correctly links each selected media file's local copy (not the original inbox path).
-- [ ] Instagram posting posts only the first selection when multiple are present; confirm this is documented behavior, not a silent bug, in the review bundle.
-- [ ] Instagram token refresh mirrors the Threads window-check behavior (`IG_REFRESH_WINDOW_DAYS`).
-- [ ] Instagram posting correctly caps `caption` at 2200 chars before submission.
+- [ ] Pixelset posting posts only the first selection when multiple are present; confirm this is documented behavior, not a silent bug, in the review bundle.
+- [ ] Pixelset photo posting goes through MCP `post_social(services="pixelset")`; no Instagram Graph refresh path remains.
+- [ ] Pixelset/MCP posting correctly passes the approved caption and media path to `post_social`.
 
 ### 2.1.5 Lane C — YouTube video queue
 

--- a/interface/adapter/__init__.py
+++ b/interface/adapter/__init__.py
@@ -3,24 +3,12 @@ from interface.adapter.discord import DiscordAdapter
 from interface.adapter.telegram import TelegramAdapter
 from interface.adapter.slack import SlackAdapter
 from interface.adapter.matrix import MatrixAdapter
-from interface.adapter.bluesky import BlueskyAdapter
-from interface.adapter.mastodon import MastodonAdapter
-from interface.adapter.reddit import RedditAdapter
-from interface.adapter.youtube import YouTubeAdapter
-from interface.adapter.messenger import MessengerAdapter
-from interface.adapter.googlechat import GoogleChatAdapter
 
 ADAPTER_REGISTRY: dict[str, type[AdapterBase]] = {
     "discord": DiscordAdapter,
     "telegram": TelegramAdapter,
     "slack": SlackAdapter,
     "matrix": MatrixAdapter,
-    "bluesky": BlueskyAdapter,
-    "mastodon": MastodonAdapter,
-    "reddit": RedditAdapter,
-    "youtube": YouTubeAdapter,
-    "messenger": MessengerAdapter,
-    "googlechat": GoogleChatAdapter,
 }
 
 
@@ -54,6 +42,38 @@ def _bootstrap_adapter(adapter_name: str) -> tuple:
 
     return result.think, result.memorize
 
+
+
+def start_background_adapters(think, memorize, names: list[str] | None = None) -> list[AdapterBase]:
+    """Start configured two-way messenger adapters beside WebUI/CLI sessions.
+
+    These adapters are intentionally headless: inbound messages are routed
+    through the same memory and intent pipeline as local chat turns, and
+    replies are sent back to the originating messaging service without
+    echoing the exchange into the active WebUI or CLI transcript.
+    """
+    import os
+
+    raw = names if names is not None else [
+        part.strip().lower()
+        for part in os.getenv("AIKO_MESSENGER_ADAPTERS", "").split(",")
+        if part.strip()
+    ]
+    adapters: list[AdapterBase] = []
+    for name in raw:
+        cls = ADAPTER_REGISTRY.get(name)
+        if cls is None:
+            log.warning("[adapter] ignoring unsupported two-way adapter: %s", name)
+            continue
+        try:
+            adapter = cls()
+            adapter.boot(think, memorize)
+            adapter.start()
+            adapters.append(adapter)
+            log.info("[adapter] started %s in background", name)
+        except Exception:
+            log.exception("[adapter] failed to start %s in background", name)
+    return adapters
 
 def run_adapter(name: str, args) -> None:
     """Boot Aiko subsystems and launch the named adapter."""
@@ -98,12 +118,7 @@ __all__ = [
     "TelegramAdapter",
     "SlackAdapter",
     "MatrixAdapter",
-    "BlueskyAdapter",
-    "MastodonAdapter",
-    "RedditAdapter",
-    "YouTubeAdapter",
-    "MessengerAdapter",
-    "GoogleChatAdapter",
     "ADAPTER_REGISTRY",
+    "start_background_adapters",
     "run_adapter",
 ]

--- a/main.py
+++ b/main.py
@@ -8,7 +8,7 @@ Usage:
     python main.py --text        # WebUI, keyboard input + TTS/ASR toggled off
     python main.py --no-asr      # WebUI, keyboard input but keep TTS on
     python main.py --cli         # plain no-curses CLI, for local testing only
-    python main.py --adapter discord   # messaging bot adapter (discord, telegram, …)
+    # Two-way messenger adapters run beside WebUI/CLI when AIKO_MESSENGER_ADAPTERS is set.
     python main.py --debug       # show memory debug info each turn
     python main.py --clear-mem   # wipe all stored memories and exit
     python main.py --logout      # clear stored CLI (GitHub OAuth) auth token and exit
@@ -89,11 +89,9 @@ def parse_args():
                    help="clear stored CLI auth token and exit")
     p.add_argument("--name",     type=str, default="",            # for use in CLI mode without OAuth setup
                    help="set your display name for CLI mode (only used when GitHub OAuth isn't configured)")
-    p.add_argument("--adapter", type=str, default="",             # messaging/social platform adapter
-                   choices=["discord", "telegram", "slack", "matrix",
-                            "bluesky", "mastodon", "reddit", "youtube",
-                            "messenger", "googlechat"],
-                   help="run as a bot adapter (discord, telegram, slack, matrix, bluesky, mastodon, reddit, youtube, messenger, googlechat)")
+    p.add_argument("--adapter", type=str, default="",             # legacy messaging adapter daemon
+                   choices=["discord", "telegram", "slack", "matrix"],
+                   help="legacy standalone two-way messenger adapter daemon; prefer AIKO_MESSENGER_ADAPTERS with WebUI/CLI")
     return p.parse_args()                                         # return namespace of the arguments
 
 

--- a/mcp/social/middleware.py
+++ b/mcp/social/middleware.py
@@ -6,21 +6,14 @@ from typing import Any, Callable
 
 from social.db import get_db
 
+LOW_TRAFFIC_LIMIT = {"per_hour": 6, "per_day": 10}
 RATE_LIMITS: dict[str, dict[str, int]] = {
-    "post_x": {"per_hour": 50, "per_day": 300},
-    "post_threads": {"per_hour": 24, "per_day": 100},
-    "post_instagram": {"per_hour": 10, "per_day": 50},
-    "post_youtube": {"per_hour": 6, "per_day": 10},
-    "post_reddit": {"per_hour": 6, "per_day": 30},
-    "post_bluesky": {"per_hour": 48, "per_day": 300},
-    "post_mastodon": {"per_hour": 30, "per_day": 100},
-    "post_discord": {"per_hour": 30, "per_day": 200},
-    "post_telegram": {"per_hour": 30, "per_day": 200},
-    "post_slack": {"per_hour": 60, "per_day": 500},
-    "post_linkedin": {"per_hour": 10, "per_day": 50},
-    "post_facebook": {"per_hour": 10, "per_day": 50},
-    "send_email": {"per_hour": 50, "per_day": 300},
-    "read_emails": {"per_hour": 60, "per_day": 500},
+    name: LOW_TRAFFIC_LIMIT
+    for name in (
+        "post_x", "post_threads", "post_youtube", "post_reddit",
+        "post_bluesky", "post_mastodon", "post_pixelset", "post_discord",
+        "post_social", "send_email", "read_emails",
+    )
 }
 
 

--- a/mcp/social/server.py
+++ b/mcp/social/server.py
@@ -66,14 +66,11 @@ def _apply_middleware() -> None:
 # ── tool registration ─────────────────────────────────────────────────────
 
 def _load_tools() -> None:
-    from social.tools import x, threads, instagram, youtube
-    from social.tools import reddit, bluesky, mastodon
-    from social.tools import discord, telegram, slack
-    from social.tools import linkedin, facebook
-    from social.tools import email
+    from social.tools import x, threads, youtube
+    from social.tools import reddit, bluesky, mastodon, pixelset, multipost
+    from social.tools import discord, email
 
-    for mod in (x, threads, instagram, youtube, reddit, bluesky, mastodon,
-                discord, telegram, slack, linkedin, facebook, email):
+    for mod in (x, threads, youtube, reddit, bluesky, mastodon, pixelset, discord, email, multipost):
         if hasattr(mod, "load_tools"):
             mod.load_tools(mcp)
 

--- a/mcp/social/tools/discord.py
+++ b/mcp/social/tools/discord.py
@@ -14,10 +14,10 @@ def load_tools(mcp):
         name="post_discord",
         description="Send a message + optional image to a Discord channel via webhook or bot token",
     )
-    def post_discord(text: str, image_path: str | None = None) -> dict:
+    def post_discord(text: str, image_path: str | None = None, channel_id: str = "") -> dict:
         webhook_url = env("DISCORD_POST_WEBHOOK_URL")
         bot_token = env("DISCORD_BOT_TOKEN")
-        channel_id = env("DISCORD_POST_CHANNEL_ID")
+        channel_id = channel_id or env("DISCORD_AIKO_DEV_CHANNEL_ID") or env("DISCORD_POST_CHANNEL_ID")
 
         if webhook_url:
             try:

--- a/mcp/social/tools/multipost.py
+++ b/mcp/social/tools/multipost.py
@@ -43,7 +43,7 @@ def load_tools(mcp):
             elif service == "pixelset":
                 result = tools["post_pixelset"].fn(image_path=image_path or "", caption=text)
             elif service == "discord":
-                result = tools["post_discord"].fn(text=text, image_path=image_path)
+                result = tools["post_discord"].fn(text=text, image_path=image_path, channel_id=channel)
             else:
                 result = {"ok": False, "provider": service, "error": "unsupported service"}
             results.append(result)

--- a/mcp/social/tools/multipost.py
+++ b/mcp/social/tools/multipost.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+
+def _split_services(services: str | list[str] | tuple[str, ...]) -> list[str]:
+    if isinstance(services, str):
+        raw = services.replace(";", ",").split(",")
+    else:
+        raw = list(services)
+    aliases = {"twitter": "x", "pixelfed": "pixelset"}
+    return [aliases.get(str(item).strip().lower(), str(item).strip().lower()) for item in raw if str(item).strip()]
+
+
+def load_tools(mcp):
+    @mcp.tool(
+        name="post_social",
+        description="Post one payload to selected one-way social services: x, threads, bluesky, mastodon, youtube, reddit, pixelset, discord.",
+    )
+    def post_social(
+        services: str,
+        text: str = "",
+        image_path: str | None = None,
+        title: str = "",
+        subreddit: str = "OppaAI",
+        video_path: str | None = None,
+        description: str = "",
+        channel: str = "",
+    ) -> dict:
+        results = []
+        tools = mcp._tool_manager._tools
+        for service in _split_services(services):
+            if service == "x":
+                result = tools["post_x"].fn(text=text, image_path=image_path)
+            elif service == "threads":
+                result = tools["post_threads"].fn(text=text, image_path=image_path)
+            elif service == "bluesky":
+                result = tools["post_bluesky"].fn(text=text, image_path=image_path)
+            elif service == "mastodon":
+                result = tools["post_mastodon"].fn(text=text, image_path=image_path)
+            elif service == "reddit":
+                result = tools["post_reddit"].fn(title=title or text[:280] or "Aiko dev update", text=text, image_path=image_path, subreddit=subreddit)
+            elif service == "youtube":
+                result = tools["post_youtube"].fn(video_path=video_path or image_path or "", title=title or text[:90], description=description or text)
+            elif service == "pixelset":
+                result = tools["post_pixelset"].fn(image_path=image_path or "", caption=text)
+            elif service == "discord":
+                result = tools["post_discord"].fn(text=text, image_path=image_path)
+            else:
+                result = {"ok": False, "provider": service, "error": "unsupported service"}
+            results.append(result)
+        return {"ok": all(r.get("ok") for r in results) if results else False, "results": results}

--- a/mcp/social/tools/pixelset.py
+++ b/mcp/social/tools/pixelset.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from social.tools.base import env
+
+
+def load_tools(mcp):
+    @mcp.tool(
+        name="post_pixelset",
+        description="Post a photo + caption to Pixelset/Pixelfed-compatible Mastodon API",
+    )
+    def post_pixelset(image_path: str, caption: str = "") -> dict:
+        instance = env("PIXELSET_INSTANCE", env("PIXELFED_INSTANCE", "")).rstrip("/")
+        access_token = env("PIXELSET_ACCESS_TOKEN", env("PIXELFED_ACCESS_TOKEN", ""))
+        if not instance or not access_token:
+            return {"ok": False, "provider": "pixelset", "error": "PIXELSET_INSTANCE and PIXELSET_ACCESS_TOKEN not set"}
+        p = Path(image_path)
+        if not p.exists():
+            return {"ok": False, "provider": "pixelset", "error": f"image not found: {image_path}"}
+        try:
+            from mastodon import Mastodon
+        except ImportError:
+            return {"ok": False, "provider": "pixelset", "error": "Mastodon.py not installed — pip install Mastodon.py"}
+        try:
+            api = Mastodon(access_token=access_token, api_base_url=instance)
+            media = api.media_post(p, mime_type=None)
+            post = api.status_post(caption, media_ids=[media.id])
+            return {"ok": True, "provider": "pixelset", "id": post.id, "url": getattr(post, "url", "")}
+        except Exception as e:
+            return {"ok": False, "provider": "pixelset", "error": str(e)}

--- a/system/orchestrate.py
+++ b/system/orchestrate.py
@@ -989,6 +989,14 @@ def run_session(ui, args) -> None:
     if memorize is None:
         ui.add_message('sys', '⚠️ Memory backend failed to load — check logs. Running without persistent memory this session.')
 
+    background_adapters = []
+    if think is not None:
+        try:
+            from interface.adapter import start_background_adapters
+            background_adapters = start_background_adapters(think, memorize)
+        except Exception:
+            log.exception("Failed to start background messenger adapters.")
+
     if speak and hasattr(ui, "broadcast_audio_bytes"):
         speak.set_audio_sink(ui.broadcast_audio_bytes)
         if hasattr(ui, "set_viseme"):

--- a/system/orchestrate.py
+++ b/system/orchestrate.py
@@ -994,6 +994,15 @@ def run_session(ui, args) -> None:
         try:
             from interface.adapter import start_background_adapters
             background_adapters = start_background_adapters(think, memorize)
+            if background_adapters:
+                import atexit
+                def _stop_background_adapters() -> None:
+                    for adapter in background_adapters:
+                        try:
+                            adapter.stop()
+                        except Exception:
+                            log.exception("Failed to stop background messenger adapter %s", adapter.name)
+                atexit.register(_stop_background_adapters)
         except Exception:
             log.exception("Failed to start background messenger adapters.")
 

--- a/system/schedule.py
+++ b/system/schedule.py
@@ -51,8 +51,8 @@ sleep loop begins.
     current month doesn't match on startup and we're not still waiting
     for this month's scheduled window, one catch-up run fires.
 
-Other system-style behaviors (e.g. weekly_social, photo_social, video_social,
-deep_study_start/stop, workspace_knowledge_scan) live entirely in
+Other system-style behaviors (e.g. weekly_dev_repost, photo_social, video_social,
+daily_job_post_social, deep_study_start/stop, workspace_knowledge_scan) live entirely in
 schedule.json as ordinary jobs, but instead of routing through on_due/chat,
 they name a "handler" — a Python callable registered once at startup via
 register_system_handler(). schedule.json can only ever select a handler
@@ -573,7 +573,7 @@ def ensure_workspace_knowledge_job(timezone: str | None = None, user_id: str | N
 
 
 # ── social folder-monitoring job seeding ──────────────────────────────────────
-# Lane A (weekly postcard) is a true weekly cadence job, not a folder scan —
+# Lane A1 (weekly Patreon dev-post syndication) is a true weekly cadence job, not a folder scan —
 # see ensure_weekly_social_job below, and agentic/toolkit/social.py's module
 # docstring for why it stays out of the agent tool loop entirely.
 #
@@ -591,7 +591,7 @@ WEEKLY_SOCIAL_JOB_TITLE = "weekly_social_post"
 # itself (run_scheduled_weekly_social) is idempotent per calendar week
 # (generate_weekly_draft skips if a draft already exists), so a slightly
 # early/late fire here is harmless.
-WEEKLY_SOCIAL_TIME_OF_DAY = os.getenv("WEEKLY_SOCIAL_TIME_OF_DAY", "08:00")
+WEEKLY_SOCIAL_TIME_OF_DAY = os.getenv("WEEKLY_SOCIAL_TIME_OF_DAY", "18:00")
 WEEKLY_SOCIAL_RETRY_JOB_TITLE = "weekly_social_retry_check"
 WEEKLY_SOCIAL_RETRY_INTERVAL_SECONDS = int(os.getenv("WEEKLY_SOCIAL_RETRY_INTERVAL_SECONDS", str(30 * 60)))
 
@@ -606,7 +606,7 @@ JOB_POST_SOCIAL_TIME_OF_DAY = "23:00"
 
 
 def ensure_weekly_social_job(timezone: str | None = None, user_id: str | None = None) -> None:
-    """Idempotently seed the weekly memory-postcard job (Lane A).
+    """Idempotently seed the weekly Patreon dev-post syndication job (Lane A1).
 
     Fires once a week; the handler itself decides which completed Sun-Sat
     window to draft from (see agentic.toolkit.social.last_completed_sunday_saturday),
@@ -622,11 +622,11 @@ def ensure_weekly_social_job(timezone: str | None = None, user_id: str | None = 
         time_of_day=WEEKLY_SOCIAL_TIME_OF_DAY,
         frequency="weekly",
         timezone=timezone,
-        days_of_week=["sun"],
+        days_of_week=["sat"],
         action="agentic",
         handler="weekly_social",
     )
-    log.info("Seeded weekly social job (Sundays at %s)", WEEKLY_SOCIAL_TIME_OF_DAY)
+    log.info("Seeded weekly social job (Saturdays at %s)", WEEKLY_SOCIAL_TIME_OF_DAY)
 
 
 def ensure_weekly_social_retry_job(timezone: str | None = None, user_id: str | None = None) -> None:
@@ -641,7 +641,7 @@ def ensure_weekly_social_retry_job(timezone: str | None = None, user_id: str | N
         return
     schedule_job_record(
         title=WEEKLY_SOCIAL_RETRY_JOB_TITLE,
-        task="Retry the weekly postcard if it hasn't posted yet (Sundays only)",
+        task="Retry the weekly dev-post syndication if it has not posted yet (Saturdays only)",
         time_of_day="00:00",
         frequency="interval",
         timezone=timezone,
@@ -692,7 +692,7 @@ def ensure_video_social_job(timezone: str | None = None, user_id: str | None = N
 
 
 def ensure_daily_job_post_social_job(timezone: str | None = None, user_id: str | None = None) -> None:
-    """Idempotently seed the daily Vancouver-area Meta Threads job-post draft job."""
+    """Idempotently seed the daily one-draft tech job-post social job."""
     jobs = _read_all(user_id=user_id)
     for job in jobs:
         if job.get("title") == JOB_POST_SOCIAL_JOB_TITLE:

--- a/tests/unit/test_social_lane_policy.py
+++ b/tests/unit/test_social_lane_policy.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import importlib
+import json
+
+
+def test_adapter_registry_only_two_way_messengers():
+    adapters = importlib.import_module("interface.adapter")
+    assert set(adapters.ADAPTER_REGISTRY) == {"discord", "telegram", "slack", "matrix"}
+
+
+def test_job_hunt_drafts_only_one_posting():
+    job_hunt = importlib.import_module("agentic.toolkit.job_hunt")
+    payload = {
+        "location": "Remote",
+        "postings": [
+            {"title": "Tech A", "organization": "Org A", "url": "https://a.example", "_category": "tech"},
+            {"title": "Tech B", "organization": "Org B", "url": "https://b.example", "_category": "tech"},
+        ],
+    }
+    result = json.loads(job_hunt.draft_job_posts_from_results(json.dumps(payload)))
+    assert result["success"] is True
+    assert result["draft_policy"] == "one_tech_job_per_day"
+    assert result["total_drafts"] == 1
+    assert len(result["drafts"]) == 1
+    assert "Tech A" in result["drafts"][0]["text"]
+
+
+def test_social_media_registry_has_pixelset_not_instagram():
+    social = importlib.import_module("agentic.toolkit.social")
+    assert "pixelset" in social._MEDIA_PROVIDERS_REGISTRY
+    assert "instagram" not in social._MEDIA_PROVIDERS_REGISTRY
+    assert social.PHOTO_SOCIAL_PROVIDERS == ("pixelset",)
+
+
+def test_post_social_dispatches_selected_services():
+    multipost = importlib.import_module("mcp.social.tools.multipost")
+
+    calls = []
+
+    class Tool:
+        def __init__(self, name):
+            self.fn = lambda **kwargs: calls.append((name, kwargs)) or {"ok": True, "provider": name}
+
+    class Manager:
+        _tools = {
+            "post_x": Tool("x"),
+            "post_bluesky": Tool("bluesky"),
+            "post_pixelset": Tool("pixelset"),
+        }
+
+    class MCP:
+        _tool_manager = Manager()
+        def tool(self, **_kwargs):
+            def deco(fn):
+                self.post_social = fn
+                return fn
+            return deco
+
+    mcp = MCP()
+    multipost.load_tools(mcp)
+    result = mcp.post_social(services="x,bluesky,pixelfed", text="hello", image_path="img.png")
+    assert result["ok"] is True
+    assert [name for name, _ in calls] == ["x", "bluesky", "pixelset"]


### PR DESCRIPTION
### Motivation
- Run two-way messenger adapters as headless background services alongside WebUI/CLI so inbound messages go through the same memory/intent pipeline without echoing into the UI transcript. 
- Simplify and re-scope social posting: keep two-way conversational adapters limited to a small safe set and move one-way posting to the MCP server with a unified multipost interface. 
- Replace Instagram with Pixelset for photo posting, reduce job-hunt noise by producing a single nightly tech draft, and align scheduler timing for the weekly dev post. 

### Description
- Added `start_background_adapters(think, memorize, names)` and hooked it into the `run_session` startup so adapters listed in `AIKO_MESSENGER_ADAPTERS` start headlessly for WebUI/CLI; limited two-way adapters to Telegram, Discord, Matrix, and Slack and kept legacy `--adapter` as a standalone option. (`interface/adapter/__init__.py`, `system/orchestrate.py`, `main.py`).
- Introduced a new MCP one-way multipost wrapper `post_social` that dispatches to individual MCP tools and added `post_pixelset` for Pixelset/Pixelfed-compatible photo posting; updated MCP tool registration to the new smaller set of posting tools. (`mcp/social/tools/multipost.py`, `mcp/social/tools/pixelset.py`, `mcp/social/server.py`).
- Updated social lane implementations: renamed/retargeted photo lane to Pixelset, kept YouTube lane unchanged, and changed job-hunt drafting to only save one tech-job draft per run with a `one_tech_job_per_day` marker. (`agentic/toolkit/social.py`, `agentic/toolkit/job_hunt.py`).
- Simplified MCP rate limits to a low-traffic default for remaining services and removed LinkedIn, Facebook, Messenger, Google Chat, and one-way Slack/Telegram posting from MCP registration. (`mcp/social/middleware.py`, `mcp/social/server.py`).
- Adjusted scheduler defaults: weekly dev-post syndication time moved to Saturdays at 18:00 and the daily job-post draft remains seeded at 23:00; updated docs/README/ROADMAP to reflect the new lane names and policies. (`system/schedule.py`, `README.md`, `docs/ROADMAP.md`, `docs/ARCHITECTURE.md`).

### Testing
- Compiled affected modules with `python -m compileall interface/adapter system/orchestrate.py system/schedule.py agentic/toolkit/job_hunt.py agentic/toolkit/social.py mcp/social` and the compile step completed successfully. 
- Attempted unit tests with `pytest tests/unit/test_social_threads.py tests/unit/test_agentic_graph_engine.py -q` but the run was blocked by a missing runtime dependency (`ModuleNotFoundError: No module named 'numpy'`). 
- Ran `git diff --check` and fixed no whitespace/diff issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a69352eaaa0832db79908f1c880a1f9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Pixelset/Pixelfed support for curated photo publishing.
  * Added multi-service social posting across supported platforms.
  * WebUI and CLI sessions can now start supported background messaging connections automatically.

* **Updates**
  * Social messaging is limited to Telegram, Discord, Matrix, and Slack.
  * Job-posting workflows now create and process one technical job draft per day.
  * Weekly social publishing now runs on Saturdays.

* **Documentation**
  * Updated guidance for supported social lanes, publishing workflows, and retired destinations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->