### PR TITLE
feat(memory): Phase E — core profile + D live co-mentions + Studio edges

### DIFF
--- a/memory/PHASE_E.md
+++ b/memory/PHASE_E.md
@@ -20,7 +20,16 @@ block = core_profile_for_context(memorize)
 - `CORE_PROFILE_MAX_CHARS` (default 900)
 - `CORE_PROFILE_PATH` optional override path
 
+## Also in this PR (Phase D polish)
+- **Live co-mentions:** `memory_meta._insert_row` calls `upsert_co_mentions` after each write (best-effort; no LLM).
+- **Studio edges:** `graph_export.export_memory_graph` merges `relations_as_graph_edges` when `include_entities=True`.
+
+Offline rebuild still available:
+```bash
+uv run python -m util.migrate_memory_phase_d
+```
+
 ## Notes
 - No extra LLM
 - Wire into `think.py` / context assembly when ready (not required to merge module)
-- Best after Phase A (status) + Phase B (kind tags)
+- Best after Phase A (status) + Phase B (kind tags) + Phase D (entity_relations table)

--- a/memory/PHASE_E.md
+++ b/memory/PHASE_E.md
@@ -1,0 +1,26 @@
+# Phase E — Core profile (Letta-lite)
+
+## Goal
+Always-on durable user facts without paying full RRF every turn.
+
+## Sources (priority)
+1. Optional `~/.aiko/<user>/memory/core_profile.json` → `{ "facts": ["..."] }`
+2. Active personal memories ordered by: pinned → kind identity/preference → access_count
+
+## API
+```python
+from memory.core_profile import core_profile_for_context, format_core_profile
+
+block = core_profile_for_context(memorize)
+# inject near system prompt / memory_context
+```
+
+## Config
+- `CORE_PROFILE_MAX_FACTS` (default 12)
+- `CORE_PROFILE_MAX_CHARS` (default 900)
+- `CORE_PROFILE_PATH` optional override path
+
+## Notes
+- No extra LLM
+- Wire into `think.py` / context assembly when ready (not required to merge module)
+- Best after Phase A (status) + Phase B (kind tags)

