### PR TITLE
feat(memory): Phase B — entity tags + unified search_memory

### DIFF
--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -84,11 +84,15 @@ MEMORY_WRITE_IDLE_GRACE: "3.0"  # Seconds of idle chat before background memory 
 MEMORY_WRITE_MAX_WAIT: "45.0"  # Max seconds memory writer waits before forcing the write.
 
 # -- Phase A metadata (auto-migrated; no rebuild) --
-# Columns added on first open: status, supersedes_id, kind, source, entities.
-# Existing rows default status=active. Offline migrate:
-#   uv run python -m util.migrate_memory_phase_a
-#   uv run python -m util.migrate_memory_phase_a --dry-run
-# Recall filters status=active by default (include_history=True to see superseded).
+# Columns: status, supersedes_id, kind, source, entities.
+# Offline migrate: uv run python -m util.migrate_memory_phase_a
+
+# -- Phase B entity tags + unified search (no rebuild, no extra LLM) --
+# Rule-based entity extract + kind on write. Optional backfill:
+#   uv run python -m util.migrate_memory_phase_b --dry-run
+#   uv run python -m util.migrate_memory_phase_b
+# Unified facade: from memory import search_memory
+MEMORY_ENTITY_BOOST: "0.003"  # Soft score boost when query text mentions a tagged entity on a personal memory.
 
 # -- Decay and dream merge --
 FORGET_HALF_LIFE_DAYS: "21"  # Days until memory retention score halves.

--- a/memory/__init__.py
+++ b/memory/__init__.py
@@ -1,0 +1,5 @@
+"""Aiko memory package — personal, knowledge, and unified recall helpers."""
+
+from memory.search_memory import memories_for_entity, search_memory
+
+__all__ = ["search_memory", "memories_for_entity"]

