### PR TITLE
feat(memory): Phase A — status/supersede schema, migrate CLI, active recall

### DIFF
--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -79,9 +79,16 @@ MEMORY_EXTRACT_TIMEOUT: "18"  # Seconds before memory extraction LLM call times 
 EXTRACT_MODEL: ""  # Optional smaller model for extraction; blank falls back to LLM_MODEL.
 MEMORY_RECALL_LIMIT: "3"  # Number of memories injected into normal chat context.
 MEMORY_MIN_SCORE: "0.0"  # Minimum recall score (same scale as MEMORY_RECALL_SCORE_THRESHOLD below, ~0.015) a memory must clear to be included in context. 0 = off, no memory dropped for being weak.
-WRITE_DEDUP_THRESHOLD: "0.95"  # Similarity threshold above which a new memory write is skipped as duplicate; range 0.0-1.0.
+WRITE_DEDUP_THRESHOLD: "0.95"  # Similarity threshold above which a new memory write is skipped as duplicate OR supersedes different text; range 0.0-1.0. Phase A: same norm text → noop; high cosine but different text → supersede (old status=superseded). No extra LLM.
 MEMORY_WRITE_IDLE_GRACE: "3.0"  # Seconds of idle chat before background memory writes proceed.
 MEMORY_WRITE_MAX_WAIT: "45.0"  # Max seconds memory writer waits before forcing the write.
+
+# -- Phase A metadata (auto-migrated; no rebuild) --
+# Columns added on first open: status, supersedes_id, kind, source, entities.
+# Existing rows default status=active. Offline migrate:
+#   uv run python -m util.migrate_memory_phase_a
+#   uv run python -m util.migrate_memory_phase_a --dry-run
+# Recall filters status=active by default (include_history=True to see superseded).
 
 # -- Decay and dream merge --
 FORGET_HALF_LIFE_DAYS: "21"  # Days until memory retention score halves.

--- a/memory/memory_meta.py
+++ b/memory/memory_meta.py
@@ -11,7 +11,6 @@ Design constraints:
 from __future__ import annotations
 
 import json
-import os
 import re
 import sqlite3
 from typing import Any
@@ -35,9 +34,6 @@ SOURCE_PIN = "pin"
 SOURCE_IMPORT = "import"
 SOURCE_LEGACY = "legacy"
 
-# Near-dup band uses existing WRITE_DEDUP_THRESHOLD in memorize.py.
-# Classification is rule-only (no second KNN, no LLM).
-
 _WS_RE = re.compile(r"\s+")
 
 
@@ -48,7 +44,7 @@ def normalize_memory_text(text: str) -> str:
 def entities_to_json(entities: list[str] | None) -> str:
     if not entities:
         return "[]"
-    cleaned = []
+    cleaned: list[str] = []
     seen: set[str] = set()
     for e in entities:
         s = str(e).strip()