--- a/memory/core_profile.py
+++ b/memory/core_profile.py
@@ -1,0 +1,199 @@
+"""
+memory/core_profile.py
+
+Phase E: Letta-lite core profile — a small always-on block of durable facts
+about the user (identity / preferences / pins), independent of per-turn RRF.
+
+No extra LLM. Reads existing memory rows + optional JSON override file.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+from system.log import get_logger
+from system.userspace import current_user_id, user_state_path
+
+log = get_logger(__name__)
+
+CORE_PROFILE_MAX_FACTS = int(os.getenv("CORE_PROFILE_MAX_FACTS", "12"))
+CORE_PROFILE_MAX_CHARS = int(os.getenv("CORE_PROFILE_MAX_CHARS", "900"))
+CORE_PROFILE_PATH = os.getenv("CORE_PROFILE_PATH", "").strip()  # optional JSON override
+
+
+def _profile_override_path(user_id: str) -> Path:
+    if CORE_PROFILE_PATH:
+        return Path(CORE_PROFILE_PATH).expanduser()
+    return user_state_path("memory/core_profile.json", user_id)
+
+
+def load_profile_override(user_id: str | None = None) -> list[str]:
+    """Optional human/edited facts from core_profile.json: {"facts": ["..."]}."""
+    uid = user_id or current_user_id()
+    path = _profile_override_path(uid)
+    if not path.is_file():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        log.warning("core_profile override unreadable: %s", e)
+        return []
+    facts = data.get("facts") if isinstance(data, dict) else None
+    if not isinstance(facts, list):
+        return []
+    return [str(f).strip() for f in facts if str(f).strip()]
+
+
+def save_profile_override(facts: list[str], user_id: str | None = None) -> Path:
+    uid = user_id or current_user_id()
+    path = _profile_override_path(uid)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {"facts": [str(f).strip() for f in facts if str(f).strip()]}
+    path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return path
+
+
+def _fetch_core_rows(conn: sqlite3.Connection, user_id: str, limit: int) -> list[dict[str, Any]]:
+    cols = {str(r[1]) for r in conn.execute("PRAGMA table_info(memories)").fetchall()}
+    if "id" not in cols:
+        return []
+
+    has_status = "status" in cols
+    has_kind = "kind" in cols
+
+    # Prefer pinned + identity-kind active facts; fall back to high access_count.
+    where = ["user_id = ?"]
+    params: list[Any] = [user_id]
+    if has_status:
+        where.append("(status = 'active' OR status IS NULL)")
+
+    order = "pinned DESC"
+    if has_kind:
+        order += ", CASE WHEN kind = 'identity' THEN 0 WHEN kind = 'preference' THEN 1 ELSE 2 END"
+    order += ", access_count DESC, created_at DESC"
+
+    sql = f"""
+        SELECT id, memory, pinned, access_count, created_at
+        {', kind' if has_kind else ''}
+        FROM memories
+        WHERE {' AND '.join(where)}
+        ORDER BY {order}
+        LIMIT ?
+    """
+    params.append(int(limit))
+    try:
+        rows = conn.execute(sql, params).fetchall()
+    except sqlite3.Error as e:
+        log.warning("core_profile query failed: %s", e)
+        return []
+    return [dict(r) for r in rows]
+
+
+def collect_core_facts(
+    *,
+    user_id: str | None = None,
+    conn: sqlite3.Connection | None = None,
+    max_facts: int | None = None,
+) -> list[str]:
+    """Merge override JSON + durable DB facts (deduped, order preserved)."""
+    uid = user_id or current_user_id()
+    cap = int(max_facts or CORE_PROFILE_MAX_FACTS)
+    out: list[str] = []
+    seen: set[str] = set()
+
+    def _add(text: str) -> None:
+        t = (text or "").strip()
+        if not t:
+            return
+        key = " ".join(t.lower().split())
+        if key in seen:
+            return
+        seen.add(key)
+        out.append(t)
+
+    for f in load_profile_override(uid):
+        _add(f)
+        if len(out) >= cap:
+            return out[:cap]
+
+    owns = conn is None
+    if conn is None:
+        import os
+        from pathlib import Path
+        from memory.vecstore import initialize_store_db, resolve_user_db_path
+
+        env = os.getenv("SQLITE_MEMORY_PATH", "").strip()
+        db_path = Path(env).expanduser() if env else resolve_user_db_path("memory/memory.db", user_id=uid)
+        if not db_path.exists() and str(db_path) != ":memory:":
+            return out[:cap]
+        try:
+            conn = initialize_store_db(str(db_path), "PRAGMA journal_mode = WAL;", user_id=uid, vector=True)
+        except Exception as e:
+            log.warning("core_profile open failed: %s", e)
+            return out[:cap]
+
+    try:
+        for row in _fetch_core_rows(conn, uid, limit=max(cap * 3, cap)):
+            _add(str(row.get("memory") or ""))
+            if len(out) >= cap:
+                break
+    finally:
+        if owns and conn is not None:
+            try:
+                conn.close()
+            except Exception:
+                pass
+
+    return out[:cap]
+
+
+def format_core_profile(
+    *,
+    user_id: str | None = None,
+    conn: sqlite3.Connection | None = None,
+    max_facts: int | None = None,
+    max_chars: int | None = None,
+) -> str | None:
+    """Return an XML-ish block for system/context injection, or None if empty."""
+    facts = collect_core_facts(user_id=user_id, conn=conn, max_facts=max_facts)
+    if not facts:
+        return None
+
+    budget = int(max_chars or CORE_PROFILE_MAX_CHARS)
+    lines = [
+        "<core_profile>",
+        "Durable facts about the user (always-on). Use silently; do not dump this block.",
+        "",
+    ]
+    used = sum(len(x) + 1 for x in lines)
+    for f in facts:
+        line = f"  - {f}"
+        if used + len(line) + 20 > budget:
+            break
+        lines.append(line)
+        used += len(line) + 1
+    lines.append("</core_profile>")
+    block = "\n".join(lines)
+    if len(block) > budget:
+        block = block[: budget - 20].rstrip() + "\n</core_profile>"
+    return block
+
+
+def core_profile_for_context(
+    memorize: Any = None,
+    *,
+    user_id: str | None = None,
+) -> str | None:
+    """Convenience: use open AikoMemorize connection when available."""
+    uid = user_id
+    conn = None
+    if memorize is not None:
+        try:
+            uid = uid or memorize.get_user_id()
+            conn = memorize._conn
+        except Exception:
+            conn = None
+    return format_core_profile(user_id=uid, conn=conn)

--- a/memory/graph_export.py
+++ b/memory/graph_export.py
@@ -2,6 +2,7 @@
 memory/graph_export.py
 
 Phase C: export personal memory as a node/edge graph for visualization.
+Phase D polish: merge entity co-mention edges from entity_relations.
 
 Read-only. Tolerates pre-Phase-A DBs (missing status/entities columns).
 """
