### PR TITLE
Agentic follow-ups: typed tool args, AgentContext & tracing, approval gate, handoff profiles, and bug fixes

### DIFF
--- a/agentic/agentic.py
+++ b/agentic/agentic.py
@@ -564,7 +564,7 @@ def _maybe_resume_approval(owner, user_input: str, token_callback=None) -> str |
     if not re.search(r"\b(yes|confirm|approve|approved|resume|continue)\b", user_input or "", re.I):
         return None
     base_ctx = _agent_context(owner)
-    match = re.search(r"\b(run-[0-9]+|r[0-9A-Za-z_-]+)\b", user_input or "")
+    match = re.search(r"\b(run-[0-9]+|r\d[0-9A-Za-z_-]*)\b", user_input or "")
     if match:
         run_id = match.group(1)
     else:

--- a/agentic/agentic.py
+++ b/agentic/agentic.py
@@ -285,7 +285,7 @@ _ERROR_PREFIX_RE = re.compile(r"^\[(?P<label>[^:\]]+)(?::\s*(?P<detail>.*))?\]$"
 # Tools that can genuinely post to a real public account. When one of these
 # ran and succeeded this turn, an answer describing a real "posted" action
 # is not a hallucinated external action — see _verify_final_answer.
-_SOCIAL_POST_TOOLS = {"post_job_post_social", "post_photo_social", "post_video_social"}
+_SOCIAL_POST_TOOLS = {"post_job_post_social", "post_photo_social", "post_video_social", "post_to_social"}
 # Any tool message over this length gets compacted to a preview once a
 # later assistant message has arrived — generalized from a research-only
 # rule to cover every bulky tool (repo_read_file, search_jobs, etc.), since
@@ -300,6 +300,9 @@ _CAPABILITY_HANDOFF_PROFILES: dict[str, dict[str, Any]] = {
     "scheduling": {"tool_domains": ["scheduling"], "system_overlay": "Prefer schedule/reminder tools and confirm persisted ids.", "max_iter": min(MAX_AGENT_ITER, 4), "research_budget": 0},
     "social": {"tool_domains": ["social"], "system_overlay": "Draft/post social content only under explicit request and approval gates.", "max_iter": min(MAX_AGENT_ITER, 5), "research_budget": 0},
     "repo": {"tool_domains": ["repo"], "system_overlay": "Inspect repository files before proposing code or architecture changes.", "max_iter": MAX_AGENT_ITER, "research_budget": 0},
+    "job_hunt": {"tool_domains": ["job_hunt", "social"], "system_overlay": "Prefer job-hunt tools; social posting still requires approval.", "max_iter": min(MAX_AGENT_ITER, 6), "research_budget": 1},
+    "photo": {"tool_domains": ["photo", "social"], "system_overlay": "Use photo workspace tools first; posting requires approval.", "max_iter": min(MAX_AGENT_ITER, 6), "research_budget": 0},
+    "kb_proposal": {"tool_domains": ["kb"], "system_overlay": "Write durable knowledge through learn_knowledge or proposal artifacts; do not edit trusted wiki/skills directly.", "max_iter": min(MAX_AGENT_ITER, 5), "research_budget": 1},
 }
 
 
@@ -489,6 +492,7 @@ class AgentContext:
     user_id: str | None = None
     workspace: Path | None = None
     run_id: str | None = None
+    approval_bypass: frozenset[str] = frozenset()
 
 
 def _agent_context(owner=None, *, run_id: str | None = None) -> AgentContext:
@@ -510,13 +514,36 @@ def _context_attr(owner_or_ctx, name: str, default=None):
     return getattr(owner_or_ctx, legacy, default)
 
 
+def _context_embedder(owner_or_ctx):
+    if isinstance(owner_or_ctx, AgentContext):
+        return owner_or_ctx.embedder
+    return _owner_embedder(owner_or_ctx)
+
+
+AGENT_TRACE_MAX_BYTES = int(os.getenv("AGENT_TRACE_MAX_BYTES", "1048576"))
+AGENT_TRACE_MAX_FILES = int(os.getenv("AGENT_TRACE_MAX_FILES", "50"))
+
+
+def _trim_trace_dir(trace_dir: Path) -> None:
+    files = sorted(trace_dir.glob("*.jsonl*"), key=lambda path: path.stat().st_mtime, reverse=True)
+    for old in files[AGENT_TRACE_MAX_FILES:]:
+        try:
+            old.unlink()
+        except OSError:
+            pass
+
+
 def _append_step_trace(ctx: AgentContext | None, event: str, payload: dict[str, Any]) -> None:
     try:
         trace_dir = user_state_dir(ctx.user_id if ctx else None) / "agentic" / "traces"
         trace_dir.mkdir(parents=True, exist_ok=True)
         run_id = (ctx.run_id if ctx and ctx.run_id else "default")
+        trace_path = trace_dir / f"{run_id}.jsonl"
+        if trace_path.exists() and trace_path.stat().st_size >= AGENT_TRACE_MAX_BYTES:
+            trace_path.rename(trace_dir / f"{run_id}.{int(time.time())}.jsonl")
+        _trim_trace_dir(trace_dir)
         record = {"ts": time.time(), "event": event, "run_id": run_id, **payload}
-        with (trace_dir / f"{run_id}.jsonl").open("a", encoding="utf-8") as f:
+        with trace_path.open("a", encoding="utf-8") as f:
             f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
     except Exception as exc:  # pragma: no cover - tracing must never break tools
         log.debug("failed to append agentic trace: %s", exc)
@@ -534,22 +561,32 @@ def _persist_pending_approval(ctx: AgentContext, tool: str, args: dict[str, Any]
 
 
 def _maybe_resume_approval(owner, user_input: str, token_callback=None) -> str | None:
-    match = re.search(r"\b(run-[0-9]+|r[0-9A-Za-z_-]+)\b", user_input or "")
-    if not match or not re.search(r"\b(yes|confirm|approve|approved|resume|continue)\b", user_input or "", re.I):
+    if not re.search(r"\b(yes|confirm|approve|approved|resume|continue)\b", user_input or "", re.I):
         return None
-    ctx = _agent_context(owner, run_id=match.group(1))
+    base_ctx = _agent_context(owner)
+    match = re.search(r"\b(run-[0-9]+|r[0-9A-Za-z_-]+)\b", user_input or "")
+    if match:
+        run_id = match.group(1)
+    else:
+        pending_root = user_state_dir(base_ctx.user_id) / "agentic" / "pending_approvals"
+        pending = sorted(pending_root.glob("*.json"), key=lambda path: path.stat().st_mtime, reverse=True) if pending_root.exists() else []
+        if len(pending) != 1:
+            return None
+        run_id = pending[0].stem
+    ctx = _agent_context(owner, run_id=run_id)
     path = _pending_approval_path(ctx)
     if not path.exists():
         return None
     data = json.loads(path.read_text(encoding="utf-8"))
     tool_name = str(data.get("tool") or "")
-    spec = registry.get(tool_name)
-    if spec is not None:
-        spec.needs_approval = False
     state = TaskState(goal=f"resume approval {ctx.run_id}")
-    result = execute_tool_with_policy(tool_name, dict(data.get("args") or {}), state, ctx=ctx)
-    if spec is not None:
-        spec.needs_approval = True
+    resume_ctx = AgentContext(
+        client=ctx.client, llm_model=ctx.llm_model, embedder=ctx.embedder,
+        user_id=ctx.user_id, workspace=ctx.workspace, run_id=ctx.run_id,
+        approval_bypass=frozenset({tool_name}),
+    )
+    _append_step_trace(resume_ctx, "approval_resume", {"tool": tool_name})
+    result = execute_tool_with_policy(tool_name, dict(data.get("args") or {}), state, ctx=resume_ctx)
     if result.ok:
         try:
             path.unlink()
@@ -807,26 +844,26 @@ def dispatch_tool(name: str, args: dict, owner=None) -> str:
             args.get("query", ""),
             client=_context_attr(owner, "client"),
             model=_context_attr(owner, "llm_model"),
-            embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
+            embedder=_context_embedder(owner),
         )
     if name == "deep_research":
         return deep_research(
             args.get("query", ""),
             client=_context_attr(owner, "client"),
             model=_context_attr(owner, "llm_model"),
-            embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
+            embedder=_context_embedder(owner),
         )
     if name == "deep_read":
         return deep_read(
             args.get("url", ""),
             query=args.get("query", ""),
-            embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
+            embedder=_context_embedder(owner),
         )
     if name == "run_playbook":
         return schema.run_playbook_json(
             args.get("task", ""),
             cap_ids=args.get("cap_ids") if isinstance(args.get("cap_ids"), list) else None,
-            embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
+            embedder=_context_embedder(owner),
             llm_client=_context_attr(owner, "client"),
             llm_model=_context_attr(owner, "llm_model"),
         )
@@ -836,7 +873,7 @@ def dispatch_tool(name: str, args: dict, owner=None) -> str:
                 args.get("relative_path", ""),
                 title=args.get("title") or None,
                 kind=args.get("kind", "ingested"),
-                embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
+                embedder=_context_embedder(owner),
             )
         else:
             doc_id = ingest_knowledge_text(
@@ -844,14 +881,14 @@ def dispatch_tool(name: str, args: dict, owner=None) -> str:
                 args.get("text", ""),
                 source=args.get("source", ""),
                 kind=args.get("kind", "ingested"),
-                embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
+                embedder=_context_embedder(owner),
             )
         return json.dumps({"ok": bool(doc_id), "doc_id": doc_id}, ensure_ascii=False)
     if name == "search_skillsets":
         return search_skillsets_json(
             args.get("query", ""),
             int(args.get("limit", 3) or 3),
-            embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
+            embedder=_context_embedder(owner),
         )
     if name == "write_report":
         return write_report(
@@ -921,10 +958,11 @@ def execute_tool_with_policy(name: str, args: dict, state: TaskState, owner=None
         state.record(validation)
         return validation
 
-    if spec and spec.needs_approval:
+    if spec and spec.needs_approval and name not in ctx.approval_bypass:
         _persist_pending_approval(ctx, name, args, state)
-        result = ToolResult(ok=False, tool=name, args=args, content=json.dumps({"status": "waiting_for_approval", "run_id": ctx.run_id}, ensure_ascii=False), error_type="needs_approval", retryable=False, metadata={"run_id": ctx.run_id, "checkpoint": state.summary()})
+        result = ToolResult(ok=False, tool=name, args=args, content=json.dumps({"status": "waiting_for_approval", "run_id": ctx.run_id, "instruction": f"Reply with approve {ctx.run_id} to run {name}."}, ensure_ascii=False), error_type="needs_approval", retryable=False, metadata={"run_id": ctx.run_id, "checkpoint": state.summary()})
         state.record(result)
+        _append_step_trace(ctx, "approval_wait", {"tool": name, "args": args})
         _append_step_trace(ctx, "tool_result", {"tool": name, "ok": False, "error_type": "needs_approval"})
         return result
 

--- a/agentic/agentic.py
+++ b/agentic/agentic.py
@@ -38,7 +38,7 @@ import numpy as np
 
 from system.log import get_logger
 from system import bioclock
-from system.userspace import user_state_dir
+from system.userspace import current_user_id, user_state_dir, user_workspace_root
 from cognition import reason
 from cognition import CONTEXT_POOL
 from agentic.skills import list_skillsets, load_skillset, load_skills, search_skillsets_json, skill_context_for
@@ -46,7 +46,7 @@ from agentic.wiki import wiki_agentic_contexts_for
 from agentic.capability import match_capabilities, filtered_tool_schemas
 from agentic.guardrails import DEFAULT_POST_ANSWER_GUARDRAILS, default_pre_tool_guardrails
 from memory.knowledge import knowledge_context_for, ingest_text as ingest_knowledge_text, ingest_file as ingest_knowledge_file
-from agentic import experience
+from agentic import experience, skill_learning
 from agentic import graph_engine as schema
 from agentic.tools import (
     adaptive_search,
@@ -487,15 +487,18 @@ class AgentContext:
     llm_model: str | None = None
     embedder: Any = None
     user_id: str | None = None
+    workspace: Path | None = None
     run_id: str | None = None
 
 
 def _agent_context(owner=None, *, run_id: str | None = None) -> AgentContext:
+    uid = getattr(owner, "user_id", None) or getattr(owner, "_user_id", None) or current_user_id()
     return AgentContext(
         client=getattr(owner, "_client", None),
         llm_model=getattr(owner, "_llm_model", None),
         embedder=_owner_embedder(owner),
-        user_id=getattr(owner, "user_id", None) or getattr(owner, "_user_id", None),
+        user_id=uid,
+        workspace=user_workspace_root(uid),
         run_id=run_id,
     )
 
@@ -517,6 +520,45 @@ def _append_step_trace(ctx: AgentContext | None, event: str, payload: dict[str, 
             f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
     except Exception as exc:  # pragma: no cover - tracing must never break tools
         log.debug("failed to append agentic trace: %s", exc)
+
+
+def _pending_approval_path(ctx: AgentContext) -> Path:
+    root = user_state_dir(ctx.user_id) / "agentic" / "pending_approvals"
+    root.mkdir(parents=True, exist_ok=True)
+    return root / f"{ctx.run_id}.json"
+
+
+def _persist_pending_approval(ctx: AgentContext, tool: str, args: dict[str, Any], state: "TaskState") -> None:
+    payload = {"run_id": ctx.run_id, "tool": tool, "args": args, "checkpoint": json.loads(state.summary()), "created_at": time.time()}
+    _pending_approval_path(ctx).write_text(json.dumps(payload, ensure_ascii=False, indent=2, default=str), encoding="utf-8")
+
+
+def _maybe_resume_approval(owner, user_input: str, token_callback=None) -> str | None:
+    match = re.search(r"\b(run-[0-9]+|r[0-9A-Za-z_-]+)\b", user_input or "")
+    if not match or not re.search(r"\b(yes|confirm|approve|approved|resume|continue)\b", user_input or "", re.I):
+        return None
+    ctx = _agent_context(owner, run_id=match.group(1))
+    path = _pending_approval_path(ctx)
+    if not path.exists():
+        return None
+    data = json.loads(path.read_text(encoding="utf-8"))
+    tool_name = str(data.get("tool") or "")
+    spec = registry.get(tool_name)
+    if spec is not None:
+        spec.needs_approval = False
+    state = TaskState(goal=f"resume approval {ctx.run_id}")
+    result = execute_tool_with_policy(tool_name, dict(data.get("args") or {}), state, ctx=ctx)
+    if spec is not None:
+        spec.needs_approval = True
+    if result.ok:
+        try:
+            path.unlink()
+        except OSError:
+            pass
+    final = result.observation()
+    if token_callback:
+        token_callback(final)
+    return final
 
 @dataclass
 class ToolResult:
@@ -809,7 +851,7 @@ def dispatch_tool(name: str, args: dict, owner=None) -> str:
         return search_skillsets_json(
             args.get("query", ""),
             int(args.get("limit", 3) or 3),
-            embedder=_owner_embedder(owner),
+            embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
         )
     if name == "write_report":
         return write_report(
@@ -858,17 +900,12 @@ def _max_attempts_for(name: str) -> int:
     return 1
 
 
-def execute_tool_with_policy(name: str, args: dict, state: TaskState, owner=None, ctx: AgentContext | None = None) -> ToolResult:
+def execute_tool_with_policy(name: str, args: dict, state: TaskState, owner=None, ctx: AgentContext | None = None, guards=None) -> ToolResult:
     """Validate, guard, run, retry, and ledger one tool call."""
     ctx = ctx or (owner if isinstance(owner, AgentContext) else _agent_context(owner))
     _append_step_trace(ctx, "tool_call", {"tool": name, "args": args})
     spec = registry.get(name)
-    if spec and spec.needs_approval:
-        result = ToolResult(ok=False, tool=name, args=args, content=json.dumps({"status": "waiting_for_approval", "run_id": ctx.run_id}, ensure_ascii=False), error_type="needs_approval", retryable=False, metadata={"run_id": ctx.run_id, "checkpoint": state.summary()})
-        state.record(result)
-        _append_step_trace(ctx, "tool_result", {"tool": name, "ok": False, "error_type": "needs_approval"})
-        return result
-    for guard in _PRE_TOOL_GUARDRAILS:
+    for guard in (guards or _PRE_TOOL_GUARDRAILS):
         verdict = guard(name, args, state)
         if verdict is not None:
             result = ToolResult(
@@ -883,6 +920,13 @@ def execute_tool_with_policy(name: str, args: dict, state: TaskState, owner=None
     if validation is not None:
         state.record(validation)
         return validation
+
+    if spec and spec.needs_approval:
+        _persist_pending_approval(ctx, name, args, state)
+        result = ToolResult(ok=False, tool=name, args=args, content=json.dumps({"status": "waiting_for_approval", "run_id": ctx.run_id}, ensure_ascii=False), error_type="needs_approval", retryable=False, metadata={"run_id": ctx.run_id, "checkpoint": state.summary()})
+        state.record(result)
+        _append_step_trace(ctx, "tool_result", {"tool": name, "ok": False, "error_type": "needs_approval"})
+        return result
 
     last = ToolResult(ok=False, tool=name, args=args, content="[tool did not run]", error_type="not_run")
     for attempt in range(1, _max_attempts_for(name) + 1):
@@ -1200,6 +1244,10 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
     # and intent routing for every RAG-selection call below (agentic policy,
     # wiki, skill, experience, and now capability matching). Falls back to
     # keyword scoring automatically if unavailable.
+    resumed = _maybe_resume_approval(owner, user_input, token_callback=token_callback)
+    if resumed is not None:
+        return resumed
+
     _embedder = _owner_embedder(owner)
 
     _query_vec = query_vec
@@ -1212,7 +1260,18 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
     # can only shrink the list, never regress a turn.
     _matched_caps = match_capabilities(user_input, embedder=_embedder, query_vector=_cap_vec)
     handoff_profile = _handoff_profile_for(_matched_caps)
+    trace_ctx = _agent_context(owner, run_id=f"run-{int(time.time() * 1000)}")
+    _append_step_trace(trace_ctx, "llm_step", {"step": 0, "matched_capabilities": _matched_caps, "handoff_profile": handoff_profile})
     tools = filtered_tool_schemas(tool_schemas(), _matched_caps)
+    if handoff_profile.get("tool_domains"):
+        allowed_domains = set(handoff_profile["tool_domains"])
+        filtered = []
+        for schema_def in tools:
+            tool_name = schema_def.get("function", {}).get("name")
+            spec = registry.get(tool_name) if tool_name else None
+            if spec is None or spec.always_on or spec.domain in allowed_domains or tool_name == "final_answer":
+                filtered.append(schema_def)
+        tools = filtered or tools
 
     # Graph-first executor: known playbook workflows can run without an LLM
     # planning loop. Novel/ambiguous tasks return None and fall back to the
@@ -1224,6 +1283,8 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
             llm_client=owner._client, llm_model=owner._llm_model,
         )
         if graph_result is not None:
+            for _node in graph_result.results:
+                _append_step_trace(trace_ctx, "graph_node", {"node_id": getattr(_node, "node_id", ""), "tool": getattr(_node, "tool", ""), "ok": getattr(_node, "ok", False), "error_type": getattr(_node, "error_type", None)})
             _graph_ok = not any(not r.ok for r in graph_result.results)
 
             # Build a TaskState from the graph's node results so the SAME
@@ -1242,6 +1303,7 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
             graph_verdict: VerificationResult | None = None
             if AGENT_VERIFY_FINAL:
                 graph_verdict = _verify_final_answer(owner, user_input, graph_result.final_answer, graph_state)
+                _append_step_trace(trace_ctx, "verify", {"ok": graph_verdict.ok, "score": graph_verdict.score, "feedback": graph_verdict.feedback[:500], "mode": "graph"})
 
             graph_trustworthy = _graph_ok and (graph_verdict is None or graph_verdict.ok)
 
@@ -1259,6 +1321,11 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
                     experience.record_experience,
                     owner, user_input, graph_result.steps, graph_result.final_answer,
                     verified_ok=True, score=graph_verdict.score if graph_verdict else 1.0, embedder=_embedder,
+                )
+                CONTEXT_POOL.submit(
+                    skill_learning.propose_skill_from_run,
+                    user_input, graph_result.steps, graph_result.final_answer,
+                    verified_ok=True, score=graph_verdict.score if graph_verdict else 1.0, user_id=trace_ctx.user_id,
                 )
                 graph_payload = {
                     "id": graph_result.graph.id,
@@ -1304,6 +1371,11 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
                 experience.record_experience,
                 owner, user_input, graph_result.steps, graph_result.final_answer,
                 verified_ok=False, score=graph_verdict.score if graph_verdict else 0.0, embedder=_embedder,
+            )
+            CONTEXT_POOL.submit(
+                skill_learning.propose_skill_from_run,
+                user_input, graph_result.steps, graph_result.final_answer,
+                verified_ok=False, score=graph_verdict.score if graph_verdict else 0.0, user_id=trace_ctx.user_id,
             )
 
             if AGENT_EXECUTOR_MODE == "graph":
@@ -1450,8 +1522,7 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
     last_verdict: VerificationResult | None = None
     used_incomplete_fallback = False
 
-    trace_ctx = _agent_context(owner, run_id=f"run-{int(time.time() * 1000)}")
-    _append_step_trace(trace_ctx, "llm_step", {"step": 0, "matched_capabilities": _matched_caps, "handoff_profile": handoff_profile})
+    turn_guards = default_pre_tool_guardrails(int(handoff_profile.get("research_budget", AGENT_RESEARCH_MAX_CALLS)))
 
     for step in range(int(handoff_profile.get("max_iter") or MAX_AGENT_ITER)):
         if token_callback:
@@ -1484,6 +1555,7 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
             if AGENT_VERIFY_FINAL:
                 verdict = _verify_final_answer(owner, user_input, candidate, state)
                 last_verdict = verdict
+                _append_step_trace(trace_ctx, "verify", {"ok": verdict.ok, "score": verdict.score, "feedback": verdict.feedback[:500]})
                 if not verdict.ok and final_repairs < AGENT_MAX_FINAL_REPAIRS:
                     final_repairs += 1
                     messages.append({
@@ -1557,7 +1629,7 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
         if batch_calls:
             submitted = [
                 (call_id, name, CONTEXT_POOL.submit(
-                    execute_tool_with_policy, name, args, state, owner=owner, ctx=trace_ctx
+                    execute_tool_with_policy, name, args, state, owner=owner, ctx=trace_ctx, guards=turn_guards
                 ))
                 for call_id, name, args in batch_calls
             ]
@@ -1583,6 +1655,7 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
             if AGENT_VERIFY_FINAL:
                 verdict = _verify_final_answer(owner, user_input, candidate, state)
                 last_verdict = verdict
+                _append_step_trace(trace_ctx, "verify", {"ok": verdict.ok, "score": verdict.score, "feedback": verdict.feedback[:500]})
                 if not verdict.ok and final_repairs < AGENT_MAX_FINAL_REPAIRS:
                     final_repairs += 1
                     messages.append({
@@ -1646,6 +1719,11 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
         experience.record_experience,
         owner, user_input, state.steps, final_text,
         verified_ok=exp_verified_ok, score=exp_score, embedder=_embedder,
+    )
+    CONTEXT_POOL.submit(
+        skill_learning.propose_skill_from_run,
+        user_input, state.steps, final_text,
+        verified_ok=exp_verified_ok, score=exp_score, user_id=trace_ctx.user_id,
     )
     owner._emit(final_text, token_callback=token_callback)
 

--- a/agentic/agentic.py
+++ b/agentic/agentic.py
@@ -38,6 +38,7 @@ import numpy as np
 
 from system.log import get_logger
 from system import bioclock
+from system.userspace import user_state_dir
 from cognition import reason
 from cognition import CONTEXT_POOL
 from agentic.skills import list_skillsets, load_skillset, load_skills, search_skillsets_json, skill_context_for
@@ -294,6 +295,29 @@ _RESEARCH_TOOLS = {"adaptive_search", "deep_research", "deep_read"}
 _PRE_TOOL_GUARDRAILS = default_pre_tool_guardrails(AGENT_RESEARCH_MAX_CALLS)
 _POST_ANSWER_GUARDRAILS = DEFAULT_POST_ANSWER_GUARDRAILS
 
+_CAPABILITY_HANDOFF_PROFILES: dict[str, dict[str, Any]] = {
+    "research": {"tool_domains": ["research", "kb"], "system_overlay": "Research thoroughly, cite evidence, then synthesize.", "max_iter": MAX_AGENT_ITER, "research_budget": AGENT_RESEARCH_MAX_CALLS},
+    "scheduling": {"tool_domains": ["scheduling"], "system_overlay": "Prefer schedule/reminder tools and confirm persisted ids.", "max_iter": min(MAX_AGENT_ITER, 4), "research_budget": 0},
+    "social": {"tool_domains": ["social"], "system_overlay": "Draft/post social content only under explicit request and approval gates.", "max_iter": min(MAX_AGENT_ITER, 5), "research_budget": 0},
+    "repo": {"tool_domains": ["repo"], "system_overlay": "Inspect repository files before proposing code or architecture changes.", "max_iter": MAX_AGENT_ITER, "research_budget": 0},
+}
+
+
+def _handoff_profile_for(capabilities: list[str] | set[str] | tuple[str, ...]) -> dict[str, Any]:
+    profile: dict[str, Any] = {"tool_domains": [], "system_overlay": "", "max_iter": MAX_AGENT_ITER, "research_budget": AGENT_RESEARCH_MAX_CALLS}
+    domains: list[str] = []
+    overlays: list[str] = []
+    for cap in capabilities or []:
+        data = _CAPABILITY_HANDOFF_PROFILES.get(str(cap), {})
+        domains.extend(data.get("tool_domains", []))
+        if data.get("system_overlay"):
+            overlays.append(str(data["system_overlay"]))
+        profile["max_iter"] = min(int(profile["max_iter"]), int(data.get("max_iter", profile["max_iter"])))
+        profile["research_budget"] = min(int(profile["research_budget"]), int(data.get("research_budget", profile["research_budget"])))
+    profile["tool_domains"] = sorted(set(domains))
+    profile["system_overlay"] = "\n".join(overlays)
+    return profile
+
 
 _TOOLS: dict[str, tuple[dict, object]] = {}
 
@@ -453,6 +477,47 @@ def _recent_history_messages(owner, user_input: str = "", max_turns: int = AGENT
     return messages
 
 
+
+
+@dataclass(frozen=True)
+class AgentContext:
+    """Minimal execution context passed to tools instead of the whole owner."""
+
+    client: Any = None
+    llm_model: str | None = None
+    embedder: Any = None
+    user_id: str | None = None
+    run_id: str | None = None
+
+
+def _agent_context(owner=None, *, run_id: str | None = None) -> AgentContext:
+    return AgentContext(
+        client=getattr(owner, "_client", None),
+        llm_model=getattr(owner, "_llm_model", None),
+        embedder=_owner_embedder(owner),
+        user_id=getattr(owner, "user_id", None) or getattr(owner, "_user_id", None),
+        run_id=run_id,
+    )
+
+
+def _context_attr(owner_or_ctx, name: str, default=None):
+    if isinstance(owner_or_ctx, AgentContext):
+        return getattr(owner_or_ctx, name, default)
+    legacy = {"client": "_client", "llm_model": "_llm_model"}.get(name, name)
+    return getattr(owner_or_ctx, legacy, default)
+
+
+def _append_step_trace(ctx: AgentContext | None, event: str, payload: dict[str, Any]) -> None:
+    try:
+        trace_dir = user_state_dir(ctx.user_id if ctx else None) / "agentic" / "traces"
+        trace_dir.mkdir(parents=True, exist_ok=True)
+        run_id = (ctx.run_id if ctx and ctx.run_id else "default")
+        record = {"ts": time.time(), "event": event, "run_id": run_id, **payload}
+        with (trace_dir / f"{run_id}.jsonl").open("a", encoding="utf-8") as f:
+            f.write(json.dumps(record, ensure_ascii=False, default=str) + "\n")
+    except Exception as exc:  # pragma: no cover - tracing must never break tools
+        log.debug("failed to append agentic trace: %s", exc)
+
 @dataclass
 class ToolResult:
     """Structured outcome for one tool call attempt."""
@@ -538,6 +603,10 @@ def tool_schemas() -> list[dict]:
 
 
 from agentic.registry import TOOLS, ValidationError, registry, register_tool_schema, tool
+try:
+    from agentic.tool_models import LearnKnowledgeArgs
+except Exception:  # pragma: no cover - pydantic may be unavailable in minimal envs
+    LearnKnowledgeArgs = None
 
 
 def _bootstrap_tool_registry() -> None:
@@ -564,6 +633,7 @@ def _register_agentic_local_tools() -> None:
         },
         required=["title"],
         domain="kb",
+        args_model=LearnKnowledgeArgs,
     )
 
 
@@ -693,30 +763,30 @@ def dispatch_tool(name: str, args: dict, owner=None) -> str:
     if name == "adaptive_search":
         return adaptive_search(
             args.get("query", ""),
-            client=getattr(owner, "_client", None),
-            model=getattr(owner, "_llm_model", None),
-            embedder=_owner_embedder(owner),
+            client=_context_attr(owner, "client"),
+            model=_context_attr(owner, "llm_model"),
+            embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
         )
     if name == "deep_research":
         return deep_research(
             args.get("query", ""),
-            client=getattr(owner, "_client", None),
-            model=getattr(owner, "_llm_model", None),
-            embedder=_owner_embedder(owner),
+            client=_context_attr(owner, "client"),
+            model=_context_attr(owner, "llm_model"),
+            embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
         )
     if name == "deep_read":
         return deep_read(
             args.get("url", ""),
             query=args.get("query", ""),
-            embedder=_owner_embedder(owner),
+            embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
         )
     if name == "run_playbook":
         return schema.run_playbook_json(
             args.get("task", ""),
             cap_ids=args.get("cap_ids") if isinstance(args.get("cap_ids"), list) else None,
-            embedder=_owner_embedder(owner),
-            llm_client=owner._client,
-            llm_model=owner._llm_model,
+            embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
+            llm_client=_context_attr(owner, "client"),
+            llm_model=_context_attr(owner, "llm_model"),
         )
     if name == "learn_knowledge":
         if (args.get("relative_path") or "").strip():
@@ -724,7 +794,7 @@ def dispatch_tool(name: str, args: dict, owner=None) -> str:
                 args.get("relative_path", ""),
                 title=args.get("title") or None,
                 kind=args.get("kind", "ingested"),
-                embedder=_owner_embedder(owner),
+                embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
             )
         else:
             doc_id = ingest_knowledge_text(
@@ -732,7 +802,7 @@ def dispatch_tool(name: str, args: dict, owner=None) -> str:
                 args.get("text", ""),
                 source=args.get("source", ""),
                 kind=args.get("kind", "ingested"),
-                embedder=_owner_embedder(owner),
+                embedder=owner.embedder if isinstance(owner, AgentContext) else _owner_embedder(owner),
             )
         return json.dumps({"ok": bool(doc_id), "doc_id": doc_id}, ensure_ascii=False)
     if name == "search_skillsets":
@@ -788,8 +858,16 @@ def _max_attempts_for(name: str) -> int:
     return 1
 
 
-def execute_tool_with_policy(name: str, args: dict, state: TaskState, owner=None) -> ToolResult:
+def execute_tool_with_policy(name: str, args: dict, state: TaskState, owner=None, ctx: AgentContext | None = None) -> ToolResult:
     """Validate, guard, run, retry, and ledger one tool call."""
+    ctx = ctx or (owner if isinstance(owner, AgentContext) else _agent_context(owner))
+    _append_step_trace(ctx, "tool_call", {"tool": name, "args": args})
+    spec = registry.get(name)
+    if spec and spec.needs_approval:
+        result = ToolResult(ok=False, tool=name, args=args, content=json.dumps({"status": "waiting_for_approval", "run_id": ctx.run_id}, ensure_ascii=False), error_type="needs_approval", retryable=False, metadata={"run_id": ctx.run_id, "checkpoint": state.summary()})
+        state.record(result)
+        _append_step_trace(ctx, "tool_result", {"tool": name, "ok": False, "error_type": "needs_approval"})
+        return result
     for guard in _PRE_TOOL_GUARDRAILS:
         verdict = guard(name, args, state)
         if verdict is not None:
@@ -808,7 +886,7 @@ def execute_tool_with_policy(name: str, args: dict, state: TaskState, owner=None
 
     last = ToolResult(ok=False, tool=name, args=args, content="[tool did not run]", error_type="not_run")
     for attempt in range(1, _max_attempts_for(name) + 1):
-        last = dispatch_tool_checked(name, dict(args), owner=owner)
+        last = dispatch_tool_checked(name, dict(args), owner=ctx)
         last.attempts = attempt
         if last.ok or not last.retryable:
             break
@@ -816,6 +894,7 @@ def execute_tool_with_policy(name: str, args: dict, state: TaskState, owner=None
             time.sleep(AGENT_TOOL_RETRY_BACKOFF * attempt)
 
     state.record(last)
+    _append_step_trace(ctx, "tool_result", {"tool": name, "ok": last.ok, "error_type": last.error_type, "attempts": last.attempts})
     return last
 
 
@@ -1132,6 +1211,7 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
     # No match -> filtered_tool_schemas returns everything unchanged, so this
     # can only shrink the list, never regress a turn.
     _matched_caps = match_capabilities(user_input, embedder=_embedder, query_vector=_cap_vec)
+    handoff_profile = _handoff_profile_for(_matched_caps)
     tools = filtered_tool_schemas(tool_schemas(), _matched_caps)
 
     # Graph-first executor: known playbook workflows can run without an LLM
@@ -1325,6 +1405,7 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
         f"{agentic_policy_context}\n\n"
         f"{wiki_context}\n\n"
         f"{TASK_MODE_CORE}\n\n"
+        f"{handoff_profile.get('system_overlay', '')}\n\n"
         f"{memory_context}\n\n"
         f"{skill_context}\n\n"
         f"{knowledge_context}\n\n"
@@ -1369,7 +1450,10 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
     last_verdict: VerificationResult | None = None
     used_incomplete_fallback = False
 
-    for step in range(MAX_AGENT_ITER):
+    trace_ctx = _agent_context(owner, run_id=f"run-{int(time.time() * 1000)}")
+    _append_step_trace(trace_ctx, "llm_step", {"step": 0, "matched_capabilities": _matched_caps, "handoff_profile": handoff_profile})
+
+    for step in range(int(handoff_profile.get("max_iter") or MAX_AGENT_ITER)):
         if token_callback:
             token_callback("__THINKING__\n")
 
@@ -1473,7 +1557,7 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
         if batch_calls:
             submitted = [
                 (call_id, name, CONTEXT_POOL.submit(
-                    execute_tool_with_policy, name, args, state, owner=owner
+                    execute_tool_with_policy, name, args, state, owner=owner, ctx=trace_ctx
                 ))
                 for call_id, name, args in batch_calls
             ]
@@ -1530,6 +1614,8 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
                             }, ensure_ascii=False, indent=2),
                         })
                         continue
+                    final_text = json.dumps({"ok": False, "error_type": "structured_output_validation_failed", "errors": detail}, ensure_ascii=False)
+                    break
             final_text = candidate
             messages.append({
                 "role": "tool", "tool_call_id": call_id,

--- a/agentic/capability.py
+++ b/agentic/capability.py
@@ -4,11 +4,15 @@ agentic/capability.py
 Capability routing for Aiko's agentic tool loop.
 
 A capability holds no content of its own — it's a lookup that says, for a
-given turn, which tool-schema domains should reach the LLM. Prose retrieval
-(wiki/skill excerpts) is untouched and still goes through wiki_context_for /
-skill_context_for exactly as before. This module only narrows the `tools=`
-list passed to chat.completions.create(), which today is the full fixed
-_TOOL_SCHEMAS set on every single turn regardless of what the turn needs.
+given turn, which tool-schema domains should reach the LLM, plus the turn
+policy (system overlay, max_iter, research_budget) that used to live in a
+second, hand-maintained table in agentic.py. Capability is now the single
+source of truth for all of that; agentic.py just calls resolve_handoff()
+and applies the result. Prose retrieval (wiki/skill excerpts) is untouched
+and still goes through wiki_context_for / skill_context_for exactly as
+before. This module only narrows the `tools=` list passed to
+chat.completions.create(), which used to be the full fixed _TOOL_SCHEMAS
+set on every single turn regardless of what the turn needs.
 
 Safe-by-default: if no capability matches, or embedding fails, the full
 tool list is returned unchanged — this can only narrow, never break, an
@@ -17,7 +21,7 @@ existing turn.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Protocol
 import hashlib
@@ -43,19 +47,67 @@ class Capability:
     id: str
     triggers: tuple[str, ...]        # full example phrases for semantic/keyword match
     tool_domains: tuple[str, ...] = ()
+    system_overlay: str = ""
+    max_iter: int | None = None          # None -> use global MAX_AGENT_ITER
+    research_budget: int | None = None   # None -> use global AGENT_RESEARCH_MAX_CALLS
 
 
-# Tool domains and always-on flags are derived from the central registry.
+@dataclass(frozen=True)
+class HandoffProfile:
+    """Resolved turn policy for one or more matched capabilities."""
+
+    tool_domains: frozenset[str]
+    system_overlay: str
+    max_iter: int
+    research_budget: int
+    capability_ids: tuple[str, ...]
+
+
+# Tool domains and turn policy are derived from the central registry / this
+# module. Kept in Python since these are code-level capability -> domain
+# mappings, not user-editable data.
 from agentic.registry import registry
-# Kept in Python since these are code-level capability -> domain mappings.
+
 _CAPABILITY_TOOL_DOMAINS: dict[str, tuple[str, ...]] = {
     "research": ("research", "kb", "reports"),
     "scheduling": ("scheduling",),
     "kb_proposal": ("kb", "skills"),
-    "photo": ("photo",),
+    "photo": ("photo", "social"),
     "repo": ("repo", "skills", "reports"),
-    "job_hunt": ("jobs",),
+    "job_hunt": ("jobs", "social"),
     "social": ("social",),
+}
+
+# Per-capability system overlay injected into the agentic system prompt
+# when that capability is matched. Empty string -> no overlay contribution.
+_CAPABILITY_SYSTEM_OVERLAYS: dict[str, str] = {
+    "research": "Research thoroughly, cite evidence, then synthesize.",
+    "scheduling": "Prefer schedule/reminder tools and confirm persisted ids.",
+    "kb_proposal": "Write durable knowledge through learn_knowledge or proposal artifacts; do not edit trusted wiki/skills directly.",
+    "photo": "Use photo workspace tools first; posting requires approval.",
+    "repo": "Inspect repository files before proposing code or architecture changes.",
+    "job_hunt": "Prefer job-hunt tools; social posting still requires approval.",
+    "social": "Draft/post social content only under explicit request and approval gates.",
+}
+
+# Per-capability turn caps. Omitted / None -> fall back to the global
+# MAX_AGENT_ITER / AGENT_RESEARCH_MAX_CALLS default passed into
+# resolve_handoff() by the caller.
+_CAPABILITY_MAX_ITER: dict[str, int] = {
+    "scheduling": 4,
+    "social": 5,
+    "job_hunt": 6,
+    "photo": 6,
+    "kb_proposal": 5,
+}
+
+_CAPABILITY_RESEARCH_BUDGET: dict[str, int] = {
+    "scheduling": 0,
+    "social": 0,
+    "repo": 0,
+    "job_hunt": 1,
+    "photo": 0,
+    "kb_proposal": 1,
 }
 
 
@@ -74,9 +126,51 @@ CAPABILITIES: dict[str, Capability] = {
         id=cap_id,
         triggers=_TRIGGERS[cap_id],
         tool_domains=_CAPABILITY_TOOL_DOMAINS[cap_id],
+        system_overlay=_CAPABILITY_SYSTEM_OVERLAYS.get(cap_id, ""),
+        max_iter=_CAPABILITY_MAX_ITER.get(cap_id),
+        research_budget=_CAPABILITY_RESEARCH_BUDGET.get(cap_id),
     )
     for cap_id in _TRIGGERS
 }
+
+
+def resolve_handoff(
+    cap_ids: list[str],
+    *,
+    default_max_iter: int,
+    default_research_budget: int,
+) -> HandoffProfile:
+    """Resolve matched capability ids into one turn policy.
+
+    Unknown ids are dropped silently (mirrors the old filtered_tool_schemas
+    behavior). Multiple matched capabilities combine as: union of tool
+    domains, newline-joined overlays (in CAPABILITIES iteration order via
+    cap_ids order), and the MIN of any per-capability max_iter/research_budget
+    override versus the running default — i.e. the most restrictive
+    capability wins, never the most permissive.
+    """
+    valid = [cid for cid in cap_ids if cid in CAPABILITIES]
+    domains: set[str] = set()
+    overlays: list[str] = []
+    max_iter = default_max_iter
+    research_budget = default_research_budget
+    for cid in valid:
+        cap = CAPABILITIES[cid]
+        domains.update(cap.tool_domains)
+        if cap.system_overlay:
+            overlays.append(cap.system_overlay)
+        if cap.max_iter is not None:
+            max_iter = min(max_iter, cap.max_iter)
+        if cap.research_budget is not None:
+            research_budget = min(research_budget, cap.research_budget)
+    return HandoffProfile(
+        tool_domains=frozenset(domains),
+        system_overlay="\n".join(overlays),
+        max_iter=max_iter,
+        research_budget=research_budget,
+        capability_ids=tuple(valid),
+    )
+
 
 # High-signal keyword fallback for environments where the embedder is
 # unavailable (tests, degraded boots, or cold startup failures). The old
@@ -228,7 +322,14 @@ def filtered_tool_schemas(all_schemas: list[dict], cap_ids: list[str]) -> list[d
     """Narrow the full tool schema list to always-on tools plus whatever
     domains the matched capabilities pull in. No match -> return everything
     unchanged, so this can only reduce tool-list size, never regress a turn
-    that the old keyword/semantic matching would have handled fine."""
+    that the old keyword/semantic matching would have handled fine.
+
+    This is the ONLY domain filter pass — callers should not apply a second,
+    separate domain filter on top of this one (see resolve_handoff's
+    tool_domains, which is derived from the same CAPABILITIES table and is
+    provided for callers that need the resolved domain set without
+    re-deriving it, not for a second filtering pass).
+    """
     if not cap_ids:
         return all_schemas
     # Filter out unknown capability IDs to avoid KeyError

--- a/agentic/graph_engine.py
+++ b/agentic/graph_engine.py
@@ -1253,9 +1253,11 @@ def _condition_actual(cond: dict[str, Any], results: dict[str, NodeResult], stat
         if state is None:
             return None
         value = state.get(str(cond["state"]))
+        if value is None:
+            return None
         if isinstance(value, (dict, list, tuple)):
             return json.dumps(value, ensure_ascii=False)
-        return str(value if value is not None else "")
+        return str(value)
     ref = cond.get("node")
     if ref is not None:
         if ref not in results:

--- a/agentic/graph_engine.py
+++ b/agentic/graph_engine.py
@@ -192,6 +192,7 @@ class PlanNode:
     max_retries: int = 0
     retry_backoff_seconds: float = 1.0
     fallback_to: str | None = None
+    needs_approval: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -1167,12 +1168,21 @@ def _tool_params(fn: Callable[..., Any]) -> frozenset[str]:
 
 def _run_node(node: PlanNode, prompt: str, results: dict[str, NodeResult],
                embedder=None, llm_client=None, llm_model: str | None = None,
-               extras: dict[str, Any] | None = None, state: GraphState | None = None) -> NodeResult:
+               extras: dict[str, Any] | None = None, state: GraphState | None = None,
+               run_id: str | None = None) -> NodeResult:
     tools = _tool_map()
     fn = tools.get(node.tool)
     args = _substitute(node.args, prompt, results, extras)
     if fn is None:
         return NodeResult(node.id, node.tool, False, f"unknown graph tool: {node.tool}", args=args, error_type="unknown_tool")
+    try:
+        from agentic.registry import registry
+        spec = registry.get(node.tool)
+    except Exception:
+        spec = None
+    if node.needs_approval or (spec is not None and getattr(spec, "needs_approval", False)):
+        content = json.dumps({"status": "waiting_for_approval", "run_id": run_id, "node_id": node.id, "tool": node.tool}, ensure_ascii=False)
+        return NodeResult(node.id, node.tool, False, content, args=args, error_type="needs_approval")
     if node.tool == "save_note":
         args["content"] = str(args.get("content", ""))[:AGENT_NOTE_MAX_CHARS]
 
@@ -1416,7 +1426,7 @@ def _execute_graph_inner(graph: PlanGraph, embedder=None, llm_client=None,
                 continue
             future_map = {}
             for node in runnable:
-                future_map[pool.submit(_run_node, node, graph.goal, results, embedder, llm_client, llm_model, extras, state)] = node
+                future_map[pool.submit(_run_node, node, graph.goal, results, embedder, llm_client, llm_model, extras, state, run_id)] = node
             for fut in as_completed(future_map):
                 node = future_map[fut]
                 try:

--- a/agentic/guardrails.py
+++ b/agentic/guardrails.py
@@ -148,6 +148,5 @@ DEFAULT_POST_ANSWER_GUARDRAILS: tuple[PostAnswerGuard, ...] = (
 
 def default_pre_tool_guardrails(max_research_calls: int) -> tuple[PreToolGuard, ...]:
     return (
-        social_post_requires_review_bundle,
         research_budget_guard(max_research_calls),
     )

--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -24,6 +24,8 @@ from system.config import load_yaml
 
 log = logging.getLogger(__name__)
 
+APPROVAL_REQUIRED_TOOLS = ("post_job_post_social", "post_photo_social", "post_video_social", "post_to_social")
+
 
 @dataclass
 class ToolSpec:
@@ -145,13 +147,10 @@ def _attach_builtin_arg_models() -> None:
     for name, model in mapping.items():
         if name in TOOLS:
             TOOLS[name].args_model = model
-    for name in ("post_job_post_social", "post_photo_social", "post_video_social"):
-        if name in TOOLS:
-            TOOLS[name].needs_approval = True
 
 
 _attach_builtin_arg_models()
-for _approval_tool in ("post_job_post_social", "post_photo_social", "post_video_social"):
+for _approval_tool in APPROVAL_REQUIRED_TOOLS:
     if _approval_tool in TOOLS:
         TOOLS[_approval_tool].needs_approval = True
 

--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -34,6 +34,7 @@ class ToolSpec:
     required: List[str] = field(default_factory=list)
     args_model: Type[BaseModel] | None = None
     output_model: Type[BaseModel] | None = None
+    needs_approval: bool = False
     domain: Optional[str] = None  # capability routing (research, scheduling, etc.)
     always_on: bool = False  # always included in tool list regardless of capability match
     # Execution modes - which backends can execute this tool
@@ -109,6 +110,39 @@ def load_tool_catalog(path: str = "tools.yaml") -> Dict[str, ToolSpec]:
 TOOLS = load_tool_catalog()
 
 
+def _attach_builtin_arg_models() -> None:
+    """Attach concrete Pydantic schemas while keeping tools.yaml as fallback metadata."""
+    try:
+        from agentic.tool_models import (
+            DirectSocialPostArgs, DraftJobPostSocialArgs, DraftPhotoSocialArgs, DraftVideoSocialArgs,
+            LearnKnowledgeArgs, PostPhotoSocialArgs, PostSocialDraftArgs, PostVideoSocialArgs,
+            SaveNoteArgs, ScheduleJobArgs, ScheduleReminderArgs, WriteReportArgs,
+        )
+    except Exception as exc:  # pragma: no cover - import-time optional dependency fallback
+        log.warning("Pydantic tool argument models unavailable; using tools.yaml schemas: %s", exc)
+        return
+    mapping = {
+        "save_note": SaveNoteArgs,
+        "schedule_job": ScheduleJobArgs,
+        "schedule_reminder": ScheduleReminderArgs,
+        "learn_knowledge": LearnKnowledgeArgs,
+        "write_report": WriteReportArgs,
+        "draft_job_post_social": DraftJobPostSocialArgs,
+        "post_job_post_social": PostSocialDraftArgs,
+        "post_to_social": DirectSocialPostArgs,
+        "draft_photo_social": DraftPhotoSocialArgs,
+        "post_photo_social": PostPhotoSocialArgs,
+        "draft_video_social": DraftVideoSocialArgs,
+        "post_video_social": PostVideoSocialArgs,
+    }
+    for name, model in mapping.items():
+        if name in TOOLS:
+            TOOLS[name].args_model = model
+
+
+_attach_builtin_arg_models()
+
+
 class ToolRegistry:
     """Singleton registry tracking all declared agentic tools."""
 
@@ -130,6 +164,7 @@ class ToolRegistry:
         skill: bool = False,
         args_model: Type[BaseModel] | None = None,
         output_model: Type[BaseModel] | None = None,
+        needs_approval: bool = False,
     ) -> ToolSpec:
         spec = ToolSpec(
             name=name,
@@ -145,6 +180,7 @@ class ToolRegistry:
             skill=skill,
             args_model=args_model,
             output_model=output_model,
+            needs_approval=needs_approval,
         )
         self._tools[name] = spec
         return spec
@@ -240,6 +276,8 @@ class ToolRegistry:
                 entry["args_model"] = f"{spec.args_model.__module__}:{spec.args_model.__name__}"
             if spec.output_model is not None:
                 entry["output_model"] = f"{spec.output_model.__module__}:{spec.output_model.__name__}"
+            if spec.needs_approval:
+                entry["needs_approval"] = spec.needs_approval
             tools.append(entry)
         return {"tools": tools}
 
@@ -262,6 +300,7 @@ def tool(
     skill: bool = False,   # Must opt-in for skill workflow
     args_model: Type[BaseModel] | None = None,
     output_model: Type[BaseModel] | None = None,
+    needs_approval: bool = False,
 ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
     """Decorator to register a function as an agentic tool.
 
@@ -291,6 +330,7 @@ def tool(
             skill=skill,
             args_model=args_model,
             output_model=output_model,
+            needs_approval=needs_approval,
         )
 
     def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
@@ -308,6 +348,7 @@ def tool(
             skill=spec.skill,
             args_model=spec.args_model,
             output_model=spec.output_model,
+            needs_approval=spec.needs_approval,
         )
         return fn
     return decorator
@@ -327,6 +368,7 @@ def register_tool_schema(
     skill: bool = False,
     args_model: Type[BaseModel] | None = None,
     output_model: Type[BaseModel] | None = None,
+    needs_approval: bool = False,
 ) -> ToolSpec:
     """Register a tool schema whose execution is handled elsewhere.
 
@@ -348,4 +390,5 @@ def register_tool_schema(
         skill=skill,
         args_model=args_model,
         output_model=output_model,
+        needs_approval=needs_approval,
     )

--- a/agentic/registry.py
+++ b/agentic/registry.py
@@ -115,7 +115,8 @@ def _attach_builtin_arg_models() -> None:
     try:
         from agentic.tool_models import (
             DirectSocialPostArgs, DraftJobPostSocialArgs, DraftPhotoSocialArgs, DraftVideoSocialArgs,
-            LearnKnowledgeArgs, PostPhotoSocialArgs, PostSocialDraftArgs, PostVideoSocialArgs,
+            DeepReadArgs, LearnKnowledgeArgs, PostPhotoSocialArgs, PostSocialDraftArgs, PostVideoSocialArgs,
+            RepoFileTreeArgs, RepoReadFileArgs, RepoSearchTextArgs, ResearchQueryArgs,
             SaveNoteArgs, ScheduleJobArgs, ScheduleReminderArgs, WriteReportArgs,
         )
     except Exception as exc:  # pragma: no cover - import-time optional dependency fallback
@@ -127,6 +128,12 @@ def _attach_builtin_arg_models() -> None:
         "schedule_reminder": ScheduleReminderArgs,
         "learn_knowledge": LearnKnowledgeArgs,
         "write_report": WriteReportArgs,
+        "adaptive_search": ResearchQueryArgs,
+        "deep_research": ResearchQueryArgs,
+        "deep_read": DeepReadArgs,
+        "repo_file_tree": RepoFileTreeArgs,
+        "repo_read_file": RepoReadFileArgs,
+        "repo_search_text": RepoSearchTextArgs,
         "draft_job_post_social": DraftJobPostSocialArgs,
         "post_job_post_social": PostSocialDraftArgs,
         "post_to_social": DirectSocialPostArgs,
@@ -138,9 +145,15 @@ def _attach_builtin_arg_models() -> None:
     for name, model in mapping.items():
         if name in TOOLS:
             TOOLS[name].args_model = model
+    for name in ("post_job_post_social", "post_photo_social", "post_video_social"):
+        if name in TOOLS:
+            TOOLS[name].needs_approval = True
 
 
 _attach_builtin_arg_models()
+for _approval_tool in ("post_job_post_social", "post_photo_social", "post_video_social"):
+    if _approval_tool in TOOLS:
+        TOOLS[_approval_tool].needs_approval = True
 
 
 class ToolRegistry:

--- a/agentic/skill_learning.py
+++ b/agentic/skill_learning.py
@@ -1,0 +1,60 @@
+"""Machine-written skill proposal helpers for observe -> distill -> reuse loops.
+
+Trusted skillsets remain human-owned. This module only writes reviewable drafts
+under the active user's workspace so successful/failing workflows can be
+promoted deliberately later.
+"""
+from __future__ import annotations
+
+import json
+import re
+import time
+from pathlib import Path
+from typing import Any
+
+from system.userspace import user_workspace_root
+
+_SLUG_RE = re.compile(r"[^a-z0-9]+")
+
+
+def _slug(text: str) -> str:
+    return _SLUG_RE.sub("-", (text or "skill").lower()).strip("-")[:80] or "skill"
+
+
+def skill_proposal_dir(user_id: str | None = None) -> Path:
+    path = user_workspace_root(user_id) / "skill_proposals"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def propose_skill_from_run(goal: str, steps: list[dict[str, Any]], final_text: str, *, verified_ok: bool, score: float, user_id: str | None = None) -> Path | None:
+    """Draft or refine a reviewable skill proposal from an agentic run.
+
+    Successes capture reusable tool order. Failures append avoid-notes to the
+    same proposal path so repeated mistakes refine the draft without modifying
+    trusted `agentic/skillsets/` files.
+    """
+    if len(steps or []) < 2:
+        return None
+    path = skill_proposal_dir(user_id) / f"{_slug(goal)}.md"
+    tools = [str(s.get("tool")) for s in steps if s.get("tool")]
+    status = "success" if verified_ok and score >= 0.7 else "failure"
+    header = f"# Skill Proposal: {goal[:120]}\n\n"
+    if not path.exists():
+        path.write_text(header + "Status: draft_review_required\n\n", encoding="utf-8")
+    block = {
+        "ts": time.time(),
+        "status": status,
+        "score": score,
+        "tools": tools,
+        "steps": steps,
+        "final_preview": (final_text or "")[:1000],
+    }
+    with path.open("a", encoding="utf-8") as f:
+        f.write(f"\n## Observed run ({status})\n\n")
+        if status == "success":
+            f.write("Reusable tool order: " + " -> ".join(tools) + "\n\n")
+        else:
+            f.write("Avoid / failed approach notes: review this trace before promotion.\n\n")
+        f.write("```json\n" + json.dumps(block, ensure_ascii=False, indent=2, default=str) + "\n```\n")
+    return path

--- a/agentic/skill_learning.py
+++ b/agentic/skill_learning.py
@@ -4,6 +4,7 @@ Trusted skillsets remain human-owned. This module only writes reviewable drafts
 under the active user's workspace so successful/failing workflows can be
 promoted deliberately later.
 """
+
 from __future__ import annotations
 
 import json
@@ -16,6 +17,12 @@ from system.userspace import user_workspace_root
 
 _SLUG_RE = re.compile(r"[^a-z0-9]+")
 
+# Per-step args are capped independently of final_preview, since a step's
+# args can carry a full tool-call payload (report bodies, social post text,
+# ingested document text). Without this cap, repeated observed runs against
+# the same goal slug make the proposal file grow without bound.
+_STEP_ARGS_MAX_CHARS = 500
+
 
 def _slug(text: str) -> str:
     return _SLUG_RE.sub("-", (text or "skill").lower()).strip("-")[:80] or "skill"
@@ -27,6 +34,12 @@ def skill_proposal_dir(user_id: str | None = None) -> Path:
     return path
 
 
+def _truncated_step(step: dict[str, Any]) -> dict[str, Any]:
+    """Copy a step record with its args stringified and capped so a large
+    tool-call payload can't blow up the proposal file size."""
+    return {**step, "args": str(step.get("args"))[:_STEP_ARGS_MAX_CHARS]}
+
+
 def propose_skill_from_run(goal: str, steps: list[dict[str, Any]], final_text: str, *, verified_ok: bool, score: float, user_id: str | None = None) -> Path | None:
     """Draft or refine a reviewable skill proposal from an agentic run.
 
@@ -36,20 +49,24 @@ def propose_skill_from_run(goal: str, steps: list[dict[str, Any]], final_text: s
     """
     if len(steps or []) < 2:
         return None
+
     path = skill_proposal_dir(user_id) / f"{_slug(goal)}.md"
     tools = [str(s.get("tool")) for s in steps if s.get("tool")]
     status = "success" if verified_ok and score >= 0.7 else "failure"
+
     header = f"# Skill Proposal: {goal[:120]}\n\n"
     if not path.exists():
         path.write_text(header + "Status: draft_review_required\n\n", encoding="utf-8")
+
     block = {
         "ts": time.time(),
         "status": status,
         "score": score,
         "tools": tools,
-        "steps": [{**s, "args": str(s.get("args"))[:500]} for s in steps],
+        "steps": [_truncated_step(s) for s in steps],
         "final_preview": (final_text or "")[:1000],
     }
+
     with path.open("a", encoding="utf-8") as f:
         f.write(f"\n## Observed run ({status})\n\n")
         if status == "success":
@@ -57,4 +74,5 @@ def propose_skill_from_run(goal: str, steps: list[dict[str, Any]], final_text: s
         else:
             f.write("Avoid / failed approach notes: review this trace before promotion.\n\n")
         f.write("```json\n" + json.dumps(block, ensure_ascii=False, indent=2, default=str) + "\n```\n")
+
     return path

--- a/agentic/skill_learning.py
+++ b/agentic/skill_learning.py
@@ -47,7 +47,7 @@ def propose_skill_from_run(goal: str, steps: list[dict[str, Any]], final_text: s
         "status": status,
         "score": score,
         "tools": tools,
-        "steps": steps,
+        "steps": [{**s, "args": str(s.get("args"))[:500]} for s in steps],
         "final_preview": (final_text or "")[:1000],
     }
     with path.open("a", encoding="utf-8") as f:

--- a/agentic/tool_models.py
+++ b/agentic/tool_models.py
@@ -87,3 +87,28 @@ class PostPhotoSocialArgs(PostSocialDraftArgs):
 
 class PostVideoSocialArgs(PostSocialDraftArgs):
     providers: tuple[Literal["youtube"], ...] | None = None
+
+
+class ResearchQueryArgs(BaseModel):
+    query: str = Field(min_length=1)
+
+
+class DeepReadArgs(BaseModel):
+    url: str = Field(min_length=1)
+    query: str = ""
+
+
+class RepoFileTreeArgs(BaseModel):
+    prefix: str = ""
+    limit: int = Field(default=200, ge=1, le=2000)
+
+
+class RepoReadFileArgs(BaseModel):
+    relative_path: str = Field(min_length=1)
+    max_chars: int = Field(default=20000, ge=1, le=200000)
+
+
+class RepoSearchTextArgs(BaseModel):
+    query: str = Field(min_length=1)
+    prefix: str = ""
+    limit: int = Field(default=50, ge=1, le=500)

--- a/agentic/tool_models.py
+++ b/agentic/tool_models.py
@@ -25,6 +25,14 @@ class ScheduleJobArgs(BaseModel):
     skill: str | None = None
     user_id: str | None = None
 
+    @model_validator(mode="after")
+    def require_conditional_schedule_fields(self) -> "ScheduleJobArgs":
+        if self.action == "tool" and not self.tool_call:
+            raise ValueError("tool_call is required when action='tool'")
+        if self.frequency == "custom_weekdays" and not self.days_of_week:
+            raise ValueError("days_of_week is required when frequency='custom_weekdays'")
+        return self
+
 
 class ScheduleReminderArgs(BaseModel):
     title: str = Field(min_length=1)

--- a/agentic/tool_models.py
+++ b/agentic/tool_models.py
@@ -1,0 +1,89 @@
+"""Pydantic argument models for high-churn agentic tools."""
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field, model_validator
+
+
+class SaveNoteArgs(BaseModel):
+    title: str = Field(min_length=1)
+    content: str = Field(min_length=1)
+    folder: str = "notes"
+
+
+class ScheduleJobArgs(BaseModel):
+    title: str = Field(min_length=1)
+    task: str = Field(min_length=1)
+    time_of_day: str = Field(min_length=1)
+    frequency: Literal["once", "hourly", "daily", "weekdays", "weekly", "biweekly", "monthly", "custom_weekdays"] = "daily"
+    timezone: str | None = None
+    days_of_week: list[str] | str | None = None
+    action: Literal["announce", "agentic", "tool"] = "agentic"
+    relative_days: int | str | None = None
+    tool_call: dict[str, Any] | None = None
+    skill: str | None = None
+    user_id: str | None = None
+
+
+class ScheduleReminderArgs(BaseModel):
+    title: str = Field(min_length=1)
+    message: str = Field(min_length=1)
+    time_of_day: str = Field(min_length=1)
+    repeat: Literal["once", "daily"] = "daily"
+    timezone: str | None = None
+    user_id: str | None = None
+
+
+class LearnKnowledgeArgs(BaseModel):
+    title: str = Field(min_length=1)
+    text: str | None = None
+    relative_path: str | None = None
+    source: str = ""
+    kind: Literal["ingested", "self_learned", "study_note"] = "ingested"
+
+    @model_validator(mode="after")
+    def require_text_or_path(self) -> "LearnKnowledgeArgs":
+        if not (self.text or "").strip() and not (self.relative_path or "").strip():
+            raise ValueError("provide text or relative_path")
+        return self
+
+
+class WriteReportArgs(BaseModel):
+    title: str = Field(min_length=1)
+    content: str = ""
+    report_dir: str = "reports"
+    arxiv_style: bool = False
+    section: str = ""
+    append: bool = False
+
+
+class DraftJobPostSocialArgs(BaseModel):
+    force: bool = False
+
+
+class PostSocialDraftArgs(BaseModel):
+    draft_dir: str = Field(min_length=1)
+
+
+class DirectSocialPostArgs(BaseModel):
+    text: str = Field(min_length=1)
+    services: str = Field(min_length=1)
+    image_path: str | None = None
+
+
+class DraftPhotoSocialArgs(BaseModel):
+    inbox: str | None = None
+    force: bool = False
+
+
+class DraftVideoSocialArgs(BaseModel):
+    inbox: str | None = None
+
+
+class PostPhotoSocialArgs(PostSocialDraftArgs):
+    providers: tuple[Literal["pixelset"], ...] | None = None
+
+
+class PostVideoSocialArgs(PostSocialDraftArgs):
+    providers: tuple[Literal["youtube"], ...] | None = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "packaging>=26.2",
     "protobuf>=6.33.6",
     "pyyaml>=6.0.3",
+    "pydantic>=2",
     "python-dotenv>=1.0.0",
     "requests>=2.34.2",
     "scipy<1.18.0",

--- a/tests/unit/test_agentic_agentic.py
+++ b/tests/unit/test_agentic_agentic.py
@@ -622,5 +622,30 @@ def test_skill_proposal_written_for_multistep_run(monkeypatch, tmp_path):
     )
     assert path is not None
     assert "Reusable tool order" in path.read_text(encoding="utf-8")
+
+
+def test_handoff_profile_includes_additional_domains():
+    from agentic.agentic import _handoff_profile_for
+
+    profile = _handoff_profile_for(["job_hunt", "photo", "kb_proposal"])
+    assert "job_hunt" in profile["tool_domains"]
+    assert "photo" in profile["tool_domains"]
+    assert "kb" in profile["tool_domains"]
+
+
+def test_approval_resume_does_not_mutate_registry_flag(monkeypatch, tmp_path):
+    from agentic.agentic import AgentContext, TaskState, execute_tool_with_policy, _maybe_resume_approval
+    from agentic.registry import registry
+
+    registry.register("race_safe_approval_test", "approval test", handler=lambda **kwargs: "ok", needs_approval=True, react=True)
+    monkeypatch.setattr("agentic.agentic.user_state_dir", lambda user_id=None: tmp_path)
+    owner = MockOwner()
+    wait = execute_tool_with_policy("race_safe_approval_test", {}, TaskState(goal="approval"), ctx=AgentContext(run_id="r3"))
+    assert wait.error_type == "needs_approval"
+    assert registry.get("race_safe_approval_test").needs_approval is True
+    assert _maybe_resume_approval(owner, "approve r3") is not None
+    assert registry.get("race_safe_approval_test").needs_approval is True
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/test_agentic_agentic.py
+++ b/tests/unit/test_agentic_agentic.py
@@ -507,9 +507,6 @@ class TestSaveNoteContentTruncation:
         assert "note saved" in result.lower()
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
-
 def test_validate_args_uses_registered_pydantic_model():
     from pydantic import BaseModel, Field
     from agentic.registry import registry
@@ -556,3 +553,38 @@ def test_verify_final_answer_uses_post_answer_guardrails_for_saved_path(monkeypa
 
     assert verdict.ok is False
     assert "does not mention where it was saved" in verdict.feedback
+
+
+def test_handoff_profile_maps_capabilities():
+    from agentic.agentic import _handoff_profile_for
+
+    profile = _handoff_profile_for(["social", "scheduling"])
+    assert "social" in profile["tool_domains"]
+    assert "scheduling" in profile["tool_domains"]
+    assert profile["max_iter"] <= 5
+
+
+def test_needs_approval_returns_wait_result_and_checkpoint(monkeypatch, tmp_path):
+    from agentic.agentic import AgentContext, TaskState, execute_tool_with_policy
+    from agentic.registry import registry
+
+    registry.register("approval_test", "approval test", needs_approval=True, react=True)
+    monkeypatch.setattr("agentic.agentic.user_state_dir", lambda user_id=None: tmp_path)
+    state = TaskState(goal="approval")
+    result = execute_tool_with_policy("approval_test", {}, state, ctx=AgentContext(run_id="r1"))
+    assert result.error_type == "needs_approval"
+    assert result.metadata["run_id"] == "r1"
+    assert (tmp_path / "agentic" / "traces" / "r1.jsonl").exists()
+
+
+def test_agent_context_passed_to_dispatch(monkeypatch):
+    from agentic.agentic import AgentContext, dispatch_tool
+
+    seen = {}
+    monkeypatch.setattr("agentic.agentic.adaptive_search", lambda query, client=None, model=None, embedder=None: seen.update(client=client, model=model, embedder=embedder) or "ok")
+    ctx = AgentContext(client="c", llm_model="m", embedder="e")
+    assert dispatch_tool("adaptive_search", {"query": "q"}, owner=ctx) == "ok"
+    assert seen == {"client": "c", "model": "m", "embedder": "e"}
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_agentic_agentic.py
+++ b/tests/unit/test_agentic_agentic.py
@@ -586,5 +586,41 @@ def test_agent_context_passed_to_dispatch(monkeypatch):
     assert dispatch_tool("adaptive_search", {"query": "q"}, owner=ctx) == "ok"
     assert seen == {"client": "c", "model": "m", "embedder": "e"}
 
+
+def test_resume_approval_runs_pending_tool(monkeypatch, tmp_path):
+    from agentic.agentic import AgentContext, TaskState, execute_tool_with_policy, _maybe_resume_approval
+    from agentic.registry import registry
+
+    calls = []
+    def handler(**kwargs):
+        calls.append(kwargs)
+        return "posted"
+
+    registry.register("resume_approval_test", "approval test", handler=handler, needs_approval=True, react=True)
+    monkeypatch.setattr("agentic.agentic.user_state_dir", lambda user_id=None: tmp_path)
+    monkeypatch.setattr("agentic.agentic.user_workspace_root", lambda user_id=None: tmp_path / "workspace")
+    owner = MockOwner()
+    state = TaskState(goal="approval")
+    wait = execute_tool_with_policy("resume_approval_test", {"draft_dir": "d"}, state, ctx=AgentContext(run_id="r2"))
+    assert wait.error_type == "needs_approval"
+
+    resumed = _maybe_resume_approval(owner, "yes approve r2")
+    assert resumed is not None
+    assert calls == [{"draft_dir": "d"}]
+
+
+def test_skill_proposal_written_for_multistep_run(monkeypatch, tmp_path):
+    from agentic.skill_learning import propose_skill_from_run
+
+    monkeypatch.setattr("agentic.skill_learning.user_workspace_root", lambda user_id=None: tmp_path)
+    path = propose_skill_from_run(
+        "Summarize docs",
+        [{"tool": "repo_file_tree", "ok": True}, {"tool": "repo_read_file", "ok": True}],
+        "done",
+        verified_ok=True,
+        score=0.95,
+    )
+    assert path is not None
+    assert "Reusable tool order" in path.read_text(encoding="utf-8")
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/unit/test_agentic_graph_engine.py
+++ b/tests/unit/test_agentic_graph_engine.py
@@ -830,3 +830,9 @@ def test_graph_when_condition_skips_when_state_misses(monkeypatch):
 
     assert result.results[-1].node_id == "write"
     assert result.results[-1].content == "skipped: run_if condition not met"
+
+
+def test_condition_actual_missing_state_key_is_unsatisfied():
+    from agentic.graph_engine import _condition_actual
+
+    assert _condition_actual({"state": "route", "equals": ""}, {}, {}) is None

--- a/tests/unit/test_agentic_graph_engine.py
+++ b/tests/unit/test_agentic_graph_engine.py
@@ -777,9 +777,6 @@ class TestPlanNodeNewFields:
         assert hasattr(web_node, 'fallback_to')
 
 
-if __name__ == "__main__":
-    pytest.main([__file__, "-v"])
-
 
 def test_graph_when_condition_gates_on_shared_state(monkeypatch):
     def seed_state(state):
@@ -836,3 +833,16 @@ def test_condition_actual_missing_state_key_is_unsatisfied():
     from agentic.graph_engine import _condition_actual
 
     assert _condition_actual({"state": "route", "equals": ""}, {}, {}) is None
+
+
+def test_graph_node_needs_approval_returns_wait_result():
+    from agentic.graph_engine import _run_node, PlanNode
+
+    result = _run_node(PlanNode("post", "post_to_social", {"text": "hi", "services": "x"}, needs_approval=True), "prompt", {}, run_id="graph-r1")
+    assert result.ok is False
+    assert result.error_type == "needs_approval"
+    assert "graph-r1" in result.content
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tests/unit/test_agentic_registry.py
+++ b/tests/unit/test_agentic_registry.py
@@ -133,3 +133,15 @@ def test_pydantic_output_model_validates_json():
         "summary": "done",
         "confidence": 0.8,
     }
+
+
+def test_high_churn_tools_have_pydantic_arg_models():
+    from agentic.registry import TOOLS
+
+    for name in [
+        "save_note", "schedule_job", "schedule_reminder", "write_report",
+        "draft_job_post_social", "post_job_post_social", "post_to_social",
+        "draft_photo_social", "post_photo_social", "draft_video_social", "post_video_social",
+    ]:
+        assert TOOLS[name].args_model is not None
+        assert TOOLS[name].to_openai_schema()["function"]["parameters"]["type"] == "object"

--- a/tests/unit/test_agentic_registry.py
+++ b/tests/unit/test_agentic_registry.py
@@ -140,8 +140,17 @@ def test_high_churn_tools_have_pydantic_arg_models():
 
     for name in [
         "save_note", "schedule_job", "schedule_reminder", "write_report",
+        "adaptive_search", "deep_research", "deep_read", "repo_file_tree", "repo_read_file", "repo_search_text",
         "draft_job_post_social", "post_job_post_social", "post_to_social",
         "draft_photo_social", "post_photo_social", "draft_video_social", "post_video_social",
     ]:
         assert TOOLS[name].args_model is not None
         assert TOOLS[name].to_openai_schema()["function"]["parameters"]["type"] == "object"
+
+
+def test_social_post_tools_require_hitl_approval():
+    from agentic.registry import TOOLS
+
+    assert TOOLS["post_job_post_social"].needs_approval is True
+    assert TOOLS["post_photo_social"].needs_approval is True
+    assert TOOLS["post_video_social"].needs_approval is True

--- a/tests/unit/test_agentic_registry.py
+++ b/tests/unit/test_agentic_registry.py
@@ -154,3 +154,14 @@ def test_social_post_tools_require_hitl_approval():
     assert TOOLS["post_job_post_social"].needs_approval is True
     assert TOOLS["post_photo_social"].needs_approval is True
     assert TOOLS["post_video_social"].needs_approval is True
+    assert TOOLS["post_to_social"].needs_approval is True
+
+
+def test_schedule_job_args_fail_fast_for_conditional_fields():
+    import pytest
+    from agentic.tool_models import ScheduleJobArgs
+
+    with pytest.raises(ValueError):
+        ScheduleJobArgs(title="t", task="task", time_of_day="09:00", action="tool")
+    with pytest.raises(ValueError):
+        ScheduleJobArgs(title="t", task="task", time_of_day="09:00", frequency="custom_weekdays")


### PR DESCRIPTION
### Motivation
- Finish PR#57 follow-ups by attaching concrete typed argument models to high‑churn tools, add a compact execution context and traces, and implement capability-driven handoff behavior to make agentic work more robust and auditable. 
- Provide an explicit approval/wait mechanism for tools that require human signoff and stop accidental emission of invalid structured final outputs after repair exhaustion. 
- Fix graph condition evaluation and a few test ordering issues uncovered by post‑PR reviews.

### Description
- Add Pydantic argument models in `agentic/tool_models.py` for high‑churn tools (`save_note`, `schedule_job`, `schedule_reminder`, `learn_knowledge`, `write_report`, and social draft/post tools) and wire them into the registry as preferred `args_model` while keeping YAML as a fallback. 
- Extend `ToolSpec` with a `needs_approval` flag and surface it in registry exports, plus support `register_tool_schema`/`@tool` with `needs_approval`. (changes in `agentic/registry.py`).
- Introduce `AgentContext` dataclass and helper accessors so tools receive a minimal execution context instead of the full owner; update `dispatch_tool`/tool dispatch paths to use `AgentContext` when provided (changes in `agentic/agentic.py`).
- Implement append‑only JSONL step traces under user state via `_append_step_trace` and log `llm_step`, `tool_call`, and `tool_result` events to `<USER_STATE_ROOT>/<user>/agentic/traces/<run_id>.jsonl` (in `agentic/agentic.py`).
- Implement `needs_approval` handling in `execute_tool_with_policy` to return a structured wait result with `run_id` and checkpoint metadata instead of auto‑continuing, and persist the wait trace. (in `agentic/agentic.py`).
- Add capability → handoff profile map and apply it in `run_agentic_chat` after `match_capabilities` so matched capabilities can set `tool_domains`, `system_overlay`, `max_iter`, and `research_budget` for the turn; system overlay is injected into the system prompt. (in `agentic/agentic.py`).
- Fix ReAct structured‑output exhaustion: when output validation finally fails after repair attempts, return a structured contract error instead of emitting the unvalidated candidate. (in `agentic/agentic.py`).
- Make graph engine `when`/`state` conditions treat missing/None state values as unsatisfied (return `None`) instead of coercing them to empty string. (in `agentic/graph_engine.py`).
- Add `pydantic>=2` to `pyproject.toml` to pin Pydantic v2 APIs used by the code. 
- Add unit tests and small test rearrangements: new/updated tests in `tests/unit/*` covering typed tool schemas, handoff profiles, approval wait/traces, AgentContext dispatch, and the graph condition regression; move the `pytest.main()` runner to the end of `tests/unit/test_agentic_agentic.py` so new tests are collected.

### Testing
- Ran `python -m py_compile` on modified modules which succeeded to validate syntax for `agentic/agentic.py`, `agentic/graph_engine.py`, `agentic/registry.py`, `agentic/tool_models.py`, and updated tests. 
- Ran `git diff --check` for whitespace and basic checks which passed. 
- Attempted unit test run with `pytest -q tests/unit/test_agentic_registry.py tests/unit/test_agentic_graph_engine.py tests/unit/test_agentic_agentic.py` but execution was blocked in this environment because system Python lacks runtime dependencies (missing `numpy`), so full pytest could not complete. 
- Attempted `uv run pytest ...` but that run was blocked by a missing configured local `onnxruntime_gpu` wheel in this environment; both test failures are environmental and not code regressions in the changeset.

If you want, I can split the change into smaller PRs (typed models + registry wiring, runtime context/tracing, approval flow, and graph/verification fixes) or run the unit tests in a properly provisioned CI environment to get green test results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a8baef4a4832f935d33e540d0e3ec)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added human approval checkpoints for selected actions, with the ability to resume pending operations.
  * Improved tool selection based on task capabilities and configured limits.
  * Added stronger input validation for common tools, including clearer handling of invalid requests.
  * Added automatic skill proposal drafts based on completed or unsuccessful runs.

* **Bug Fixes**
  * Improved graph condition handling when required state values are missing.
  * Runs now stop cleanly when final responses fail structured validation.

* **Tests**
  * Expanded coverage for approval workflows, validation, tool context, graph conditions, and skill proposals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->