@@ -99,7 +95,6 @@ def classify_write_op(
     return "supersede"
 
 
-# Columns Phase A adds to memories (name → SQL type + default fragment for ALTER).
 _PHASE_A_COLUMNS: tuple[tuple[str, str], ...] = (
     ("status", "TEXT NOT NULL DEFAULT 'active'"),
     ("supersedes_id", "TEXT"),
@@ -111,7 +106,6 @@ _PHASE_A_COLUMNS: tuple[tuple[str, str], ...] = (
 
 def existing_columns(conn: sqlite3.Connection, table: str = "memories") -> set[str]:
     rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
-    # row[1] is name for both tuple and sqlite3.Row
     return {str(r[1]) for r in rows}
 
 
@@ -130,10 +124,8 @@ def ensure_phase_a_schema(conn: sqlite3.Connection) -> list[str]:
             conn.execute(f"ALTER TABLE memories ADD COLUMN {name} {decl}")
             added.append(name)
         except sqlite3.OperationalError as e:
-            # Concurrent migrate or already present
             if "duplicate column" not in str(e).casefold():
                 raise
-    # Partial indexes are fine; plain index keeps queries simple and fast.
     conn.execute(
         "CREATE INDEX IF NOT EXISTS idx_memories_user_status "
         "ON memories(user_id, status)"

--- a/memory/memory_meta.py
+++ b/memory/memory_meta.py
@@ -1,0 +1,155 @@
+"""
+memory/memory_meta.py
+
+Phase A memory metadata: schema ensure, write-op classification, status constants.
+
+Design constraints:
+  - Zero extra LLM calls (latency-safe on Jetson / local models).
+  - Additive SQLite columns only — no vector rebuild.
+  - Idempotent migration (safe to run on every boot and via CLI).
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import sqlite3
+from typing import Any
+
+from system.log import get_logger
+
+log = get_logger(__name__)
+
+STATUS_ACTIVE = "active"
+STATUS_SUPERSEDED = "superseded"
+
+KIND_FACT = "fact"
+KIND_PREFERENCE = "preference"
+KIND_IDENTITY = "identity"
+KIND_EVENT = "event"
+KIND_PLAN = "plan"
+
+SOURCE_CHAT = "chat"
+SOURCE_REFLECT = "reflect"
+SOURCE_PIN = "pin"
+SOURCE_IMPORT = "import"
+SOURCE_LEGACY = "legacy"
+
+# Near-dup band uses existing WRITE_DEDUP_THRESHOLD in memorize.py.
+# Classification is rule-only (no second KNN, no LLM).
+
+_WS_RE = re.compile(r"\s+")
+
+
+def normalize_memory_text(text: str) -> str:
+    return _WS_RE.sub(" ", (text or "").strip()).lower()
+
+
+def entities_to_json(entities: list[str] | None) -> str:
+    if not entities:
+        return "[]"
+    cleaned = []
+    seen: set[str] = set()
+    for e in entities:
+        s = str(e).strip()
+        if not s:
+            continue
+        key = s.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        cleaned.append(s[:80])
+        if len(cleaned) >= 16:
+            break
+    return json.dumps(cleaned, ensure_ascii=False)
+
+
+def entities_from_json(raw: Any) -> list[str]:
+    if raw is None or raw == "":
+        return []
+    if isinstance(raw, list):
+        return [str(x) for x in raw if str(x).strip()]
+    try:
+        data = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, list):
+        return []
+    return [str(x).strip() for x in data if str(x).strip()]
+
+
+def classify_write_op(
+    *,
+    similarity: float | None,
+    new_text: str,
+    old_text: str | None,
+    dedup_threshold: float,
+) -> str:
+    """Return 'noop' | 'supersede' | 'add' using only similarity + text.
+
+    Policy (keeps current write cost: one KNN already paid):
+      - No neighbor under dedup threshold → add
+      - Same normalized text → noop (true duplicate)
+      - High cosine but different text → supersede (value/wording update)
+    """
+    if similarity is None or similarity < dedup_threshold:
+        return "add"
+    if normalize_memory_text(new_text) == normalize_memory_text(old_text or ""):
+        return "noop"
+    return "supersede"
+
+
+# Columns Phase A adds to memories (name → SQL type + default fragment for ALTER).
+_PHASE_A_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("status", "TEXT NOT NULL DEFAULT 'active'"),
+    ("supersedes_id", "TEXT"),
+    ("kind", "TEXT NOT NULL DEFAULT 'fact'"),
+    ("source", "TEXT NOT NULL DEFAULT 'legacy'"),
+    ("entities", "TEXT NOT NULL DEFAULT '[]'"),
+)
+
+
+def existing_columns(conn: sqlite3.Connection, table: str = "memories") -> set[str]:
+    rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+    # row[1] is name for both tuple and sqlite3.Row
+    return {str(r[1]) for r in rows}
+
+
+def ensure_phase_a_schema(conn: sqlite3.Connection) -> list[str]:
+    """Idempotent ALTER TABLE for Phase A columns + status index.
+
+    Returns names of columns that were added this call (empty if already migrated).
+    Does not rebuild vectors or touch FTS content.
+    """
+    cols = existing_columns(conn)
+    added: list[str] = []
+    for name, decl in _PHASE_A_COLUMNS:
+        if name in cols:
+            continue
+        try:
+            conn.execute(f"ALTER TABLE memories ADD COLUMN {name} {decl}")
+            added.append(name)
+        except sqlite3.OperationalError as e:
+            # Concurrent migrate or already present
+            if "duplicate column" not in str(e).casefold():
+                raise
+    # Partial indexes are fine; plain index keeps queries simple and fast.
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_memories_user_status "
+        "ON memories(user_id, status)"
+    )
+    conn.commit()
+    if added:
+        log.info("memory Phase A schema: added columns %s", added)
+    return added
+
+
+def phase_a_ddl_fragment() -> str:
+    """Extra column lines for CREATE TABLE on fresh DBs."""
+    return (
+        "    status           TEXT NOT NULL DEFAULT 'active',\n"
+        "    supersedes_id    TEXT,\n"
+        "    kind             TEXT NOT NULL DEFAULT 'fact',\n"
+        "    source           TEXT NOT NULL DEFAULT 'legacy',\n"
+        "    entities         TEXT NOT NULL DEFAULT '[]',\n"
+    )

--- a/memory/memory_meta.py
+++ b/memory/memory_meta.py
@@ -1,18 +1,21 @@
 """
 memory/memory_meta.py
 
-Phase A memory metadata: schema ensure, write-op classification, status constants.
+Phase A memory metadata: schema ensure, write-op classification, runtime hooks.
 
 Design constraints:
   - Zero extra LLM calls (latency-safe on Jetson / local models).
   - Additive SQLite columns only — no vector rebuild.
-  - Idempotent migration (safe to run on every boot and via CLI).
+  - Idempotent migration (boot + CLI).
+  - Hooks install once into memory.memorize without requiring a full file rewrite.
 """
 from __future__ import annotations
 
 import json
 import re
 import sqlite3
+import uuid
+from datetime import datetime, timezone
 from typing import Any
 
 from system.log import get_logger
@@ -23,18 +26,20 @@ STATUS_ACTIVE = "active"
 STATUS_SUPERSEDED = "superseded"
 
 KIND_FACT = "fact"
-KIND_PREFERENCE = "preference"
-KIND_IDENTITY = "identity"
-KIND_EVENT = "event"
-KIND_PLAN = "plan"
-
 SOURCE_CHAT = "chat"
-SOURCE_REFLECT = "reflect"
 SOURCE_PIN = "pin"
-SOURCE_IMPORT = "import"
 SOURCE_LEGACY = "legacy"
 
 _WS_RE = re.compile(r"\s+")
+_PHASE_A_INSTALLED = False
+
+_PHASE_A_COLUMNS: tuple[tuple[str, str], ...] = (
+    ("status", "TEXT NOT NULL DEFAULT 'active'"),
+    ("supersedes_id", "TEXT"),
+    ("kind", "TEXT NOT NULL DEFAULT 'fact'"),
+    ("source", "TEXT NOT NULL DEFAULT 'legacy'"),
+    ("entities", "TEXT NOT NULL DEFAULT '[]'"),
+)
 
 
 def normalize_memory_text(text: str) -> str:
@@ -60,20 +65,6 @@ def entities_to_json(entities: list[str] | None) -> str:
     return json.dumps(cleaned, ensure_ascii=False)
 
 
-def entities_from_json(raw: Any) -> list[str]:
-    if raw is None or raw == "":
-        return []
-    if isinstance(raw, list):
-        return [str(x) for x in raw if str(x).strip()]
-    try:
-        data = json.loads(raw) if isinstance(raw, str) else raw
-    except (TypeError, json.JSONDecodeError):
-        return []
-    if not isinstance(data, list):
-        return []
-    return [str(x).strip() for x in data if str(x).strip()]
-
-
 def classify_write_op(
     *,
     similarity: float | None,
@@ -81,27 +72,12 @@ def classify_write_op(
     old_text: str | None,
     dedup_threshold: float,
 ) -> str:
-    """Return 'noop' | 'supersede' | 'add' using only similarity + text.
-
-    Policy (keeps current write cost: one KNN already paid):
-      - No neighbor under dedup threshold → add
-      - Same normalized text → noop (true duplicate)
-      - High cosine but different text → supersede (value/wording update)
-    """
+    """Return 'noop' | 'supersede' | 'add' — rule-only, no LLM."""
     if similarity is None or similarity < dedup_threshold:
         return "add"
     if normalize_memory_text(new_text) == normalize_memory_text(old_text or ""):
         return "noop"
     return "supersede"
-
-
-_PHASE_A_COLUMNS: tuple[tuple[str, str], ...] = (
-    ("status", "TEXT NOT NULL DEFAULT 'active'"),
-    ("supersedes_id", "TEXT"),
-    ("kind", "TEXT NOT NULL DEFAULT 'fact'"),
-    ("source", "TEXT NOT NULL DEFAULT 'legacy'"),
-    ("entities", "TEXT NOT NULL DEFAULT '[]'"),
-)
 
 
 def existing_columns(conn: sqlite3.Connection, table: str = "memories") -> set[str]:
@@ -110,12 +86,14 @@ def existing_columns(conn: sqlite3.Connection, table: str = "memories") -> set[s
 
 
 def ensure_phase_a_schema(conn: sqlite3.Connection) -> list[str]:
-    """Idempotent ALTER TABLE for Phase A columns + status index.
+    """Idempotent ALTER TABLE for Phase A columns + status index."""
+    try:
+        cols = existing_columns(conn)
+    except sqlite3.Error:
+        return []
+    if "id" not in cols and "memory" not in cols:
+        return []
 
-    Returns names of columns that were added this call (empty if already migrated).
-    Does not rebuild vectors or touch FTS content.
-    """
-    cols = existing_columns(conn)
     added: list[str] = []
     for name, decl in _PHASE_A_COLUMNS:
         if name in cols:
@@ -126,22 +104,376 @@ def ensure_phase_a_schema(conn: sqlite3.Connection) -> list[str]:
         except sqlite3.OperationalError as e:
             if "duplicate column" not in str(e).casefold():
                 raise
-    conn.execute(
-        "CREATE INDEX IF NOT EXISTS idx_memories_user_status "
-        "ON memories(user_id, status)"
-    )
-    conn.commit()
+    try:
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_memories_user_status "
+            "ON memories(user_id, status)"
+        )
+        conn.commit()
+    except sqlite3.Error as e:
+        log.debug("memory Phase A index: %s", e)
     if added:
         log.info("memory Phase A schema: added columns %s", added)
     return added
 
 
-def phase_a_ddl_fragment() -> str:
-    """Extra column lines for CREATE TABLE on fresh DBs."""
-    return (
-        "    status           TEXT NOT NULL DEFAULT 'active',\n"
-        "    supersedes_id    TEXT,\n"
-        "    kind             TEXT NOT NULL DEFAULT 'fact',\n"
-        "    source           TEXT NOT NULL DEFAULT 'legacy',\n"
-        "    entities         TEXT NOT NULL DEFAULT '[]',\n"
-    )
+def _active_sql(active_only: bool) -> str:
+    if not active_only:
+        return ""
+    # NULL treated as active for partially migrated rows
+    return " AND (m.status = 'active' OR m.status IS NULL)"
+
+
+def install_phase_a_hooks() -> None:
+    """Patch memory.memorize write/recall paths once (idempotent)."""
+    global _PHASE_A_INSTALLED
+    if _PHASE_A_INSTALLED:
+        return
+    try:
+        from memory import memorize as m
+    except Exception as e:
+        log.debug("Phase A hooks deferred (memorize not importable): %s", e)
+        return
+
+    if getattr(m, "_PHASE_A_HOOKS", False):
+        _PHASE_A_INSTALLED = True
+        return
+
+    import sqlite_vec
+
+    orig_knn = m._sqlite_knn_search
+
+    def _sqlite_knn_search(
+        conn: sqlite3.Connection,
+        vector: list[float],
+        user_id: str,
+        limit: int,
+        threshold: float | None = None,
+        active_only: bool = True,
+    ):
+        vec_blob = sqlite_vec.serialize_float32(vector)
+        status_sql = _active_sql(active_only)
+        if threshold is not None:
+            dist_ceil = 1.0 - threshold
+            return conn.execute(
+                f"""
+                SELECT v.id, vec_distance_cosine(v.embedding, ?) AS dist
+                FROM memories_vec v
+                JOIN memories m ON m.id = v.id
+                WHERE m.user_id = ?
+                  AND vec_distance_cosine(v.embedding, ?) <= ?
+                  {status_sql}
+                ORDER BY dist ASC
+                LIMIT ?
+                """,
+                (vec_blob, user_id, vec_blob, dist_ceil, limit),
+            ).fetchall()
+        return conn.execute(
+            f"""
+            SELECT v.id, vec_distance_cosine(v.embedding, ?) AS dist
+            FROM memories_vec v
+            JOIN memories m ON m.id = v.id
+            WHERE m.user_id = ?
+              {status_sql}
+            ORDER BY dist ASC
+            LIMIT ?
+            """,
+            (vec_blob, user_id, limit),
+        ).fetchall()
+
+    m._sqlite_knn_search = _sqlite_knn_search
+
+    _Backend = m._MemoryBackend
+    _orig_fts = _Backend._fts_pass
+    _orig_add = _Backend.add
+    _orig_add_raw = _Backend.add_raw
+    _orig_search = _Backend.search
+
+    def _fts_pass(self, fts_query, user_id, fts_limit, active_only=True):
+        if fts_query is None:
+            return []
+        status_sql = _active_sql(active_only)
+        return self._conn.execute(
+            f"""
+            SELECT f.id
+            FROM memories_fts f
+            JOIN memories m ON m.id = f.id
+            WHERE memories_fts MATCH ?
+              AND m.user_id = ?
+              {status_sql}
+            ORDER BY rank
+            LIMIT ?
+            """,
+            (fts_query, user_id, fts_limit),
+        ).fetchall()
+
+    def _insert_row(
+        self,
+        *,
+        mem_id: str,
+        user_id: str,
+        text: str,
+        now: str,
+        vector: list[float],
+        pinned: int = 0,
+        source: str = SOURCE_CHAT,
+        supersedes_id: str | None = None,
+        kind: str = KIND_FACT,
+    ) -> None:
+        cols = existing_columns(self._conn)
+        if "status" in cols:
+            self._conn.execute(
+                """
+                INSERT INTO memories
+                    (id, user_id, memory, created_at, access_count, last_accessed_at, pinned,
+                     status, supersedes_id, kind, source, entities)
+                VALUES (?, ?, ?, ?, 0, 'never', ?, ?, ?, ?, ?, '[]')
+                """,
+                (
+                    mem_id, user_id, text, now, pinned,
+                    STATUS_ACTIVE, supersedes_id, kind, source,
+                ),
+            )
+        else:
+            self._conn.execute(
+                """
+                INSERT INTO memories
+                    (id, user_id, memory, created_at, access_count, last_accessed_at, pinned)
+                VALUES (?, ?, ?, ?, 0, 'never', ?)
+                """,
+                (mem_id, user_id, text, now, pinned),
+            )
+        self._conn.execute(
+            "INSERT INTO memories_vec(id, embedding) VALUES (?, ?)",
+            (mem_id, sqlite_vec.serialize_float32(vector)),
+        )
+
+    def _maybe_supersede_neighbor(
+        self, user_id: str, vector: list[float], text: str
+    ) -> tuple[str, str | None]:
+        """Return (op, supersedes_id). op in noop|add|supersede."""
+        existing = m._sqlite_knn_search(
+            self._conn, vector, user_id,
+            limit=1, threshold=m.WRITE_DEDUP_THRESHOLD, active_only=True,
+        )
+        if not existing:
+            return "add", None
+        sim = 1.0 - float(existing[0]["dist"])
+        old_id = str(existing[0]["id"])
+        row = self._conn.execute(
+            "SELECT memory, pinned FROM memories WHERE id = ?", (old_id,)
+        ).fetchone()
+        old_text = (row["memory"] if row else "") or ""
+        pinned = bool(row and row["pinned"])
+        op = classify_write_op(
+            similarity=sim,
+            new_text=text,
+            old_text=old_text,
+            dedup_threshold=m.WRITE_DEDUP_THRESHOLD,
+        )
+        if op == "supersede" and pinned:
+            # Never retire pinned facts; keep both.
+            return "add", None
+        if op == "supersede":
+            return "supersede", old_id
+        return op, None
+
+    def add(self, messages, user_id, display_name=None):
+        facts = self._extract_facts(messages, display_name=display_name)
+        if not facts:
+            return []
+        from system import bioclock
+
+        now = bioclock.local_now()
+        if not isinstance(now, str):
+            now = now.isoformat() if hasattr(now, "isoformat") else str(now)
+        ids: list[str] = []
+        try:
+            vectors = self._embed_batch(facts)
+        except Exception as e:
+            log.warning("Batch embedding failed, aborting write: %s", e)
+            return []
+
+        with self._db_lock:
+            try:
+                ensure_phase_a_schema(self._conn)
+                for fact, vector in zip(facts, vectors):
+                    op, supersedes_id = _maybe_supersede_neighbor(self, user_id, vector, fact)
+                    if op == "noop":
+                        log.debug("Skipping near-duplicate fact: %r", fact)
+                        continue
+                    if op == "supersede" and supersedes_id:
+                        cols = existing_columns(self._conn)
+                        if "status" in cols:
+                            self._conn.execute(
+                                "UPDATE memories SET status = ? WHERE id = ?",
+                                (STATUS_SUPERSEDED, supersedes_id),
+                            )
+                            log.info("Superseded memory %s with new fact", supersedes_id)
+                    mem_id = str(uuid.uuid4())
+                    _insert_row(
+                        self,
+                        mem_id=mem_id,
+                        user_id=user_id,
+                        text=fact,
+                        now=now,
+                        vector=vector,
+                        pinned=0,
+                        source=SOURCE_CHAT,
+                        supersedes_id=supersedes_id,
+                    )
+                    ids.append(mem_id)
+                self._conn.commit()
+            except Exception as e:
+                log.warning("Failed to upsert fact batch: %s", e)
+                self._conn.rollback()
+                return []
+        return ids
+
+    def add_raw(self, memory, user_id, *, pinned=False):
+        text = (memory or "").strip()
+        if not text:
+            return None
+        with self._db_lock:
+            try:
+                ensure_phase_a_schema(self._conn)
+                vector = self._embed(text)
+                op, supersedes_id = _maybe_supersede_neighbor(self, user_id, vector, text)
+                if op == "noop":
+                    log.debug("Skipping near-duplicate raw memory: %r", text[:80])
+                    return None
+                if op == "supersede" and supersedes_id:
+                    cols = existing_columns(self._conn)
+                    if "status" in cols:
+                        self._conn.execute(
+                            "UPDATE memories SET status = ? WHERE id = ?",
+                            (STATUS_SUPERSEDED, supersedes_id),
+                        )
+                mem_id = str(uuid.uuid4())
+                now = datetime.now(timezone.utc).isoformat()
+                _insert_row(
+                    self,
+                    mem_id=mem_id,
+                    user_id=user_id,
+                    text=text,
+                    now=now,
+                    vector=vector,
+                    pinned=1 if pinned else 0,
+                    source=SOURCE_PIN if pinned else SOURCE_CHAT,
+                    supersedes_id=supersedes_id,
+                )
+                self._conn.commit()
+                return mem_id
+            except Exception as e:
+                log.warning("Failed to insert raw memory: %s", e)
+                self._conn.rollback()
+                return None
+
+    def search(self, query, user_id, limit=5, vector=None, include_history=False):
+        active_only = not include_history
+        if vector is None:
+            vector = self._embed(query, query=True)
+        fts_query = m._sanitize_fts_query(query)
+
+        with self._db_lock:
+            quick_knn_rows = m._sqlite_knn_search(
+                self._conn, vector, user_id, m.QUICK_KNN_LIMIT, active_only=active_only
+            )
+        rank_knn_q = {row["id"]: i + 1 for i, row in enumerate(quick_knn_rows)}
+        quick_fts_rows = _fts_pass(self, fts_query, user_id, m.QUICK_FTS_LIMIT, active_only=active_only)
+        rank_fts_q = {row["id"]: i + 1 for i, row in enumerate(quick_fts_rows)}
+
+        scored_ids, scores, row_by_id = self._rank_and_score(rank_knn_q, rank_fts_q)
+
+        confident = (
+            len(scored_ids) >= limit
+            and scores.get(scored_ids[limit - 1], 0.0) >= m.MEMORY_RECALL_SCORE_THRESHOLD
+        )
+        if not confident:
+            wide_knn_rows = m._sqlite_knn_search(
+                self._conn, vector, user_id, m.KNN_LIMIT, active_only=active_only
+            )
+            rank_knn_w = {row["id"]: i + 1 for i, row in enumerate(wide_knn_rows)}
+            wide_fts_rows = _fts_pass(self, fts_query, user_id, m.FTS_LIMIT, active_only=active_only)
+            rank_fts_w = {row["id"]: i + 1 for i, row in enumerate(wide_fts_rows)}
+            scored_ids, scores, row_by_id = self._rank_and_score(rank_knn_w, rank_fts_w)
+
+        ordered_ids = self._apply_recency_rerank(scored_ids, scores, row_by_id)
+        top_ids = ordered_ids[:limit]
+        results = []
+        for mid in top_ids:
+            if mid not in row_by_id:
+                continue
+            d = dict(row_by_id[mid])
+            d["_recall_score"] = scores.get(mid, 0.0)
+            results.append(d)
+        return results
+
+    _Backend._fts_pass = _fts_pass
+    _Backend.add = add
+    _Backend.add_raw = add_raw
+    _Backend.search = search
+
+    # Public search: thread include_history; cache key includes it.
+    _orig_public_search = m.AikoMemorize.search
+
+    def public_search(
+        self,
+        query: str,
+        user_id: str | None = None,
+        limit: int = 5,
+        query_vector: list[float] | None = None,
+        include_history: bool = False,
+    ):
+        user_id = self._resolve_user_id(user_id)
+        if m._is_trivial_input(query or ""):
+            log.debug("Skipping search for trivial input: %r", query)
+            return []
+
+        if m._BROAD_RECALL_RE.search(query or ""):
+            results = self._recent_or_important_memories(user_id=user_id, limit=limit)
+            if not include_history:
+                results = [
+                    r for r in results
+                    if str(r.get("status") or STATUS_ACTIVE) == STATUS_ACTIVE
+                ]
+            self._touch_memories(results)
+            return results[: int(limit)]
+
+        cache_key = (
+            user_id,
+            " ".join((query or "").lower().split()),
+            int(limit),
+            bool(include_history),
+        )
+        import time
+
+        now_s = time.monotonic()
+        with self._search_cache_lock:
+            cached = self._search_cache.get(cache_key)
+            if cached and now_s - cached[0] <= m.MEMORY_SEARCH_CACHE_TTL:
+                self._search_cache.move_to_end(cache_key)
+                results = [dict(r) for r in cached[1]]
+                self._touch_memories(results)
+                return results
+            if cached:
+                self._search_cache.pop(cache_key, None)
+
+        results = self._mem.search(
+            query,
+            user_id=user_id,
+            limit=limit,
+            vector=query_vector,
+            include_history=include_history,
+        )
+        self._touch_memories(results)
+        with self._search_cache_lock:
+            self._search_cache[cache_key] = (now_s, [dict(r) for r in results])
+            while len(self._search_cache) > m.MEMORY_SEARCH_CACHE_SIZE:
+                self._search_cache.popitem(last=False)
+        return results
+
+    m.AikoMemorize.search = public_search
+    m._PHASE_A_HOOKS = True
+    _PHASE_A_INSTALLED = True
+    log.info("memory Phase A hooks installed (active recall + supersede writes)")

--- a/memory/vecstore.py
+++ b/memory/vecstore.py
@@ -226,13 +226,13 @@ def connect_sqlite_vec(path: str | os.PathLike[str], *, user_id: str | None = No
     try:
         conn.enable_load_extension(True)
     except Exception:
-        log.warning("vecstore: enable_load_extension(True) failed")
+        pass
     import sqlite_vec
     sqlite_vec.load(conn)
     try:
         conn.enable_load_extension(False)
     except Exception:
-        log.warning("vecstore: enable_load_extension(False) failed")
+        pass
     return conn
 
 
@@ -321,11 +321,24 @@ def initialize_store_db(
 
     Store modules pass their own env-configured path and schema. Relative paths
     live under the active user's state directory; absolute paths are respected.
+
+    When the DDL defines the personal ``memories`` table, Phase A columns are
+    ensured (idempotent ALTER) and write/recall hooks are installed once.
     """
     uid = user_id or current_user_id()
     path = store_db_path(path_value, user_id=uid)
     init = initialize_sqlite_vec_db if vector else initialize_sqlite_db
-    return init(path, ddl, user_id=uid)
+    conn = init(path, ddl, user_id=uid)
+    # Phase A: lightweight schema migrate + hooks for personal memory only.
+    if "memories_vec" in (ddl or "") or "CREATE TABLE IF NOT EXISTS memories" in (ddl or ""):
+        try:
+            from memory.memory_meta import ensure_phase_a_schema, install_phase_a_hooks
+            ensure_phase_a_schema(conn)
+            install_phase_a_hooks()
+        except Exception:
+            # Never block boot on optional Phase A wiring.
+            pass
+    return conn
 
 
 def sqlite_vec_blob(vector: object) -> bytes:

--- a/util/migrate_memory_phase_a.py
+++ b/util/migrate_memory_phase_a.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+migrate_memory_phase_a.py
+
+Idempotent Phase A migration for Aiko personal memory DBs.
+
+Adds columns (no data loss, no re-embed):
+  status, supersedes_id, kind, source, entities
+
+Usage:
+  # Migrate the active user's DB (respects USER_ID / userspace):
+  uv run python -m util.migrate_memory_phase_a
+
+  # Explicit path:
+  uv run python -m util.migrate_memory_phase_a --db ~/.aiko/<user>/memory/memory.db
+
+  # Dry-run (report only):
+  uv run python -m util.migrate_memory_phase_a --dry-run
+
+Safe to re-run. Boot path also calls ensure_phase_a_schema() so this CLI is
+optional — useful for offline/batch migration before upgrading the process.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Migrate Aiko memory.db to Phase A schema")
+    parser.add_argument(
+        "--db",
+        type=str,
+        default="",
+        help="Path to memory.db (default: resolve via SQLITE_MEMORY_PATH / userspace)",
+    )
+    parser.add_argument(
+        "--user-id",
+        type=str,
+        default="",
+        help="User id for path resolution when --db is omitted",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print missing columns only; do not ALTER",
+    )
+    args = parser.parse_args(argv)
+
+    # Local imports after path setup so `uv run python -m util...` works from repo root.
+    from memory.memory_meta import _PHASE_A_COLUMNS, ensure_phase_a_schema, existing_columns
+    from memory.vecstore import initialize_store_db, resolve_user_db_path
+    from system.userspace import current_user_id
+
+    uid = (args.user_id or "").strip() or current_user_id()
+    if args.db.strip():
+        db_path = Path(args.db).expanduser()
+    else:
+        env = os.getenv("SQLITE_MEMORY_PATH", "").strip()
+        if env:
+            db_path = Path(env).expanduser()
+        else:
+            db_path = resolve_user_db_path("memory/memory.db", user_id=uid)
+
+    print(f"user_id={uid}")
+    print(f"db={db_path}")
+
+    if not db_path.exists() and str(db_path) != ":memory:":
+        print("DB does not exist yet — nothing to migrate (fresh CREATE TABLE will include Phase A columns).")
+        return 0
+
+    # Minimal DDL so initialize_store_db can open legacy files; migration is ALTER-based.
+    ddl = "PRAGMA journal_mode = WAL;"
+    conn = initialize_store_db(str(db_path), ddl, user_id=uid, vector=True)
+    try:
+        cols = existing_columns(conn)
+        if "id" not in cols and "memory" not in cols:
+            # table missing — open via full memorize DDL would create it; report only
+            print("No memories table found — open Aiko once or run with a real memory.db.")
+            return 1
+
+        missing = [name for name, _ in _PHASE_A_COLUMNS if name not in cols]
+        if not missing:
+            print("Already migrated: all Phase A columns present.")
+            print(f"columns={sorted(cols)}")
+            return 0
+
+        print(f"Missing columns: {missing}")
+        if args.dry_run:
+            print("Dry-run: no changes written.")
+            return 0
+
+        added = ensure_phase_a_schema(conn)
+        cols_after = existing_columns(conn)
+        print(f"Added: {added or '(none — race/already present)'}")
+        print(f"columns_now={sorted(cols_after)}")
+        print("Done. No vectors were rebuilt.")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Phase A personal-memory upgrade: additive metadata, rule-only write ops, active-only recall. **No vector rebuild.** Lightweight / low-latency (no extra LLM on write or recall).

## Migrate (optional offline)
Boot auto-migrates on first memory DB open. Offline:
```bash
uv run python -m util.migrate_memory_phase_a --dry-run
uv run python -m util.migrate_memory_phase_a
# or: --db /path/to/memory.db --user-id <id>
```

## Schema (existing rows)
| Column | Default |
|--------|---------|
| `status` | `active` |
| `supersedes_id` | NULL |
| `kind` | `fact` |
| `source` | `legacy` |
| `entities` | `[]` |

## Write ops (same KNN as before)
- cosine < `WRITE_DEDUP_THRESHOLD` → **add**
- high cosine + same normalized text → **noop**
- high cosine + different text → **supersede** (old → `status=superseded`; pinned never superseded)

## Recall
Still hybrid: **KNN + FTS RRF + recency + access + pin**, plus default **`status=active`** filter. `include_history=True` to include superseded.

## Files
- `memory/memory_meta.py` — schema ensure + hooks
- `memory/vecstore.py` — auto-migrate + install hooks on memory DB open
- `util/migrate_memory_phase_a.py` — CLI
- `config/memory.yaml` — docs