@@ -66,6 +67,7 @@ def export_memory_graph(
     Edge types:
       - supersedes: newer memory → older memory it replaced
       - mentions: memory → entity
+      - co_mentions: entity → entity (Phase D entity_relations)
     """
     uid = user_id or current_user_id()
     owns_conn = conn is None
@@ -192,6 +194,40 @@ def export_memory_graph(
             e for e in edges
             if e["type"] != "supersedes" or e["target"] in mem_ids
         ]
+
+        # Phase D: entity ↔ entity co-mentions
+        if include_entities:
+            try:
+                from memory.entity_graph import (
+                    ensure_entity_relations_schema,
+                    relations_as_graph_edges,
+                )
+
+                ensure_entity_relations_schema(conn)
+                for e in relations_as_graph_edges(
+                    conn, user_id=uid, limit=max(int(limit) * 2, 500)
+                ):
+                    for endpoint in (e["source"], e["target"]):
+                        if endpoint not in entity_ids and endpoint not in mem_ids:
+                            label = endpoint.removeprefix("ent:")
+                            entity_ids.add(endpoint)
+                            nodes.append({
+                                "id": endpoint,
+                                "type": "entity",
+                                "label": label,
+                                "text": label,
+                                "status": "active",
+                                "kind": "entity",
+                                "source": "",
+                                "pinned": False,
+                                "access_count": 0,
+                                "created_at": None,
+                                "entities": [],
+                                "supersedes_id": None,
+                            })
+                    edges.append(e)
+            except Exception as ex:
+                log.debug("graph_export: entity_relations skipped: %s", ex)
 
         return {
             "nodes": nodes,

--- a/memory/memory_meta.py
+++ b/memory/memory_meta.py
@@ -9,6 +9,7 @@ Design constraints:
   - Idempotent migration (boot + CLI).
   - Hooks install once into memory.memorize without requiring a full file rewrite.
   - Phase B: rule-based entity tags + kind on write.
+  - Phase D polish: live co-mention upsert on write (best-effort).
 """
 from __future__ import annotations
 
@@ -279,7 +280,8 @@ def install_phase_a_hooks() -> None:
     ) -> None:
         cols = existing_columns(self._conn)
         kind_val = kind or classify_kind(text, default=KIND_FACT)
-        ents_json = entities_to_json(entities if entities is not None else extract_entities(text))
+        ents_list = entities if entities is not None else extract_entities(text)
+        ents_json = entities_to_json(ents_list)
         if "status" in cols:
             self._conn.execute(
                 """
@@ -306,6 +308,21 @@ def install_phase_a_hooks() -> None:
             "INSERT INTO memories_vec(id, embedding) VALUES (?, ?)",
             (mem_id, sqlite_vec.serialize_float32(vector)),
         )
+
+        # Phase D: live co-mention edges (best-effort; never fail the write)
+        try:
+            from memory.entity_graph import upsert_co_mentions
+
+            if ents_list and len([e for e in ents_list if str(e).strip()]) >= 2:
+                upsert_co_mentions(
+                    self._conn,
+                    user_id=user_id,
+                    entities=ents_list,
+                    memory_id=mem_id,
+                    updated_at=now if isinstance(now, str) else None,
+                )
+        except Exception as e:
+            log.debug("entity_relations upsert skipped: %s", e)
 
     def _maybe_supersede_neighbor(
         self, user_id: str, vector: list[float], text: str


### PR DESCRIPTION
## Status: ready after A–D smoke

Letta-lite always-on core profile **plus** Phase D polish (live co-mentions + Studio edges).

## Contents

| Piece | Path |
|-------|------|
| Core profile | `memory/core_profile.py` |
| Docs | `memory/PHASE_E.md` |
| Live co-mentions on write | `memory/memory_meta.py` → `_insert_row` → `upsert_co_mentions` |
| Studio entity↔entity edges | `memory/graph_export.py` → `relations_as_graph_edges` |

## Phase E usage (after merge)

```python
from memory.core_profile import core_profile_for_context
block = core_profile_for_context(memorize)
# inject near system prompt / memory_context when ready
```

Optional override: `~/.aiko/<user>/memory/core_profile.json` → `{ "facts": ["..."] }`

Config: `CORE_PROFILE_MAX_FACTS` (12), `CORE_PROFILE_MAX_CHARS` (900), `CORE_PROFILE_PATH`

## Phase D polish

- **Write path:** after each memory insert, best-effort `upsert_co_mentions` (no extra LLM; never fails the write).
- **Studio:** `/api/graph?include_entities=true` includes `type: co_mentions` edges from `entity_relations`.
- Offline rebuild still works: `uv run python -m util.migrate_memory_phase_d`

## Smoke checklist

- [x] A+B schema + entity backfill on real encrypted DB
- [x] D rebuild → co-mention pairs present
- [ ] Pull this branch / merge to `dev`
- [ ] `core_profile_for_context` returns a block
- [ ] New multi-entity write bumps relation weight without migrate D
- [ ] Studio `/api/graph` includes `co_mentions` edges

## Notes

- No extra LLM, no vector rebuild
- Wiring core profile into `think.py` is optional follow-up (module is self-contained)
- Depends on A/B/C/D already on `dev`