--- a/memory/entities.py
+++ b/memory/entities.py
@@ -36,7 +36,7 @@ _STOP_ENTITIES = frozenset({
 
 # Kind heuristics (keyword → kind). First match wins.
 _KIND_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
-    ("identity", ("name is", "birthday", "lives in", "from ", "nationality", "age is")),
+    ("identity", ("name is", "birthday", "lives in", "nationality", "age is", "is from ")),
     ("preference", ("likes", "loves", "hates", "dislikes", "prefers", "favorite", "favourite")),
     ("plan", ("deadline", "due ", "will ", "going to", "plans to", "wants to")),
     ("event", ("hackathon", "interview", "meeting", "appointment", "lost ", "joined")),
@@ -81,7 +81,11 @@ def extract_entities(text: str, *, max_entities: int = 12) -> list[str]:
     for m in _CALLED_RE.finditer(text):
         _add(m.group(1))
     for m in _PROPER_SPAN_RE.finditer(text):
-        _add(m.group(1))
+        span = m.group(1)
+        # Sentence-initial single word is usually grammar capitalization, not an entity.
+        if m.start() == 0 and " " not in span:
+            continue
+        _add(span)
     for m in _ALLCAPS_RE.finditer(text):
         _add(m.group(1))
 

--- a/memory/entities.py
+++ b/memory/entities.py
@@ -1,0 +1,107 @@
+"""
+memory/entities.py
+
+Phase B: lightweight entity tagging for personal memories.
+
+Pure regex / heuristics — no LLM, no NER model. Runs on already-extracted
+fact strings at write time so the hot path stays Jetson-friendly.
+"""
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+# Multi-word Proper Case spans: "Hugging Face", "San Francisco"
+_PROPER_SPAN_RE = re.compile(
+    r"\b([A-Z][a-zA-Z0-9]+(?:\s+[A-Z][a-zA-Z0-9]+){0,4})\b"
+)
+# Short ALLCAPS tokens often used as project codes: GRACE, ROS2, API
+_ALLCAPS_RE = re.compile(r"\b([A-Z]{2,12}[0-9]*)\b")
+# Quoted names: "Max", 'Aiko'
+_QUOTED_RE = re.compile(r"[\"']([^\"']{2,40})[\"']")
+# Explicit name patterns: called X, named X, project X
+_CALLED_RE = re.compile(
+    r"\b(?:called|named|project|robot|dog|cat|company|team)\s+([A-Z][\w.-]{1,40})",
+    re.IGNORECASE,
+)
+
+_STOP_ENTITIES = frozenset({
+    "the", "a", "an", "and", "or", "but", "for", "with", "from", "into",
+    "monday", "tuesday", "wednesday", "thursday", "friday", "saturday", "sunday",
+    "january", "february", "march", "april", "may", "june", "july", "august",
+    "september", "october", "november", "december",
+    "today", "yesterday", "tomorrow", "user", "assistant", "aiko",
+    "he", "she", "they", "his", "her", "their", "this", "that",
+})
+
+# Kind heuristics (keyword → kind). First match wins.
+_KIND_RULES: tuple[tuple[str, tuple[str, ...]], ...] = (
+    ("identity", ("name is", "birthday", "lives in", "from ", "nationality", "age is")),
+    ("preference", ("likes", "loves", "hates", "dislikes", "prefers", "favorite", "favourite")),
+    ("plan", ("deadline", "due ", "will ", "going to", "plans to", "wants to")),
+    ("event", ("hackathon", "interview", "meeting", "appointment", "lost ", "joined")),
+)
+
+
+def _clean_entity(raw: str) -> str | None:
+    s = (raw or "").strip(" .,;:!?()[]{}").strip()
+    if len(s) < 2 or len(s) > 80:
+        return None
+    if s.casefold() in _STOP_ENTITIES:
+        return None
+    # Drop pure numbers
+    if s.isdigit():
+        return None
+    return s
+
+
+def extract_entities(text: str, *, max_entities: int = 12) -> list[str]:
+    """Extract entity-like tokens from a memory fact string.
+
+    Deterministic and cheap. Prefer precision over recall — empty is fine.
+    """
+    if not (text or "").strip():
+        return []
+
+    found: list[str] = []
+    seen: set[str] = set()
+
+    def _add(raw: str) -> None:
+        ent = _clean_entity(raw)
+        if not ent:
+            return
+        key = ent.casefold()
+        if key in seen:
+            return
+        seen.add(key)
+        found.append(ent)
+
+    for m in _QUOTED_RE.finditer(text):
+        _add(m.group(1))
+    for m in _CALLED_RE.finditer(text):
+        _add(m.group(1))
+    for m in _PROPER_SPAN_RE.finditer(text):
+        _add(m.group(1))
+    for m in _ALLCAPS_RE.finditer(text):
+        _add(m.group(1))
+
+    return found[:max_entities]
+
+
+def classify_kind(text: str, default: str = "fact") -> str:
+    """Heuristic memory kind from fact text. No LLM."""
+    low = (text or "").casefold()
+    for kind, needles in _KIND_RULES:
+        if any(n in low for n in needles):
+            return kind
+    return default
+
+
+def entity_overlap_score(query: str, entities: Iterable[str]) -> float:
+    """Return 0..1 fraction of entities mentioned in the query (casefold)."""
+    ents = [e for e in entities if e]
+    if not ents:
+        return 0.0
+    q = (query or "").casefold()
+    hits = sum(1 for e in ents if e.casefold() in q)
+    return hits / len(ents)

--- a/memory/memory_meta.py
+++ b/memory/memory_meta.py
@@ -1,13 +1,14 @@
 """
 memory/memory_meta.py
 
-Phase A memory metadata: schema ensure, write-op classification, runtime hooks.
+Phase A/B memory metadata: schema ensure, write-op classification, runtime hooks.
 
 Design constraints:
   - Zero extra LLM calls (latency-safe on Jetson / local models).
   - Additive SQLite columns only — no vector rebuild.
   - Idempotent migration (boot + CLI).
   - Hooks install once into memory.memorize without requiring a full file rewrite.
+  - Phase B: rule-based entity tags + kind on write.
 """
 from __future__ import annotations
 
@@ -65,6 +66,20 @@ def entities_to_json(entities: list[str] | None) -> str:
     return json.dumps(cleaned, ensure_ascii=False)
 
 
+def entities_from_json(raw: Any) -> list[str]:
+    if raw is None or raw == "":
+        return []
+    if isinstance(raw, list):
+        return [str(x) for x in raw if str(x).strip()]
+    try:
+        data = json.loads(raw) if isinstance(raw, str) else raw
+    except (TypeError, json.JSONDecodeError):
+        return []
+    if not isinstance(data, list):
+        return []
+    return [str(x).strip() for x in data if str(x).strip()]
+
+
 def classify_write_op(
     *,
     similarity: float | None,
@@ -117,10 +132,56 @@ def ensure_phase_a_schema(conn: sqlite3.Connection) -> list[str]:
     return added
 
 
+def backfill_entities(
+    conn: sqlite3.Connection,
+    *,
+    user_id: str | None = None,
+    limit: int = 0,
+    only_empty: bool = True,
+) -> int:
+    """Fill entities/kind for existing rows using rule-based extractors.
+
+    No re-embed. Returns number of rows updated.
+    """
+    from memory.entities import classify_kind, extract_entities
+
+    ensure_phase_a_schema(conn)
+    cols = existing_columns(conn)
+    if "entities" not in cols:
+        return 0
+
+    sql = "SELECT id, memory, entities, kind FROM memories WHERE 1=1"
+    params: list[Any] = []
+    if user_id:
+        sql += " AND user_id = ?"
+        params.append(user_id)
+    if only_empty:
+        sql += " AND (entities IS NULL OR entities = '' OR entities = '[]')"
+    sql += " ORDER BY created_at DESC"
+    if limit and limit > 0:
+        sql += " LIMIT ?"
+        params.append(int(limit))
+
+    rows = conn.execute(sql, params).fetchall()
+    updated = 0
+    for row in rows:
+        text = row["memory"] or ""
+        ents = extract_entities(text)
+        kind = classify_kind(text, default=str(row["kind"] or KIND_FACT))
+        conn.execute(
+            "UPDATE memories SET entities = ?, kind = ? WHERE id = ?",
+            (entities_to_json(ents), kind, row["id"]),
+        )
+        updated += 1
+    if updated:
+        conn.commit()
+        log.info("memory Phase B backfill: updated %d rows", updated)
+    return updated
+
+
 def _active_sql(active_only: bool) -> str:
     if not active_only:
         return ""
-    # NULL treated as active for partially migrated rows
     return " AND (m.status = 'active' OR m.status IS NULL)"
 
 
@@ -140,8 +201,7 @@ def install_phase_a_hooks() -> None:
         return
 
     import sqlite_vec
-
-    orig_knn = m._sqlite_knn_search
+    from memory.entities import classify_kind, extract_entities
 
     def _sqlite_knn_search(
         conn: sqlite3.Connection,
@@ -184,10 +244,6 @@ def install_phase_a_hooks() -> None:
     m._sqlite_knn_search = _sqlite_knn_search
 
     _Backend = m._MemoryBackend
-    _orig_fts = _Backend._fts_pass
-    _orig_add = _Backend.add
-    _orig_add_raw = _Backend.add_raw
-    _orig_search = _Backend.search
 
     def _fts_pass(self, fts_query, user_id, fts_limit, active_only=True):
         if fts_query is None:
@@ -218,20 +274,23 @@ def install_phase_a_hooks() -> None:
         pinned: int = 0,
         source: str = SOURCE_CHAT,
         supersedes_id: str | None = None,
-        kind: str = KIND_FACT,
+        kind: str | None = None,
+        entities: list[str] | None = None,
     ) -> None:
         cols = existing_columns(self._conn)
+        kind_val = kind or classify_kind(text, default=KIND_FACT)
+        ents_json = entities_to_json(entities if entities is not None else extract_entities(text))
         if "status" in cols:
             self._conn.execute(
                 """
                 INSERT INTO memories
                     (id, user_id, memory, created_at, access_count, last_accessed_at, pinned,
                      status, supersedes_id, kind, source, entities)
-                VALUES (?, ?, ?, ?, 0, 'never', ?, ?, ?, ?, ?, '[]')
+                VALUES (?, ?, ?, ?, 0, 'never', ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     mem_id, user_id, text, now, pinned,
-                    STATUS_ACTIVE, supersedes_id, kind, source,
+                    STATUS_ACTIVE, supersedes_id, kind_val, source, ents_json,
                 ),
             )
         else:
@@ -251,7 +310,6 @@ def install_phase_a_hooks() -> None:
     def _maybe_supersede_neighbor(
         self, user_id: str, vector: list[float], text: str
     ) -> tuple[str, str | None]:
-        """Return (op, supersedes_id). op in noop|add|supersede."""
         existing = m._sqlite_knn_search(
             self._conn, vector, user_id,
             limit=1, threshold=m.WRITE_DEDUP_THRESHOLD, active_only=True,
@@ -272,7 +330,6 @@ def install_phase_a_hooks() -> None:
             dedup_threshold=m.WRITE_DEDUP_THRESHOLD,
         )
         if op == "supersede" and pinned:
-            # Never retire pinned facts; keep both.
             return "add", None
         if op == "supersede":
             return "supersede", old_id
@@ -414,9 +471,6 @@ def install_phase_a_hooks() -> None:
     _Backend.add_raw = add_raw
     _Backend.search = search
 
-    # Public search: thread include_history; cache key includes it.
-    _orig_public_search = m.AikoMemorize.search
-
     def public_search(
         self,
         query: str,
@@ -476,4 +530,4 @@ def install_phase_a_hooks() -> None:
     m.AikoMemorize.search = public_search
     m._PHASE_A_HOOKS = True
     _PHASE_A_INSTALLED = True
-    log.info("memory Phase A hooks installed (active recall + supersede writes)")
+    log.info("memory Phase A/B hooks installed (active recall + supersede + entities)")

--- a/memory/memory_meta.py
+++ b/memory/memory_meta.py
@@ -70,7 +70,7 @@ def entities_from_json(raw: Any) -> list[str]:
     if raw is None or raw == "":
         return []
     if isinstance(raw, list):
-        return [str(x) for x in raw if str(x).strip()]
+        return [str(x).strip() for x in raw if str(x).strip()]
     try:
         data = json.loads(raw) if isinstance(raw, str) else raw
     except (TypeError, json.JSONDecodeError):

--- a/memory/memory_meta.py
+++ b/memory/memory_meta.py
@@ -77,7 +77,7 @@ def entities_from_json(raw: Any) -> list[str]:
         return []
     if not isinstance(data, list):
         return []
-    return [str(x).strip() for x in data if str(x).strip()]
+    return [str(x).strip() for x in raw if str(x).strip()]
 
 
 def classify_write_op(

--- a/memory/search_memory.py
+++ b/memory/search_memory.py
@@ -21,6 +21,11 @@ log = get_logger(__name__)
 MEMORY_ENTITY_BOOST = float(os.getenv("MEMORY_ENTITY_BOOST", "0.003"))
 
 
+def _escape_like(value: str) -> str:
+    """Escape SQL LIKE wildcards so entity tokens match literally."""
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
 def _normalize_personal_hit(row: dict, query: str = "") -> dict[str, Any]:
     from memory.entities import entity_overlap_score
     from memory.memory_meta import entities_from_json
@@ -200,19 +205,17 @@ def memories_for_entity(
         lock = memorize._mem._db_lock
     except Exception:
         return []
-    status_sql = "" if include_history else "AND (status = 'active' OR status IS NULL)"
-    # Match entity as a JSON string token; escape LIKE wildcards loosely
-    like = f'%"{needle.replace("%", "").replace("_", "")}"%'
+    # status_sql is one of two hardcoded literals (not user input).
+    status_clause = "" if include_history else "AND (status = 'active' OR status IS NULL)"
+    like = f'%"{_escape_like(needle)}"%'
+    sql = (
+        "SELECT * FROM memories "
+        "WHERE user_id = ? "
+        "AND entities LIKE ? ESCAPE '\\' "
+        f"{status_clause} "
+        "ORDER BY created_at DESC "
+        "LIMIT ?"
+    )
     with lock:
-        rows = conn.execute(
-            f"""
-            SELECT * FROM memories
-            WHERE user_id = ?
-              AND entities LIKE ?
-              {status_sql}
-            ORDER BY created_at DESC
-            LIMIT ?
-            """,
-            (uid, like, int(limit)),
-        ).fetchall()
+        rows = conn.execute(sql, (uid, like, int(limit))).fetchall()
     return [_normalize_personal_hit(dict(r), needle) for r in rows]

--- a/memory/search_memory.py
+++ b/memory/search_memory.py
@@ -1,0 +1,218 @@
+"""
+memory/search_memory.py
+
+Phase B unified recall facade over personal memory + learned knowledge.
+
+Keeps each store's own ranking; merges results with a simple interleave by
+normalized score. No second embedding model — callers may pass a shared
+query_vector for personal memory and an embedder for knowledge.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Iterable, Sequence
+
+from system.log import get_logger
+from system.userspace import current_user_id
+
+log = get_logger(__name__)
+
+# Soft boost when query text mentions tagged entities on a personal memory.
+MEMORY_ENTITY_BOOST = float(os.getenv("MEMORY_ENTITY_BOOST", "0.003"))
+
+
+def _normalize_personal_hit(row: dict, query: str = "") -> dict[str, Any]:
+    from memory.entities import entity_overlap_score
+    from memory.memory_meta import entities_from_json
+
+    entities = entities_from_json(row.get("entities"))
+    base = float(row.get("_recall_score") or row.get("score") or 0.0)
+    boost = MEMORY_ENTITY_BOOST * entity_overlap_score(query, entities)
+    return {
+        "store": "personal",
+        "id": str(row.get("id") or ""),
+        "text": row.get("memory") or row.get("text") or "",
+        "score": base + boost,
+        "created_at": row.get("created_at"),
+        "kind": row.get("kind") or "fact",
+        "source": row.get("source") or "",
+        "status": row.get("status") or "active",
+        "entities": entities,
+        "pinned": bool(row.get("pinned")),
+        "title": "",
+    }
+
+
+def _normalize_knowledge_hit(row: dict) -> dict[str, Any]:
+    return {
+        "store": "knowledge",
+        "id": str(row.get("id") or ""),
+        "text": row.get("text") or "",
+        "score": float(row.get("score") or 0.0),
+        "created_at": row.get("created_at"),
+        "kind": row.get("kind") or "ingested",
+        "source": row.get("source") or "",
+        "status": "active",
+        "entities": [],
+        "pinned": False,
+        "title": row.get("title") or "",
+        "doc_id": row.get("doc_id"),
+    }
+
+
+def search_personal(
+    query: str,
+    *,
+    limit: int = 5,
+    memorize: Any = None,
+    user_id: str | None = None,
+    query_vector: list[float] | None = None,
+    include_history: bool = False,
+) -> list[dict[str, Any]]:
+    """Search personal memory store; apply entity overlap boost."""
+    if memorize is None:
+        return []
+    try:
+        rows = memorize.search(
+            query,
+            user_id=user_id,
+            limit=limit,
+            query_vector=query_vector,
+            include_history=include_history,
+        )
+    except TypeError:
+        # Pre-Phase-A search signature
+        rows = memorize.search(query, user_id=user_id, limit=limit, query_vector=query_vector)
+    except Exception as e:
+        log.warning("search_personal failed: %s", e)
+        return []
+    hits = [_normalize_personal_hit(r, query) for r in (rows or [])]
+    hits.sort(key=lambda h: h["score"], reverse=True)
+    return hits[:limit]
+
+
+def search_knowledge_store(
+    query: str,
+    *,
+    limit: int = 5,
+    embedder: Any = None,
+    user_id: str | None = None,
+) -> list[dict[str, Any]]:
+    try:
+        from memory.knowledge import search_knowledge
+    except Exception as e:
+        log.debug("knowledge store unavailable: %s", e)
+        return []
+    try:
+        rows = search_knowledge(query, limit=limit, embedder=embedder, user_id=user_id)
+    except Exception as e:
+        log.warning("search_knowledge failed: %s", e)
+        return []
+    return [_normalize_knowledge_hit(r) for r in (rows or [])]
+
+
+def search_memory(
+    query: str,
+    *,
+    limit: int = 5,
+    stores: Sequence[str] = ("personal", "knowledge"),
+    memorize: Any = None,
+    embedder: Any = None,
+    user_id: str | None = None,
+    query_vector: list[float] | None = None,
+    include_history: bool = False,
+    per_store_limit: int | None = None,
+) -> list[dict[str, Any]]:
+    """Unified multi-store recall.
+
+    Returns a list of normalized hits::
+
+        {
+          "store": "personal" | "knowledge",
+          "id": str,
+          "text": str,
+          "score": float,
+          "kind": str,
+          "entities": list[str],
+          ...
+        }
+
+    Each store is queried independently (cheap parallel-ready structure);
+    results are merged by score descending. Defaults keep total work low:
+    ``per_store_limit`` defaults to ``limit``.
+    """
+    q = (query or "").strip()
+    if not q:
+        return []
+    uid = user_id or current_user_id()
+    sub = int(per_store_limit) if per_store_limit is not None else int(limit)
+    sub = max(1, sub)
+
+    merged: list[dict[str, Any]] = []
+    wanted = {s.strip().lower() for s in stores}
+
+    if "personal" in wanted:
+        merged.extend(
+            search_personal(
+                q,
+                limit=sub,
+                memorize=memorize,
+                user_id=uid,
+                query_vector=query_vector,
+                include_history=include_history,
+            )
+        )
+    if "knowledge" in wanted:
+        # Prefer embedder from memorize backend when not provided
+        emb = embedder
+        if emb is None and memorize is not None:
+            try:
+                emb = memorize._mem._embedder
+            except Exception:
+                emb = None
+        merged.extend(
+            search_knowledge_store(q, limit=sub, embedder=emb, user_id=uid)
+        )
+
+    merged.sort(key=lambda h: float(h.get("score") or 0.0), reverse=True)
+    return merged[: int(limit)]
+
+
+def memories_for_entity(
+    entity: str,
+    *,
+    memorize: Any = None,
+    user_id: str | None = None,
+    limit: int = 50,
+    include_history: bool = False,
+) -> list[dict[str, Any]]:
+    """List personal memories whose entities JSON contains ``entity``.
+
+    SQL LIKE over the JSON text — fine at personal-memory scale; no FTS index
+    required for Phase B. Used by future graph studio / debug tools.
+    """
+    if memorize is None or not (entity or "").strip():
+        return []
+    uid = user_id or current_user_id()
+    needle = entity.strip()
+    try:
+        conn = memorize._conn
+        lock = memorize._mem._db_lock
+    except Exception:
+        return []
+    status_sql = "" if include_history else "AND (status = 'active' OR status IS NULL)"
+    # Match entity as a JSON string token; escape LIKE wildcards loosely
+    like = f'%"{needle.replace("%", "").replace("_", "")}"%'
+    with lock:
+        rows = conn.execute(
+            f"""
+            SELECT * FROM memories
+            WHERE user_id = ?
+              AND entities LIKE ?
+              {status_sql}
+            ORDER BY created_at DESC
+            LIMIT ?
+            """,
+            (uid, like, int(limit)),
+        ).fetchall()
+    return [_normalize_personal_hit(dict(r), needle) for r in rows]

--- a/util/migrate_memory_phase_b.py
+++ b/util/migrate_memory_phase_b.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+migrate_memory_phase_b.py
+
+Optional offline backfill for Phase B entity tags on legacy personal memories.
+Does not re-embed. Safe to re-run (only_empty by default).
+
+Usage:
+  uv run python -m util.migrate_memory_phase_b --dry-run
+  uv run python -m util.migrate_memory_phase_b
+  uv run python -m util.migrate_memory_phase_b --limit 500 --user-id <id>
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Backfill Phase B entities/kind on memory.db")
+    parser.add_argument("--db", type=str, default="", help="Path to memory.db")
+    parser.add_argument("--user-id", type=str, default="", help="User id filter / path resolve")
+    parser.add_argument("--limit", type=int, default=0, help="Max rows to update (0 = all)")
+    parser.add_argument("--all", action="store_true", help="Re-tag even rows that already have entities")
+    parser.add_argument("--dry-run", action="store_true", help="Count candidates only")
+    args = parser.parse_args(argv)
+
+    from memory.memory_meta import backfill_entities, ensure_phase_a_schema, existing_columns
+    from memory.vecstore import initialize_store_db, resolve_user_db_path
+    from system.userspace import current_user_id
+
+    uid = (args.user_id or "").strip() or current_user_id()
+    if args.db.strip():
+        db_path = Path(args.db).expanduser()
+    else:
+        env = os.getenv("SQLITE_MEMORY_PATH", "").strip()
+        db_path = Path(env).expanduser() if env else resolve_user_db_path("memory/memory.db", user_id=uid)
+
+    print(f"user_id={uid}")
+    print(f"db={db_path}")
+    if not db_path.exists() and str(db_path) != ":memory:":
+        print("DB does not exist — nothing to backfill.")
+        return 0
+
+    conn = initialize_store_db(str(db_path), "PRAGMA journal_mode = WAL;", user_id=uid, vector=True)
+    try:
+        ensure_phase_a_schema(conn)
+        cols = existing_columns(conn)
+        if "entities" not in cols:
+            print("entities column missing — run Phase A migrate first.")
+            return 1
+
+        if args.dry_run:
+            sql = "SELECT COUNT(*) AS n FROM memories WHERE 1=1"
+            params: list = []
+            if args.user_id:
+                sql += " AND user_id = ?"
+                params.append(uid)
+            if not args.all:
+                sql += " AND (entities IS NULL OR entities = '' OR entities = '[]')"
+            n = conn.execute(sql, params).fetchone()["n"]
+            print(f"Dry-run candidates: {n}")
+            return 0
+
+        n = backfill_entities(
+            conn,
+            user_id=uid if args.user_id else None,
+            limit=args.limit,
+            only_empty=not args.all,
+        )
+        print(f"Updated {n} rows (no vectors rebuilt).")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
Phase B on top of Phase A: **rule-based entity tags** at write time and a **unified `search_memory()`** facade. Still **no vector rebuild** and **no extra LLM** on the hot path.

## Entity tags
- `memory/entities.py` — regex/heuristic extractors (proper spans, ALLCAPS codes, quoted names, `called/named/project X`)
- Heuristic `kind`: identity / preference / plan / event / fact
- Written into `entities` + `kind` columns on every `add` / `add_raw`
- Soft recall boost when query text mentions a tagged entity (`MEMORY_ENTITY_BOOST`, default `0.003`)

## Unified search
```python
from memory import search_memory

hits = search_memory(
    "GRACE robot",
    limit=5,
    stores=("personal", "knowledge"),
    memorize=memorize,   # AikoMemorize instance
    # embedder=...       # optional; falls back to memorize embedder
)
# each hit: store, id, text, score, kind, entities, ...
```

Also: `memories_for_entity("GRACE", memorize=...)` for graph-studio-style listing.

## Optional backfill (legacy rows)
New writes are tagged automatically. For old rows:
```bash
uv run python -m util.migrate_memory_phase_b --dry-run
uv run python -m util.migrate_memory_phase_b
```

## Latency notes
- Entity extract runs only on fact strings already produced by extraction (microseconds)
- Unified search runs each store independently; no shared second model
- No change to embedding dims or FTS schema


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added unified memory search across personal and knowledge stores.
  * Added entity-aware retrieval with configurable score boosting.
  * Added automatic entity and memory-type tagging for new and existing memories.
  * Added lookup and filtering of memories associated with specific entities.
  * Added an optional migration tool for backfilling entity metadata, including dry-run support.
* **Documentation**
  * Updated memory phase guidance, migration instructions, and configuration documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->