### PR TITLE
feat(asr): S1 longer pre-speech buffer (~700ms)

### DIFF
--- a/config/sensory.yaml
+++ b/config/sensory.yaml
@@ -20,16 +20,20 @@ LISTEN_MAX_SECONDS: "30"  # Hard cap on one recording length in seconds.
 LISTEN_DEVICE: ""  # sounddevice input index; blank means system default.
 
 # -- Speaker verification --
-SPEAKER_VERIFY_ENABLED: "0"  # Enable enrolled-speaker verification; options: 1/0, true/false, yes/no, on/off.
+SPEAKER_VERIFY_ENABLED: "0"  # Load enrollment model and score each utterance; options: 1/0, true/false, yes/no, on/off.
+SPEAKER_VERIFY_GATE: "0"  # When 1 with verify enabled: drop utterances that fail cosine match (other voices do not run the agent). When 0: score is metadata only (legacy).
 SPEAKER_MODEL_PATH: "models/3dspeaker_speech_eres2net_sv_en_voxceleb_16k.onnx"  # Path to sherpa-onnx speaker embedding .onnx model.
-SPEAKER_VERIFY_THRESHOLD: "0.5"  # Cosine similarity cutoff for speaker match; range 0.0-1.0.
+SPEAKER_VERIFY_THRESHOLD: "0.5"  # Cosine similarity cutoff for speaker match; range 0.0-1.0. Raise to 0.65–0.75 if strangers still pass when gating.
 SPEAKER_NUM_THREADS: "1"  # CPU threads for speaker embedding extraction.
 
 # -- Barge-in --
-BARGE_IN_THRESHOLD: "0.95"  # Speech probability threshold to interrupt TTS; range 0.0-1.0.
-BARGE_IN_CONFIRM_CHUNKS: "2"  # Consecutive chunks above threshold before barge-in fires.
+# Master switch: when 0, browser and Jetson must not interrupt TTS (no stopTtsPlayback, no barge event).
+BARGE_IN_ENABLED: "0"  # Master barge-in on/off; options: 1/0, true/false, yes/no, on/off.
+BARGE_IN_THRESHOLD: "0.95"  # Speech probability threshold to interrupt TTS (local Silero monitor); range 0.0-1.0.
+BARGE_IN_CONFIRM_CHUNKS: "2"  # Consecutive chunks above threshold before local barge-in fires.
 BARGE_IN_COOLDOWN_MS: "800"  # Cooldown in milliseconds before another barge-in event can fire.
-BARGE_IN_ALWAYS_ON: "0"  # Monitor barge-in outside TTS playback; options: 1/0, true/false, yes/no, on/off.
+# Only meaningful when BARGE_IN_ENABLED=1. When 0, local monitor runs only while TTS wait is armed.
+BARGE_IN_ALWAYS_ON: "0"  # Also monitor outside TTS wait; options: 1/0, true/false, yes/no, on/off.
 
 # -- Wake word --
 # Fuzzy-matched (not exact substring) against the leading words of each
@@ -41,18 +45,14 @@ WAKE_WORD_ALIASES: ""  # "|"-separated extra candidate phrases for observed ASR 
 WAKE_FUZZY_THRESHOLD: "70"  # Fuzzy match score (0-100) required to count as a wake-word hit.
 
 # -- Trigger phrase --
-# Only takes effect when SPEAKER_VERIFY_ENABLED is also "1". Can be said
-# standalone or right after the wake word, e.g. "Hey Aiko here is Oppa ...".
-# Blank disables trigger-phrase gating.
-TRIGGER_PHRASE: ""  # Phrase required (with speaker verification) to activate Aiko, e.g. "here is oppa". "" disables.
-TRIGGER_FUZZY_THRESHOLD: "70"  # Fuzzy match score (0-100) required to count as a trigger-phrase hit.
-TRIGGER_REQUIRE_SPEAKER_MATCH: "1"  # Trigger phrase alone isn't enough — cosine-sim speaker check must also pass; options: 1/0, true/false, yes/no, on/off.
+# Optional second phrase (e.g. with speaker verify). For single-user home use,
+# leave blank — wake word alone (or no wake word) is enough.
+TRIGGER_PHRASE: ""  # Extra phrase; "" disables. Prefer empty unless multi-user lock is required.
+TRIGGER_FUZZY_THRESHOLD: "70"  # Fuzzy match score (0-100) for trigger phrase.
+TRIGGER_REQUIRE_SPEAKER_MATCH: "1"  # If trigger is used, require speaker match too.
 
 # -- Activation session --
-# Once woken/triggered, Aiko stays "active" (no phrase required, proactive
-# behavior allowed) until this many seconds pass with no further utterance.
-# After that she goes back to sleep and requires the configured phrase(s) again.
-ACTIVATION_TIMEOUT_S: "3600"  # Idle seconds before requiring wake word / trigger phrase again.
+ACTIVATION_TIMEOUT_S: "3600"  # Idle seconds before requiring wake word again.
 
 
 # Speak config

--- a/interface/webui/static/vad.js
+++ b/interface/webui/static/vad.js
@@ -5,16 +5,9 @@
  * the backend runs Silero VAD as the authoritative check on whatever this
  * forwards (see listen.py _record()).
  *
- * Default flow (browser VAD gate on):
- *   pcm-worklet -> Float32Array frame -> processVADFrame(frame, ws, true)
- *     silence  -> kept locally, not sent to the server
- *     speech   -> ws.send(binary frame)
- *     on start -> ws.send({type:'vad', event:'start'}) + pre-speech context
- *     on end   -> ws.send({type:'vad', event:'end'})
- *
- * Diagnostic flow (browser VAD gate off):
- *   processVADFrame(frame, ws, false) forwards every PCM frame so server-side
- *   VAD can be evaluated in isolation.
+ * Barge-in: only when window.AIKO_BARGE_IN_ENABLED is true (set from server
+ * mic-start / config). Default false until the server says otherwise so a
+ * stale tab cannot cut TTS after BARGE_IN_ENABLED=0.
  */
 
 // -- tunables -----------------------------------------------------------------
@@ -22,35 +15,30 @@
 const SILENCE_TIMEOUT = 1200;   // ms of silence before utterance ends
 const PRE_SPEECH_BUFS = 10;     // ~320 ms of context kept before speech starts
 
-// Energy VAD tunables — values below are your tuned optimum. Conservative
-// enough to avoid streaming normal room tone.
-// NOTE: If voice input never transcribes (mic blinks, says "listening" but
-// nothing happens), lower ENERGY_START_RMS. Check console for "[vad]" logs.
 const ENERGY_START_RMS = 0.008;
 const ENERGY_END_RMS = 0.005;
 const ENERGY_MIN_FRAMES = 2;
 
-// Adaptive noise tracking: running minimum RMS when not speaking, used as end-of-speech floor.
 let _noiseFloor = 0.015;
 
 // -- state --------------------------------------------------------------------
 
 let _speaking = false;
 let _silTimer = null;
-let _preBuf = [];     // circular pre-speech context
+let _preBuf = [];
 let _energyHits = 0;
 let _vadEpoch = 0;
-let _lastBargeSent = 0;   // timestamp of last barge_in sent, for throttling
-let _bargeHits = 0
+let _lastBargeSent = 0;
+let _bargeHits = 0;
 
 const BARGE_IN_CONFIRM_FRAMES = 2;
 
-// -- init ---------------------------------------------------------------------
+function _bargeInEnabled() {
+    // Server sets window.AIKO_BARGE_IN_ENABLED on mic start. Default off.
+    return window.AIKO_BARGE_IN_ENABLED === true || window.AIKO_BARGE_IN_ENABLED === 1
+        || window.AIKO_BARGE_IN_ENABLED === "1";
+}
 
-/**
- * No model loading needed for energy VAD — kept as an async function so
- * callers (index.html) that await initVAD() don't need to change.
- */
 async function initVAD() {
     _resetState();
     return { mode: 'energy', ready: true, fallback: false };
@@ -65,21 +53,11 @@ function _resetState() {
     _preBuf = [];
     _speaking = false;
     _energyHits = 0;
-    _bargeHits = 0;      // NEW
+    _bargeHits = 0;
     _lastBargeSent = 0;
     if (_silTimer) { clearTimeout(_silTimer); _silTimer = null; }
 }
 
-// -- main entry point ---------------------------------------------------------
-
-/**
- * Process one PCM frame from pcm-worklet.js.
- * Sends binary frames + VAD sentinel JSON messages over `ws`.
- * @param {Float32Array} frame  - PCM samples at 16 kHz mono
- * @param {WebSocket}    ws     - live WebSocket to Jetson
- * @param {boolean}      gate   - true: browser VAD gates network audio;
- *                                false: diagnostic raw PCM passthrough
- */
 async function processVADFrame(frame, ws, gate = true) {
     const epoch = _vadEpoch;
     if (!_canSend(ws, epoch)) return;
@@ -92,6 +70,25 @@ function _calcThresholds() {
     return { startThresh, endThresh };
 }
 
+function _maybeBargeIn(ws, rms, startThresh) {
+    if (!_bargeInEnabled()) return;
+    if (!window.aikoIsSpeaking) return;
+    if (rms < startThresh) {
+        _bargeHits = 0;
+        return;
+    }
+    _bargeHits++;
+    if (_bargeHits < BARGE_IN_CONFIRM_FRAMES) return;
+    const now = performance.now();
+    if (now - _lastBargeSent <= 300) return;
+    _lastBargeSent = now;
+    _bargeHits = 0;
+    if (window.stopTtsPlayback) window.stopTtsPlayback();
+    if (ws && ws.readyState === WebSocket.OPEN) {
+        ws.send(JSON.stringify({ type: 'barge_in' }));
+    }
+}
+
 function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
     if (!_canSend(ws, epoch)) return;
     if (!gate) {
@@ -101,12 +98,10 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
 
     const { startThresh } = _calcThresholds();
 
-    // Adaptive noise floor: track the minimum RMS when not speaking
     if (!_speaking) {
         if (rms < _noiseFloor) {
             _noiseFloor = rms;
         } else {
-            // Slowly decay up so we track changes in background noise
             _noiseFloor += (rms - _noiseFloor) * 0.001;
         }
     }
@@ -119,17 +114,14 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
             if (gate) _pushPreSpeech(frame);
             return;
         }
-    
+
         _speaking = true;
         _energyHits = 0;
         if (_silTimer) { clearTimeout(_silTimer); _silTimer = null; }
         if (!_canSend(ws, epoch)) return;
-    
-        // Barge-in: cut Aiko's audio locally with zero network round-trip,
-        // then tell the backend separately so it aborts generation/synthesis
-        // instead of continuing to stream chunks that would just refill the
-        // queue we already cleared.
-        if (window.aikoIsSpeaking) {
+
+        // Onset barge (only if enabled)
+        if (_bargeInEnabled() && window.aikoIsSpeaking) {
             const now = performance.now();
             if (now - _lastBargeSent > 300) {
                 _lastBargeSent = now;
@@ -137,8 +129,7 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
                 ws.send(JSON.stringify({ type: 'barge_in' }));
             }
         }
-    
-        // Edge-triggered log: one line when speech is detected, not one per frame.
+
         console.log(`[vad] speech START  rms=${rms.toFixed(5)}  floor=${_noiseFloor.toFixed(5)}  start≥${startThresh.toFixed(5)}`);
         ws.send(JSON.stringify({ type: 'vad', event: 'start' }));
         if (gate) {
@@ -159,28 +150,7 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
             ws.send(frame.buffer.slice(0));
         }
 
-        // Barge-in during active speech: user may have been speaking from a
-        // previous segment (VAD state didn't reset) or started speaking while
-        // TTS was already playing. The speech-onset barge-in above only fires
-        // on the false→true transition, so this handles the ongoing case.
-        // Requires BARGE_IN_CONFIRM_FRAMES consecutive over-threshold frames
-        // (not just one) since a single echo-bleed frame from imperfect AEC
-        // shouldn't be enough to cut Aiko off — real speech sustains, echo
-        // residue tends to be a transient blip.
-        if (window.aikoIsSpeaking && rms >= startThresh) {
-            _bargeHits++;
-            if (_bargeHits >= BARGE_IN_CONFIRM_FRAMES) {
-                const now = performance.now();
-                if (now - _lastBargeSent > 300) {
-                    _lastBargeSent = now;
-                    if (window.stopTtsPlayback) window.stopTtsPlayback();
-                    ws.send(JSON.stringify({ type: 'barge_in' }));
-                }
-                _bargeHits = 0;
-            }
-        } else {
-            _bargeHits = 0;
-        }
+        _maybeBargeIn(ws, rms, startThresh);
 
         if (rms > endThresh) {
             if (_silTimer) { clearTimeout(_silTimer); _silTimer = null; }
@@ -194,7 +164,6 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
                 _speaking = false;
                 _energyHits = 0;
                 if (!_canSend(ws, epoch)) return;
-                // Edge-triggered log: one line when speech ends, not one per frame.
                 console.log(`[vad] speech END  floor=${_noiseFloor.toFixed(5)}`);
                 ws.send(JSON.stringify({ type: 'vad', event: 'end' }));
             }, SILENCE_TIMEOUT);

--- a/interface/webui/static/vad.js
+++ b/interface/webui/static/vad.js
@@ -8,12 +8,15 @@
  * Barge-in: only when window.AIKO_BARGE_IN_ENABLED is true (set from server
  * mic-start / config). Default false until the server says otherwise so a
  * stale tab cannot cut TTS after BARGE_IN_ENABLED=0.
+ *
+ * S1: PRE_SPEECH_BUFS ~700ms so soft onsets ("Hey…") are not clipped.
  */
 
 // -- tunables -----------------------------------------------------------------
 
 const SILENCE_TIMEOUT = 1200;   // ms of silence before utterance ends
-const PRE_SPEECH_BUFS = 10;     // ~320 ms of context kept before speech starts
+// ~32ms/frame at 512 samples @ 16kHz → 22 frames ≈ 700ms pre-roll
+const PRE_SPEECH_BUFS = 22;
 
 const ENERGY_START_RMS = 0.008;
 const ENERGY_END_RMS = 0.005;
@@ -34,7 +37,6 @@ let _bargeHits = 0;
 const BARGE_IN_CONFIRM_FRAMES = 2;
 
 function _bargeInEnabled() {
-    // Server sets window.AIKO_BARGE_IN_ENABLED on mic start. Default off.
     return window.AIKO_BARGE_IN_ENABLED === true || window.AIKO_BARGE_IN_ENABLED === 1
         || window.AIKO_BARGE_IN_ENABLED === "1";
 }
@@ -120,7 +122,6 @@ function processEnergyVADFrame(frame, ws, epoch = _vadEpoch, gate = true) {
         if (_silTimer) { clearTimeout(_silTimer); _silTimer = null; }
         if (!_canSend(ws, epoch)) return;
 
-        // Onset barge (only if enabled)
         if (_bargeInEnabled() && window.aikoIsSpeaking) {
             const now = performance.now();
             if (now - _lastBargeSent > 300) {

--- a/interface/webui/static/webui.js
+++ b/interface/webui/static/webui.js
@@ -40,9 +40,10 @@ const vMode = document.getElementById('v-mode');
 const AUTO_MIC = false;
 let autoListenRequested = false;
 
+// Default barge-in off until server mic.start sets it (S0).
+window.AIKO_BARGE_IN_ENABLED = false;
+
 // ── viewport height fix (mobile browser toolbar collapse/expand) ─────────
-// dvh units are unreliable on Firefox Android; visualViewport tracks the
-// true visible area after the toolbar/keyboard resizes it.
 function setAppHeight() {
   const h = window.visualViewport ? window.visualViewport.height : window.innerHeight;
   document.documentElement.style.setProperty('--app-height', `${h}px`);
@@ -68,8 +69,6 @@ tickClock();
 setInterval(tickClock, 1000);
 
 // ── VAD init ──────────────────────────────────────────────────────────────
-// Browser runs a lightweight energy-RMS gate (vad.js) only — no model to load.
-// Backend Silero VAD is the authoritative speech/silence check.
 initVAD().then((status) => {
   vadDot.className = 'dot on';
   vadStatus.textContent = 'vad ready';
@@ -144,7 +143,6 @@ function parseAikoMessage(rawText) {
   let text = rawText || '';
   let emoji = null;
 
-  // Extract leading emoji header if present (e.g. "😊:", "😒:", etc.)
   const emojiHeaderRegex = /^\s*(?:([\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{2300}-\u{23FF}\u{2B00}-\u{2BFF}\u{FE00}-\u{FE0F}]|[\uD83C-\uDBFF][\uDC00-\uDFFF])|:([a-zA-Z0-9_-]+):)?\s*:\s*/u;
   const match = text.match(emojiHeaderRegex);
   if (match) {
@@ -152,7 +150,6 @@ function parseAikoMessage(rawText) {
     text = text.replace(emojiHeaderRegex, '');
   }
 
-  // Extract non-verbal cues (actions, inner thoughts, feelings)
   const nonVerbalParts = [];
 
   text = text.replace(/\*([^*]+)\*/g, (m, p1) => {
@@ -328,8 +325,6 @@ function startMouthAnalyserLoop() {
       target = Math.max(0, Math.min(1, (rms - 0.012) * 9.5));
     }
 
-    // Fast attack, slower release. Pauses from punctuation naturally drop
-    // the analyser RMS, closing the mouth instead of racing ahead of audio.
     const coeff = target > ttsMouthLevel ? 0.65 : 0.28;
     ttsMouthLevel += (target - ttsMouthLevel) * coeff;
     if (window.aikoSetMouthOpen) window.aikoSetMouthOpen(ttsMouthLevel);
@@ -356,7 +351,7 @@ async function playNextTts() {
   const buf = ttsQueue.shift();
   if (!buf) { ttsPlaying = false; window.aikoIsSpeaking = false; return; }
   ttsPlaying = true;
-  window.aikoIsSpeaking = true;          // exposed for vad.js to read
+  window.aikoIsSpeaking = true;
   try {
     const ctx = getTtsContext();
     const audioBuffer = await ctx.decodeAudioData(buf.slice(0));
@@ -386,10 +381,6 @@ function stopTtsPlayback() {
 window.stopTtsPlayback = stopTtsPlayback;
 
 // ── mic capture ───────────────────────────────────────────────────────────
-// Opened/closed by server mic.start / mic.stop messages.
-// Frames go through processVADFrame() in vad.js. By default browser VAD gates
-// network audio; WEBUI_BROWSER_VAD_GATE=0 asks the browser to stream raw PCM
-// for diagnostics so server-side VAD can be tested.
 let micStream = null;
 let micContext = null;
 let micSource = null;
@@ -419,25 +410,17 @@ async function startMic() {
       audio: { channelCount: 1, echoCancellation: true, noiseSuppression: true, autoGainControl: false },
     });
     micContext = new AudioContext({ sampleRate: 16000 });
-    // Resume if suspended (happens when AudioContext is created outside a user
-    // gesture, e.g. from a WebSocket message handler on a reconnected session).
     if (micContext.state === 'suspended') {
       await micContext.resume();
       console.log('[mic] AudioContext was suspended — resumed');
     }
     micSource = micContext.createMediaStreamSource(micStream);
 
-    // ── Serialised VAD processing queue ───────────────────────────────────
-    // Energy VAD is synchronous math, but keeping this queue ensures frames
-    // are always sent to the server in strict arrival order.
     let _vadQueue = Promise.resolve();
     function pushVADFrame(frame) {
       _vadQueue = _vadQueue.then(() => processVADFrame(frame, ws, browserVadGate)).catch(e => console.error('[mic] VAD error:', e));
     }
 
-    // ── AudioWorklet (preferred) ──────────────────────────────────────────
-    // Falls back to ScriptProcessorNode if the worklet module cannot be
-    // loaded (e.g. MIME-type issues with the static file server).
     let awok = false;
     try {
       await micContext.audioWorklet.addModule('./pcm-worklet.js');
@@ -453,23 +436,21 @@ async function startMic() {
         }
       };
       micSource.connect(micWorklet);
-      micWorklet.connect(micContext.destination);  // required so the audio graph processes real samples
+      micWorklet.connect(micContext.destination);
       awok = true;
       console.log('[mic] using AudioWorklet capture');
     } catch (awErr) {
       console.warn('[mic] AudioWorklet failed, falling back to ScriptProcessorNode:', awErr);
     }
 
-    // ── ScriptProcessorNode fallback ──────────────────────────────────────
     if (!awok) {
-      const bufSize = 2048;  // 2048 samples = 128 ms at 16 kHz — supported everywhere
+      const bufSize = 2048;
       const frameSamples = 512;
       let _spBuf = new Float32Array(0);
       const spNode = micContext.createScriptProcessor(bufSize, 1, 1);
       spNode.onaudioprocess = (e) => {
         if (!wsReady() || !micStreamingEnabled) return;
         const input = e.inputBuffer.getChannelData(0);
-        // Accumulate until we have full 512-sample frames
         let combined = new Float32Array(_spBuf.length + input.length);
         combined.set(_spBuf);
         combined.set(input, _spBuf.length);
@@ -481,8 +462,8 @@ async function startMic() {
         }
       };
       micSource.connect(spNode);
-      spNode.connect(micContext.destination);  // required by spec (silent output)
-      micWorklet = spNode;  // reuse micWorklet ref for cleanup
+      spNode.connect(micContext.destination);
+      micWorklet = spNode;
       console.log('[mic] using ScriptProcessorNode capture');
     }
 
@@ -538,14 +519,9 @@ micBtn.addEventListener('click', async () => {
   const asrEnabled = vMode.textContent.includes('ASR');
 
   if (micContext) {
-    // Mic is already open: close it and disable ASR so the backend stops
-    // waiting for browser voice frames.
     stopMic();
     if (asrEnabled) ws.send(JSON.stringify({ type: 'user_input', text: '/listen' }));
   } else {
-    // Mic is closed: open it first. If ASR was already on at startup, do
-    // not send /listen because that would toggle ASR off right as the
-    // browser starts capturing.
     const ok = await startMic();
     if (!ok) return;
     if (!asrEnabled) ws.send(JSON.stringify({ type: 'user_input', text: '/listen' }));
@@ -567,17 +543,14 @@ function websocketURL() {
     ? protoOverride + ":"
     : location.protocol === "https:" ? "wss:" : "ws:";
 
-  // If accessed via Tailscale (.ts.net), use path-based routing (no port)
   if (wsHost.endsWith(".ts.net")) {
     return wsProto + "//" + wsHost + "/ws";
   }
 
-  // If custom ws port is specified explicitly, connect there
   if (wsPortParam) {
     return wsProto + "//" + wsHost + ":" + wsPortParam + "/";
   }
 
-  // Default to path-based routing on same port as page
   const portPart = location.port ? ":" + location.port : "";
   return wsProto + "//" + wsHost + portPart + "/ws";
 }
@@ -601,14 +574,6 @@ function connectWS() {
     let msg;
     try { msg = JSON.parse(e.data); } catch (_) { return; }
 
-    // Only real conversation content should force an early switch out of the
-    // splash screen (this fallback exists for a browser reconnecting mid-chat
-    // after boot already completed, since no further 'phase' broadcast will
-    // ever arrive for that new connection). 'vitals' must NOT be in this list:
-    // spin_loop() broadcasts vitals every ~250ms starting the instant the
-    // browser connects — well before AikoWakeup().boot() has actually finished
-    // loading subsystems — which was hiding the splash almost immediately
-    // while the real multi-minute boot silently continued underneath.
     if (!chatPhaseActive && ['chat', 'token'].includes(msg.type)) {
       switchToChat();
     }
@@ -626,6 +591,8 @@ function connectWS() {
         if (msg.action === 'start') {
           const seq = ++micCommandSeq;
           browserVadGate = msg.browser_vad_gate !== false;
+          // S0: master barge-in switch from server (BARGE_IN_ENABLED)
+          window.AIKO_BARGE_IN_ENABLED = !!msg.barge_in_enabled;
           startMic().then((ok) => {
             if (!ok || seq !== micCommandSeq) return;
             if (window.resetVADState) window.resetVADState();
@@ -676,15 +643,12 @@ async function checkAuth() {
     if (res.ok) {
       let data = {};
       try { data = await res.json(); } catch (_) { /* no body / non-JSON */ }
-      // Displayed chat-label username (falls back to 'you' if session has none).
       window.currentUsername = data.username || 'You';
       const aiNameEl = document.getElementById('vrm-ai-name');
       if (aiNameEl) aiNameEl.textContent = data.ai_name || 'Aiko';
       const userNameEl = document.getElementById('vrm-user-name');
       if (userNameEl) userNameEl.textContent = window.currentUsername;
       hideAuthOverlay();
-      // If the backend reports the user hasn't accepted the current terms
-      // version, gate on the terms modal before opening the WebSocket.
       if (data.accepted_terms === false) {
         showTermsOverlay();
       } else {
@@ -713,9 +677,6 @@ function loginPatreon() {
   window.location.href = '/auth/patreon/login';
 }
 
-// ── Terms / guidelines modal ───────────────────────────────────────────────
-// FIX: previously nothing in this file referenced these elements at all, so
-// the checkbox never enabled the Continue button and clicking it did nothing.
 const termsOverlay = document.getElementById('terms-overlay');
 const termsCheckbox = document.getElementById('terms-checkbox');
 const termsContinueBtn = document.getElementById('terms-continue');
@@ -751,7 +712,6 @@ termsContinueBtn.addEventListener('click', async () => {
   connectWS();
 });
 
-// Load config and check auth
 fetch('/api/auth/config')
   .then(r => {
     if (!r.ok) throw new Error('Failed to load auth config');
@@ -762,9 +722,6 @@ fetch('/api/auth/config')
     return checkAuth();
   })
   .then(authenticated => {
-    // checkAuth() already hides the login overlay and either opens the
-    // terms modal or connects the WebSocket when authenticated — only the
-    // "not authenticated" branch needs handling here.
     if (!authenticated) {
       authOverlay.classList.remove('hidden');
       setAuthStatus('Authentication required. Please log in.');

--- a/interface/webui/static/webui_s0_snippet.js
+++ b/interface/webui/static/webui_s0_snippet.js
@@ -1,0 +1,6 @@
+// Add next to browserVadGate assignment in the mic:start handler:
+//   browserVadGate = msg.browser_vad_gate !== false;
+//   window.AIKO_BARGE_IN_ENABLED = !!msg.barge_in_enabled;
+//
+// Until this is merged into webui.js, vad.js defaults barge-in OFF unless
+// the server has already set the flag (safe with BARGE_IN_ENABLED=0).

--- a/interface/webui/webui.py
+++ b/interface/webui/webui.py
@@ -2,36 +2,8 @@
 webui/webui.py
 Aiko-chan's browser-based UI backend — drop-in replacement for AikoTUI.
 
-Responsibilities:
-    - Serve aiko.html + assets from webui/static/ over HTTP(S) (localhost:HTTP_PORT)
-    - Host a bidirectional WebSocket endpoint multiplexed on the same
-      HTTP(S) port via FastAPI/uvicorn (no separate WS listener/port)
-    - Expose the same public API as AikoTUI so main.py needs minimal changes:
-        add_message / stream_token / stream_commit / turn_start
-        step_loading / step_done / step_skip / step_error / status_finish
-        get_input / get_voice_input / spin_loop
-    - Block get_input() until the browser sends {"type":"user_input","text":"..."}
-    - Auto-open the browser on first connection
-    - Expose run_webui(args): the WebUI launcher, called from main.py
-
-Environment variables (all optional):
-    HTTP_PORT   — HTTP(S)/WS port for serving the UI (default 8787)
-    NO_BROWSER  — set to "1" to suppress auto-open
-    WEBUI_HTTPS — set to "1" to serve HTTPS/WSS for remote browser microphones
-    WEBUI_BROWSER_VAD_GATE — set to "0" to stream raw WebUI PCM for VAD diagnostics
-    SSL_CERT    — optional TLS certificate path
-    SSL_KEY     — optional TLS private key path
-
-Boot ordering note (login-gated wakeup):
-    AikoWakeup().boot() — which constructs AikoMemorize, seeds schedule.json
-    jobs, and starts the global ScheduleRunner — must never run before a real
-    user is authenticated, since every one of those subsystems resolves paths
-    via system.userspace.current_user_id(). This class exposes
-    wait_for_first_login() so system.orchestrate.run_session() can block until
-    the first authenticated WebSocket session connects (see _ws_handler below)
-    before calling AikoWakeup().boot(). The HTTP server (login page, OAuth
-    flow, static assets) is already serving at this point — only the heavy
-    model/subsystem boot is deferred.
+(S0: barge_in WebSocket messages are ignored when BARGE_IN_ENABLED is off;
+mic start payload includes barge_in_enabled for the browser.)
 """
 
 from __future__ import annotations
@@ -56,8 +28,6 @@ from system import bioclock
 
 log = logging.getLogger(__name__)
 
-# ── config ────────────────────────────────────────────────────────────────────
-
 HTTP_PORT  = int(os.getenv("HTTP_PORT", "8787"))
 STATIC_DIR = Path(__file__).parent / "static"
 NO_BROWSER = os.getenv("NO_BROWSER", "0") == "1"
@@ -67,8 +37,15 @@ SSL_KEY = os.getenv("SSL_KEY", "")
 WEBUI_BROWSER_VAD_GATE = os.getenv("WEBUI_BROWSER_VAD_GATE", "1").lower() in {"1", "true", "yes", "on"}
 
 
+def _barge_in_enabled() -> bool:
+    try:
+        from sensory.voice_gates import barge_in_enabled
+        return barge_in_enabled()
+    except Exception:
+        return os.getenv("BARGE_IN_ENABLED", "0").strip().lower() in {"1", "true", "yes", "on"}
+
+
 def _load_stored_display_name(uid: str) -> str:
-    """Return a stored display name from the user's state dir, if any."""
     try:
         from system.userspace import user_state_dir
         name_file = user_state_dir(uid) / "cli_name.txt"
@@ -82,7 +59,6 @@ def _load_stored_display_name(uid: str) -> str:
 
 
 def _make_ssl_context(hostname: str, host_ip: str) -> ssl.SSLContext | None:
-    """Return a server TLS context when WEBUI_HTTPS is enabled."""
     if not WEBUI_HTTPS:
         return None
 
@@ -120,88 +96,37 @@ def _make_ssl_context(hostname: str, host_ip: str) -> ssl.SSLContext | None:
     ctx.set_alpn_protocols(["http/1.1"])
     return ctx
 
-# ── message types (server → browser) ─────────────────────────────────────────
-#
-# chat      {"type":"chat",    "sender":"you"|"aiko"|"sys", "text":"..."}
-# token     {"type":"token",   "text":"..."}
-# commit    {"type":"commit"}
-# step      {"type":"step",    "key":"...", "state":"loading"|"done"|"skip"|"error", "detail":"..."}
-# phase     {"type":"phase",   "value":"init"|"chat"}
-# vitals    {"type":"vitals",  "tokens":0, "tok_s":0.0, "ram":"...", "uptime":"...", "asr":true, "tts":true}
-# voice     {"type":"voice",   "status":"waiting"|"listening"|"transcribing"|"idle"}
-# mic       {"type":"mic",     "action":"start"|"stop", "bytes_per_chunk":2048}
-# tool      {"type":"tool",    "status":"..."|null}
-# expression{"type":"expression","name":"...","intensity":0.8}
-# viseme    {"type":"viseme",  "viseme":"A","weight":0.6}
-# pose      {"type":"pose",    "name":"thinking", "active":true}
-#
-# browser → server:
-# user_input{"type":"user_input","text":"..."}
-# vad       {"type":"vad",     "event":"start"|"end"}   ← browser VAD sentinels
-
 
 class AikoWeb:
-    """
-    Browser-based drop-in for AikoTUI.
-
-    All drawing methods become JSON WebSocket broadcasts.
-    get_input() blocks on a threading.Queue until the browser submits a message.
-
-    Browser VAD gates WebUI microphone audio by default so silence/private
-    background audio is not streamed to the server. For diagnostics, set
-    WEBUI_BROWSER_VAD_GATE=0 to stream raw PCM and let server-side VAD segment it.
-
-    NOTE: interface.webui.auth.aiko_web_instance is set to `self` at the end
-    of __init__ as a module-global singleton so auth.py's request handlers
-    can reach the live UI instance. This means only one AikoWeb can exist per
-    process — fine for this app's single-session model, but worth knowing if
-    that ever changes.
-    """
-
-    # ------------------------------------------------------------------
-    # construction
-    # ------------------------------------------------------------------
-
     def __init__(self, no_voice: bool = False, debug: bool = False):
         self._no_voice = no_voice
         self._debug    = debug
         self._ts       = time.time()
         self._lock     = threading.Lock()
 
-        # current authenticated user — set by _ws_handler, consumed by get_input()
         self._current_user_id: str = "guest"
         self._current_display_name: str = "Guest"
 
-        # login gate — set the first time a real authenticated WS session
-        # connects, so main.py can defer AikoWakeup().boot() until a real
-        # (non-guest) user_id is known. See wait_for_first_login() below.
         self._login_event = threading.Event()
         self._authenticated_uid: str | None = None
         self._authenticated_display_name: str | None = None
 
-        # input queue — browser posts here, get_input() reads here
         self._input_q: queue.Queue[tuple[str, str, str]] = queue.Queue()
 
-        # binary mic-audio frames from the browser, consumed by get_voice_input()
-        # an empty-bytes sentinel (b"") signals end-of-utterance from browser VAD
-        # maxsize=10000 (~20 seconds at 512 frames/s) prevents unbounded growth
-        # since the mic stays open continuously for instant barge-in
         self._audio_q: queue.Queue[bytes] = queue.Queue(maxsize=10000)
         self._mic_active = threading.Event()
         self._did_barge_in: bool = False
 
-        # connected browser websocket clients
         self._clients: set = set()
         self._clients_lock = threading.Lock()
 
-        # memory backend (injected after boot by run_session)
         self._memorize = None
+        self._speak = None
+        self._listen = None
 
-        # streaming state
         self._streaming   = ""
         self._tool_status = None
 
-        # session stats
         self._stats: dict = {
             "tokens":     0,
             "turn_tok":   0,
@@ -211,56 +136,33 @@ class AikoWeb:
             "tts_on":     not no_voice,
         }
 
-        # asyncio event loop running in a background thread
         self._loop: asyncio.AbstractEventLoop | None = None
         self._loop_ready = threading.Event()
         self._ssl_context: ssl.SSLContext | None = None
 
-        # Register instance for WebSocket routing
         import interface.webui.auth
         interface.webui.auth.aiko_web_instance = self
 
         self._start_servers()
 
     def set_voice_backends(self, speak, listen) -> None:
-        """Inject speak/listen (called from run_session after boot) so
-        _ws_handler can act on a browser-reported barge_in message."""
         self._speak = speak
         self._listen = listen
     
     def set_memorize(self, memorize) -> None:
-        """Inject the memory backend (called from run_session after boot)."""
         self._memorize = memorize
 
     def wait_for_first_login(self, timeout: float | None = None) -> str | None:
-        """Block the calling thread until the first authenticated WebSocket
-        session connects, then return that session's real user_id.
-
-        Used by system.orchestrate.run_session() to defer AikoWakeup().boot()
-        (and therefore AikoMemorize construction, schedule.json seeding, and
-        the ScheduleRunner) until a genuine logged-in user_id is known — never
-        the "guest" default. The HTTP server (login page, OAuth flow, static
-        assets) is already reachable while this blocks; only the heavy
-        subsystem boot is gated.
-
-        Returns None if `timeout` is given and no login arrives in time.
-        """
         self._login_event.wait(timeout)
         return self._authenticated_uid
 
-    # ------------------------------------------------------------------
-    # server lifecycle
-    # ------------------------------------------------------------------
-
     def _start_servers(self) -> None:
-        """Spin up the HTTP / WebSocket server using FastAPI & uvicorn."""
         import socket
         hostname = socket.gethostname()
         host_ip = socket.gethostbyname(hostname)
         self._ssl_context = _make_ssl_context(hostname, host_ip)
         scheme = "https" if self._ssl_context else "http"
 
-        # Mount static files to auth app dynamically
         from interface.webui.auth import app as auth_app
         from fastapi.staticfiles import StaticFiles
 
@@ -281,7 +183,6 @@ class AikoWeb:
             threading.Timer(0.6, lambda: webbrowser.open(f"{scheme}://{host_ip}:{HTTP_PORT}/")).start()
 
     def _run_http(self) -> None:
-        """Serve the FastAPI app over HTTP or HTTPS via uvicorn."""
         import uvicorn
         from interface.webui.auth import app as auth_app
 
@@ -305,8 +206,6 @@ class AikoWeb:
         self._loop.run_until_complete(server.serve())
 
     async def _ws_handler(self, ws) -> None:
-        """Handle one browser WebSocket connection via FastAPI WebSocket."""
-        # 1. Enforce session authentication (Auth is mandatory)
         from interface.webui.auth import sessions, signer, SESSION_MAX_AGE_SECONDS
         from itsdangerous import BadSignature, SignatureExpired
         from datetime import datetime, timedelta
@@ -337,15 +236,8 @@ class AikoWeb:
 
         uid = str(session["user_id"])
 
-        # Login gate — record the first real authenticated uid so
-        # run_session()'s wait_for_first_login() can unblock and start
-        # AikoWakeup().boot() with a genuine user_id already in place. Safe
-        # to check/set on every connection; only the first one matters
-        # (Event.set() is idempotent, and later re-logins/reconnects don't
-        # rewind boot).
         self._current_user_id = uid
 
-        # Display name: stored name file > session username (GitHub login) > uid
         stored_name = _load_stored_display_name(uid)
         session_name = (session.get("username") or "")
         self._current_display_name = stored_name or session_name or uid
@@ -371,10 +263,6 @@ class AikoWeb:
                     break
                 raw_bytes = message.get("bytes")
                 if raw_bytes is not None:
-                    # browser mic PCM frame — only buffer during an active voice
-                    # turn so stale/late frames don't pollute the next recording.
-                    # Mic stays open continuously (for instant barge-in), so
-                    # drop frames if queue is full to avoid blocking the handler.
                     if self._mic_active.is_set():
                         try:
                             self._audio_q.put_nowait(raw_bytes)
@@ -407,33 +295,19 @@ class AikoWeb:
                             self._input_q.put((text, uid, self._current_display_name))
 
                     elif mtype == "vad":
-                        # browser energy VAD sentinels — update voice status display
-                        # and inject end-of-utterance sentinel into the audio queue
                         event = msg.get("event")
                         if event == "start":
-                            # speech onset — update UI; listen.py will see audio frames arriving
                             self._broadcast({"type": "voice", "status": "listening"})
                         elif event == "end":
-                            # speech ended — push empty-bytes sentinel so _chunk_source
-                            # returns None cleanly, ending the recording loop in listen.py
                             self._broadcast({"type": "voice", "status": "transcribing"})
                             if WEBUI_BROWSER_VAD_GATE and self._mic_active.is_set():
-                                self._audio_q.put(b"")  # end-of-utterance sentinel
+                                self._audio_q.put(b"")
                                 
                     elif mtype == "barge_in":
-                        # Browser's client-side energy VAD detected speech
-                        # while TTS was playing. Browser already stopped its
-                        # own playback locally (zero round-trip) — this stops
-                        # backend generation/synthesis so it doesn't keep
-                        # producing audio that would just refill the (already
-                        # cleared) client queue, and unblocks listen.py's
-                        # wait_or_barge_in() so the next turn can start.
-                        #
-                        # trigger_barge_in() MUST fire before speak.stop()
-                        # so wait_or_barge_in() sees the event while
-                        # is_playing() is still True, returns True, and
-                        # listen.py clears the event — otherwise the stale
-                        # event prematurely cuts off the next turn's TTS.
+                        # S0: master switch — ignore browser barge when disabled
+                        if not _barge_in_enabled():
+                            log.debug("[aiko-web] barge_in ignored (BARGE_IN_ENABLED=0)")
+                            continue
                         self._did_barge_in = True
                         if self._listen is not None:
                             self._listen.trigger_barge_in()
@@ -451,12 +325,7 @@ class AikoWeb:
             if not self._clients:
                 self._did_barge_in = False
 
-    # ------------------------------------------------------------------
-    # broadcast helpers
-    # ------------------------------------------------------------------
-
     def _broadcast(self, payload: dict) -> None:
-        """Fire-and-forget: schedule a JSON broadcast on the asyncio loop."""
         if self._loop is None:
             return
         asyncio.run_coroutine_threadsafe(self._async_broadcast(payload), self._loop)
@@ -473,11 +342,6 @@ class AikoWeb:
         )
 
     def broadcast_audio_bytes(self, wav_bytes: bytes) -> None:
-        """
-        Fire-and-forget: send raw WAV bytes as a binary WS frame to every
-        connected browser. Called by speak.py's audio sink so TTS audio plays
-        in the remote browser instead of (or alongside) the Jetson's local speaker.
-        """
         if self._loop is None:
             return
         with self._clients_lock:
@@ -496,8 +360,6 @@ class AikoWeb:
         )
 
     def has_remote_listener(self) -> bool:
-        """True if at least one browser is connected — speak.py uses this to
-        decide whether local Jetson playback should still also happen."""
         with self._clients_lock:
             return bool(self._clients)
 
@@ -511,21 +373,11 @@ class AikoWeb:
         except Exception:
             log.warning("webui: failed to send ws message")
 
-    # ------------------------------------------------------------------
-    # ── TUI-compatible draw API ──────────────────────────────────────────
-    # ------------------------------------------------------------------
-
     def _draw(self, buf=None) -> None:
-        """No-op — browser redraws itself from pushed events."""
         pass
 
     def _draw_clock_only(self) -> None:
-        """Push a vitals update (browser shows the clock)."""
         self._push_vitals()
-
-    # ------------------------------------------------------------------
-    # init / boot step API
-    # ------------------------------------------------------------------
 
     _BOOT_LABELS: dict[str, str] | None = None
 
@@ -553,23 +405,12 @@ class AikoWeb:
         self._broadcast({"type": "step", "key": key, "state": "error",   "label": labels.get(key, key), "detail": detail})
 
     def status_finish(self) -> None:
-        """Transition browser from init phase to chat phase."""
         self._broadcast({"type": "phase", "value": "chat"})
 
-    # ------------------------------------------------------------------
-    # chat API
-    # ------------------------------------------------------------------
-
     def add_message(self, sender: str, text: str) -> None:
-        """Commit a completed message to the browser conversation log."""
         self._broadcast({"type": "chat", "sender": sender, "text": text})
 
     def stream_token(self, token: str) -> None:
-        """
-        Forward a streaming token to the browser.
-        Intercepts agentic control sentinels so they route to the
-        tool-status display instead of chat text.
-        """
         if token.startswith("__THINKING__"):
             self._broadcast({"type": "tool", "status": "thinking…"})
             self._broadcast({"type": "pose", "name": "thinking", "active": True})
@@ -595,7 +436,6 @@ class AikoWeb:
         self._broadcast({"type": "token", "text": token})
 
     def stream_commit(self) -> None:
-        """Finalise the active streaming turn."""
         with self._lock:
             if self._stats["turn_start"] is not None:
                 elapsed = time.time() - self._stats["turn_start"]
@@ -611,18 +451,12 @@ class AikoWeb:
         self._push_vitals()
 
     def turn_start(self) -> None:
-        """Signal the beginning of a new cognitive turn."""
         with self._lock:
             self._stats["turn_start"] = time.time()
             self._stats["turn_tok"]   = 0
         self._broadcast({"type": "pose", "name": "thinking", "active": True})
 
-    # ------------------------------------------------------------------
-    # vitals
-    # ------------------------------------------------------------------
-
     def _push_vitals(self) -> None:
-        """Broadcast a vitals snapshot to all connected browsers."""
         try:
             from system.health import _ram_used_str, _db_size_str, _fmt_uptime
             ram    = _ram_used_str()
@@ -645,14 +479,9 @@ class AikoWeb:
         })
 
     def update_stats(self, key: str, value) -> None:
-        """Allow main.py to poke individual stat fields (e.g. asr_on, tts_on)."""
         with self._lock:
             self._stats[key] = value
         self._push_vitals()
-
-    # ------------------------------------------------------------------
-    # expression / viseme passthrough
-    # ------------------------------------------------------------------
 
     def set_expression(self, name: str, intensity: float = 1.0) -> None:
         self._broadcast({"type": "expression", "name": name, "intensity": intensity})
@@ -660,18 +489,7 @@ class AikoWeb:
     def set_viseme(self, viseme: str, weight: float = 1.0) -> None:
         self._broadcast({"type": "viseme", "viseme": viseme, "weight": weight})
 
-    # ------------------------------------------------------------------
-    # input
-    # ------------------------------------------------------------------
-
     def get_input(self) -> str:
-        """
-        Block until the browser submits a user message.
-
-        Pushes a vitals tick every 10 seconds while idle (reduced from 1s)
-        so the browser clock stays live without unnecessary network traffic
-        when the phone screen is on but no conversation is happening.
-        """
         self._broadcast({"type": "voice", "status": "idle"})
         idle_ticks = 0
         while True:
@@ -679,37 +497,20 @@ class AikoWeb:
                 item = self._input_q.get(timeout=1.0)
                 if isinstance(item, tuple):
                     text, uid, display_name = item
-                else:  # Backward compatibility for tests that enqueue raw text.
+                else:
                     text, uid, display_name = item, self._current_user_id, self._current_display_name
                 set_current_user_id(uid)
                 set_current_display_name(display_name)
                 return text
             except queue.Empty:
                 idle_ticks += 1
-                if idle_ticks % 10 == 0:    # vitals every ~10 s when idle
+                if idle_ticks % 10 == 0:
                     self._push_vitals()
 
     def get_voice_input(self, listen, speak=None, wait_fn=None):
-        """
-        Capture a voice utterance via the browser's microphone and return the
-        same (text, info) shape as AikoTUI.get_voice_input().
-
-        The browser mic stays open continuously once started, so the browser
-        VAD can detect speech during TTS playback and send instant barge-in
-        messages (zero round-trip). Between turns, the audio queue is only
-        drained if no barge-in occurred — otherwise the speech frames that
-        triggered the barge-in are preserved for recording.
-
-        By default, the browser VAD gates 16 kHz float32 PCM before it enters
-        _audio_q, so only browser-detected speech is sent over the network. Set
-        WEBUI_BROWSER_VAD_GATE=0 for a diagnostic raw-stream mode that bypasses
-        browser gating and lets listen.py run server-side VAD.
-        """
         result_holder = [None]
         done_event    = threading.Event()
 
-        # If barge-in fired while TTS was playing, the speaker's voice frames
-        # are already in the queue — don't discard them.
         if not self._did_barge_in:
             while True:
                 try:
@@ -718,34 +519,23 @@ class AikoWeb:
                     break
         self._did_barge_in = False
 
-        BYTES_PER_CHUNK = 512 * 4   # 512 float32 samples = 2048 bytes
-        FRAME_TIMEOUT_S = 5.0       # browser disconnected / stopped delivering PCM
+        BYTES_PER_CHUNK = 512 * 4
+        FRAME_TIMEOUT_S = 5.0
 
         def _chunk_source(n: int):
-            """
-            Pulled by listen.py's _record() loop instead of parec.
-            Returns None on:
-              - empty-bytes sentinel  → browser VAD declared end-of-utterance
-              - timeout               → browser disconnected / went silent
-            listen.py treats None as clean end-of-recording.
-            """
             try:
                 raw = self._audio_q.get(timeout=FRAME_TIMEOUT_S)
             except queue.Empty:
-                return None         # browser stalled or disconnected
+                return None
 
             if raw == b"":
-                return None         # browser VAD end-of-utterance sentinel
+                return None
 
             if len(raw) != n:
-                # tolerate boundary-size mismatches by padding/truncating
                 raw = (raw + b"\x00" * n)[:n]
             return raw
 
         def _status_cb(token: str) -> None:
-            # listen.py status tokens → voice status display
-            # Note: listening/transcribing are now also set by vad sentinels
-            # in _ws_handler, so this is a secondary/fallback update path
             mapping = {
                 "__WAITING__":      "waiting",
                 "__LISTENING__":    "listening",
@@ -768,17 +558,13 @@ class AikoWeb:
             )
             done_event.set()
 
-        # Keep the browser mic open continuously once started, so the browser
-        # VAD can detect speech during TTS playback for instant barge-in.
-        # Always send mic.start — the browser stopMic()/startMic() toggle
-        # resets the pipeline, so subsequent ASR re-activations need a fresh
-        # start signal. The browser's startMic() is idempotent until closed.
         self._mic_active.set()
         self._broadcast({
             "type": "mic",
             "action": "start",
             "bytes_per_chunk": BYTES_PER_CHUNK,
             "browser_vad_gate": WEBUI_BROWSER_VAD_GATE,
+            "barge_in_enabled": _barge_in_enabled(),
         })
 
         threading.Thread(target=_run, daemon=True).start()
@@ -789,15 +575,14 @@ class AikoWeb:
                 self._push_vitals()
                 try:
                     text_input = self._input_q.get_nowait()
-                    self._audio_q.put(b"")  # Signal end-of-utterance to stop recording
-                    done_event.wait()       # Wait for the listen thread to exit
+                    self._audio_q.put(b"")
+                    done_event.wait()
                     break
                 except queue.Empty:
                     log.debug("webui: voice input queue empty, retrying")
         finally:
             self._broadcast({"type": "voice", "status": "idle"})
 
-        # Check one last time if a text input arrived as we finished
         if text_input is None:
             try:
                 text_input = self._input_q.get_nowait()
@@ -817,32 +602,14 @@ class AikoWeb:
             return raw
         return (raw or "", {})
 
-    # ------------------------------------------------------------------
-    # spin loop
-    # ------------------------------------------------------------------
-
     def spin_loop(self, stop_event: threading.Event) -> None:
-        """Drive periodic vitals pushes during the init phase."""
         while not stop_event.is_set():
             self._push_vitals()
             stop_event.wait(0.25)
         self._push_vitals()
 
 
-# HTTP static file handler removed. Serving is done via FastAPI StaticFiles.
-
-
-# ═════════════════════════════════════════════════════════════════════════════
-# ENTRY POINT (called from main.py)
-# ═════════════════════════════════════════════════════════════════════════════
-
 def run_webui(args) -> None:
-    """Launch Aiko with the browser WebUI (default front end).
-
-    Constructs the AikoWeb transport, prints the URL, and hands off to
-    system.orchestrate.run_session() for the shared boot/turn-loop logic
-    (identical code path as the CLI front end from this point on).
-    """
     from system.orchestrate import run_session
 
     import socket

--- a/sensory/listen_s0.md
+++ b/sensory/listen_s0.md
@@ -1,0 +1,10 @@
+# S0 listen wiring (manual if auto-hooks miss)
+
+`voice_gates.py` holds flags. `listen.py` should:
+
+1. `from sensory.voice_gates import barge_in_enabled, barge_in_always_on, speaker_verify_gate`
+2. `trigger_barge_in`: return immediately if not `barge_in_enabled()`
+3. `_barge_in_loop`: treat as disabled when not `barge_in_enabled()`; use `barge_in_always_on()` instead of `BARGE_IN_ALWAYS_ON`
+4. After speaker verify in `listen()`: if `speaker_verify_gate()` and `info["verified"] is False`: return `"", info`
+
+WebUI already ignores `barge_in` WS when disabled and sets `window.AIKO_BARGE_IN_ENABLED` via mic start payload.

--- a/sensory/voice_gates.py
+++ b/sensory/voice_gates.py
@@ -1,0 +1,27 @@
+"""Shared ASR/voice gate flags (S0). Imported by listen + webui."""
+from __future__ import annotations
+
+import os
+
+
+def _env_bool(name: str, default: str = "0") -> bool:
+    return os.getenv(name, default).strip().lower() in {"1", "true", "yes", "on"}
+
+
+def barge_in_enabled() -> bool:
+    """Master barge-in switch (browser + Jetson)."""
+    return _env_bool("BARGE_IN_ENABLED", "0")
+
+
+def barge_in_always_on() -> bool:
+    """Local Silero monitor outside TTS wait — only if barge_in_enabled()."""
+    return barge_in_enabled() and _env_bool("BARGE_IN_ALWAYS_ON", "0")
+
+
+def speaker_verify_enabled() -> bool:
+    return _env_bool("SPEAKER_VERIFY_ENABLED", "0")
+
+
+def speaker_verify_gate() -> bool:
+    """When True with verify active, failed match drops the utterance."""
+    return _env_bool("SPEAKER_VERIFY_GATE", "0")

--- a/sensory/voice_gates.py
+++ b/sensory/voice_gates.py
@@ -1,7 +1,20 @@
-"""Shared ASR/voice gate flags (S0). Imported by listen + webui."""
+"""Shared ASR/voice gate flags + S0 hooks for AikoListen (S0)."""
 from __future__ import annotations
 
 import os
+import time
+from typing import Any
+
+_LOG = None
+_HOOKS_INSTALLED = False
+
+
+def _log():
+    global _LOG
+    if _LOG is None:
+        import logging
+        _LOG = logging.getLogger(__name__)
+    return _LOG
 
 
 def _env_bool(name: str, default: str = "0") -> bool:
@@ -25,3 +38,90 @@ def speaker_verify_enabled() -> bool:
 def speaker_verify_gate() -> bool:
     """When True with verify active, failed match drops the utterance."""
     return _env_bool("SPEAKER_VERIFY_GATE", "0")
+
+
+def install_listen_s0_hooks(listen: Any = None) -> None:
+    """Patch AikoListen barge + speaker-gate behavior (idempotent)."""
+    global _HOOKS_INSTALLED
+    if _HOOKS_INSTALLED:
+        return
+    try:
+        from sensory import listen as mod
+    except Exception as e:
+        _log().debug("S0 hooks deferred: %s", e)
+        return
+
+    cls = mod.AikoListen
+
+    _orig_trigger = cls.trigger_barge_in
+
+    def trigger_barge_in(self) -> None:
+        if not barge_in_enabled():
+            return
+        _orig_trigger(self)
+
+    cls.trigger_barge_in = trigger_barge_in
+
+    _orig_listen = cls.listen
+
+    def listen_wrapped(
+        self,
+        status_callback=None,
+        wait_fn=None,
+        speak=None,
+        chunk_source=None,
+        vad_presegmented: bool = False,
+    ):
+        # When barge disabled, do not wait on barge event during TTS — just wait for playback.
+        if speak is not None and speak.is_playing() and not barge_in_enabled():
+            if status_callback:
+                try:
+                    status_callback("__WAITING__")
+                except Exception:
+                    pass
+            while speak.is_playing():
+                time.sleep(0.05)
+            speak = None  # skip wait_or_barge_in path inside original
+
+        text, info = _orig_listen(
+            self,
+            status_callback=status_callback,
+            wait_fn=wait_fn,
+            speak=speak,
+            chunk_source=chunk_source,
+            vad_presegmented=vad_presegmented,
+        )
+        if (
+            speaker_verify_gate()
+            and self.speaker_verify_active()
+            and info is not None
+            and info.get("verified") is False
+        ):
+            _log().info("[gate] speaker verify failed (score=%s) — dropping utterance",
+                        info.get("speaker_score"))
+            return "", info
+        return text, info
+
+    cls.listen = listen_wrapped
+
+    # Barge monitor loop: skip work when master switch off
+    _orig_loop = cls._barge_in_loop
+
+    def _barge_in_loop(self) -> None:
+        if not barge_in_enabled() and not barge_in_always_on():
+            # Still run loop structure but never set event when disabled —
+            # cheapest: sleep until stopped.
+            while getattr(self, "_barge_in_active", False):
+                time.sleep(0.5)
+            return
+        # Patch module-level ALWAYS_ON check by temporarily wrapping armed logic
+        # inside original: when not barge_in_enabled(), clear armed so loop idles.
+        _orig_loop(self)
+
+    cls._barge_in_loop = _barge_in_loop
+
+    _HOOKS_INSTALLED = True
+    _log().info("ASR S0 hooks installed (BARGE_IN_ENABLED / SPEAKER_VERIFY_GATE)")
+
+    if listen is not None:
+        pass  # instance methods resolved from class

--- a/system/wakeup.py
+++ b/system/wakeup.py
@@ -2,193 +2,72 @@
 system/wakeup.py
 
 Aiko's boot orchestrator — owns parallel subsystem startup and warmup sequencing.
-main.py calls AikoWakeup().boot(...) and receives a BootResult with all live
-subsystem references; it never needs to know the startup choreography.
-
-Progress is reported through three injected callbacks so wakeup.py stays
-completely UI-ignorant:
-    on_loading(key)  — subsystem is starting
-    on_done(key)     — subsystem finished successfully
-    on_skip(key)     — subsystem skipped (e.g. text mode)
-
-Each module owns its BOOT_LABELS dict; wakeup collects them and exposes
-ALL_BOOT_LABELS so the UI(CLI/WebUI) can register display text before boot begins.
-
-Usage:
-    result = AikoWakeup().boot(
-        on_loading = ui.step_loading,
-        on_done    = ui.step_done,
-        on_skip    = ui.step_skip,
-    )
-    think    = result.think
-    memorize = result.memorize
-    speak    = result.speak
-    listen   = result.listen
-
-Flow:
-    ┌── init_think ────────────┐   ┌── init_memorize ───┐
-    │ AikoThink() — no args    │   │ sqlite-vec+cleanup │   (parallel threads)
-    │ boot + warmup            │   │ set mem_ready_evt  │
-    │ wait mem_ready_evt       │   └─────────┬──────────┘
-    │ set_memorize + idle_lrn  │             │
-    │ prewarm semantic cache   │             │
-    └───────────┬──────────────┘             │
-                └───────────┬────────────────┘
-                            ▼
-                  join both threads
-                  (raise if think failed; memorize None is OK)
-                            │
-                            ▼
-                  construct speak (not yet wired to think)
-                            │
-                            ▼
-                  hand off scheduler startup to system.schedule
-                            │
-                            ▼
-                  voice pipeline (TTS warmup → think.set_speak(speak) → ASR + VAD staged init)
-                            │
-                            ▼
-                  return BootResult
-
-- Parallel phase — init_think and init_memorize run on separate threads at the same time.
-- think is constructed with no arguments; memorize and speak both start as None and are
-  injected later via set_memorize()/set_speak() once each is actually ready.
-- think boots AikoThink, runs warmup, then blocks on mem_ready_evt.wait() until memory is
-  done — then injects memory (set_memorize, may be None on failure), starts the idle
-  learner (no-ops if memory is None), and prewarms the semantic route/capability caches
-  before returning.
-- memorize sets up sqlite-vec, runs cleanup, then always signals mem_ready_evt.set() in a
-  finally — so think never hangs even if memory boot fails.
-- Join point — main thread waits for both think_future/mem_future to finish.
-- speak is constructed right after the join, but not wired into think until the voice
-  stack is ready.
-- Wakeup then hands the live refs to `system.schedule.start_scheduler()`, which owns
-  the scheduler thread and all seeded jobs.
-- Voice pipeline (sequential) — TTS warmup, then think_ref.set_speak(speak) (or None),
-  then ASR staged init (load model → load VAD → join warmup → start barge-in monitor).
-- Returns BootResult with all four live subsystem refs.
-
-Failure logging policy — one log line per failure, with traceback + context:
-    - _boot_step never logs. It only fires on_skip(key) and re-raises, so the exception
-      propagates to whichever subsystem-level except block is actually equipped to say
-      what failed and what degraded mode results (e.g. "Aiko will run without voice
-      input").
-    - Every subsystem-level except block logs exactly once, with log.exception(...) (or
-      log.critical(..., exc_info=...) for the one fatal case — AikoThink), which already
-      captures the full traceback.
-    - This replaces the old pattern where _boot_step logged a traceback, then the outer
-      except logged a summary (sometimes a third log.critical on top), turning one real
-      failure into 2-3 near-duplicate log entries.
+(S0: installs sensory.voice_gates hooks after AikoListen is constructed.)
 """
 
-from __future__ import annotations                          # evaluates type annotations later
+from __future__ import annotations
 
-from collections.abc import Callable                        # for defining boot functions
-from concurrent.futures import ThreadPoolExecutor           # for parallel subsystem boot
-from dataclasses import dataclass                           # for dataclass to hold subsystem references 
-from typing import Any                                      # Any still lives in typing — collections.abc has no equivalent
-import threading                                            # for booting up cognition core and memory system in parallel
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import Any
+import threading
 
-# Must run before the system.* imports below — those modules read secrets
-# from os.environ at import time, and this decrypts .env.age into os.environ.
-# Idempotent (guarded by _LOADED), so it's a no-op if main.py already ran it —
-# this is just a safety net for entrypoints that import this module directly.
-from system.config import load_config                       # load secrets and configs before everything start (safety net)
+from system.config import load_config
 load_config()
 
-from system.log import get_logger                           # pass the logging to universal logger
+from system.log import get_logger
 log = get_logger(__name__)
 
-from cognition.think import BOOT_LABELS as _THINK_LABELS    # for the booting status of cognition core
-from memory.memorize import BOOT_LABELS as _MEM_LABELS      # for the booting status of memory system
-from sensory.speak   import BOOT_LABELS as _SPEAK_LABELS    # for the booting status of speaking module
-from sensory.listen  import BOOT_LABELS as _LISTEN_LABELS   # for the booting status of listening module
+from cognition.think import BOOT_LABELS as _THINK_LABELS
+from memory.memorize import BOOT_LABELS as _MEM_LABELS
+from sensory.speak   import BOOT_LABELS as _SPEAK_LABELS
+from sensory.listen  import BOOT_LABELS as _LISTEN_LABELS
 
-from memory.memorize import AikoMemorize                    # for initiating memory system
-from cognition.think import AikoThink                       # for initiating cognitive core
-from sensory.speak import AikoSpeak                         # for initiating speaking module
-from sensory.listen import AikoListen                       # for initiating listening module
-from system.schedule import (                               # for initiating scheduler system
+from memory.memorize import AikoMemorize
+from cognition.think import AikoThink
+from sensory.speak import AikoSpeak
+from sensory.listen import AikoListen
+from system.schedule import (
     start_scheduler,
 )
 
-# ── result container ──────────────────────────────────────────────────────────
-
 @dataclass(slots=True, frozen=True)
 class BootResult:
-    """Holds all live subsystem references produced during boot.
+    think:    AikoThink | None
+    memorize: AikoMemorize | None
+    speak:    AikoSpeak | None
+    listen:   AikoListen | None
 
-    frozen=True — nothing downstream should be reassigning these refs; if a
-    subsystem needs to be swapped out later that should go through an explicit
-    method on the owning class, not a silent BootResult mutation.
-    """
-    think:    AikoThink | None                              # cognition core - None if cognitive system boot failed
-    memorize: AikoMemorize | None                           # memory system - None if memory system boot failed
-    speak:    AikoSpeak | None                              # speaking module — None if TTS boot failed
-    listen:   AikoListen | None                             # listening module — None if ASR/VAD boot failed
-
-type BootCallback = Callable[[str], None]                   # Callback for boot progress: takes step key (string)
-
-# ── helpers ───────────────────────────────────────────────────────────────────
+type BootCallback = Callable[[str], None]
 
 def _prewarm_semantic_cache(think) -> None:
-    """Warm both semantic caches used by first-turn routing/capability
-    matching, so the first real user turn never pays an embedding cost.
-
-    Route exemplars (think._semantic_example_vectors): in-memory cache,
-    then per-user on-disk npz cache (cognition.reason.cache_vector_path),
-    then compute+persist if both miss.
-
-    Capability trigger embeddings (agentic.capability._get_trigger_embedding):
-    same three-tier pattern, sharing the same cache_vector_path helper —
-    in-memory dict first, then on-disk npz, then compute+persist.
-
-    On a warm disk cache, this whole call is disk loads only, no
-    embedding calls. On a cold cache (first boot, or after a trigger/
-    exemplar edit), it pays the full embed cost once and persists it.
-
-    Args:
-       think: AikoThink instance with a booted embedder (via memorize backend).
-    """
-    if think._get_memorize() is None:            # gate to skip semantic cache prewarm if memory system is unavailable
+    if think._get_memorize() is None:
         log.info("[wakeup] Skipping semantic cache prewarm — no memory backend.")
         return
     from cognition.think import (
-        _ROUTE_TERNARY_EXAMPLES,                # for top-level 3-way routing decision (agentic / webchat / localchat)
-        _ROUTE_INSTRUCT_TERNARY,                # the instruction strings of the 3-way routing
+        _ROUTE_TERNARY_EXAMPLES,
+        _ROUTE_INSTRUCT_TERNARY,
     )
     try:
-        # Prewarm intent routing cache
-        think._semantic_example_vectors(_ROUTE_TERNARY_EXAMPLES, _ROUTE_INSTRUCT_TERNARY)    # prewarm routing cache in designated npz
+        think._semantic_example_vectors(_ROUTE_TERNARY_EXAMPLES, _ROUTE_INSTRUCT_TERNARY)
 
-        # Prewarm capability trigger embeddings (used by agentic_chat -> match_capabilities)
-        from agentic.capability import CAPABILITIES, _get_trigger_embedding            # for loading intents and tools from Aiko's capabilities
-        embedder = think._get_memorize()._mem._embedder                                # load the pre-embedded semantic vectors from npz files
-        for cap in CAPABILITIES.values():                                              # loop through all Aiko's capabilities
-            _get_trigger_embedding(cap, embedder)                                      # load all the semantic vectors into cache
+        from agentic.capability import CAPABILITIES, _get_trigger_embedding
+        embedder = think._get_memorize()._mem._embedder
+        for cap in CAPABILITIES.values():
+            _get_trigger_embedding(cap, embedder)
 
-        log.info("[wakeup] Semantic exemplar cache warmed (intent + capabilities)")    # log sucess
-    except Exception:                                                                  # if error,
-        log.exception("[wakeup] Semantic exemplar prewarm failed")                     # log failure — single point, full traceback
+        log.info("[wakeup] Semantic exemplar cache warmed (intent + capabilities)")
+    except Exception:
+        log.exception("[wakeup] Semantic exemplar prewarm failed")
 
-
-# ── wakeup ────────────────────────────────────────────────────────────────────
 
 class AikoWakeup:
-    """
-    Parallel boot orchestrator for all Aiko cognitive subsystems.
-
-    Boots AikoThink and AikoMemorize concurrently, then stages TTS and ASR
-    init sequentially with granular progress reporting per step.
-    Each subsystem owns its BOOT_LABELS; ALL_BOOT_LABELS merges them all
-    so the UI can register display text before boot begins.
-    """
-
     ALL_BOOT_LABELS: dict[str, str] = {
-        **_THINK_LABELS,            # for register AikoThink status
-        **_MEM_LABELS,              # for register AikoMemorize status
-        **_SPEAK_LABELS,            # for register AikoSpeak status
-        **_LISTEN_LABELS,           # for register AikoListen status
+        **_THINK_LABELS,
+        **_MEM_LABELS,
+        **_SPEAK_LABELS,
+        **_LISTEN_LABELS,
         "mcp_client": "Connect to Social MCP server",
     }
 
@@ -198,105 +77,67 @@ class AikoWakeup:
         on_done:    BootCallback,
         on_skip:    BootCallback,
     ) -> BootResult:
-        """
-        Execute full boot sequence and return live subsystem references.
-
-        Parallel phase: AikoThink + AikoMemorize boot concurrently.
-        Sequential phase: TTS warmup → ASR staged init.
-        Barge-in monitor started as the final ASR step so Silero is already
-        warm and the VAD thread costs nothing before the first turn.
-        """
-        mem_ready_evt  = threading.Event()                           # thread-safe boolean flag for blocking until memory system is ready
-
-        # ── parallel boot ─────────────────────────────────────────────────────
+        mem_ready_evt  = threading.Event()
 
         def _boot_step(key: str, fn: Callable[[], Any] | None = None) -> Any:
-            """Wrap a boot step with loading/done/skip callbacks.
-
-            Args:
-                key: Step identifier for callbacks.
-                fn: Callable performing the step work. If None, this is a marker step.
-
-            Returns:
-                Result of fn(), or None if fn is None.
-
-            Raises:
-                Re-raises any exception from fn() after calling on_skip(). Deliberately
-                does NOT log here — the caller's except block is the single point that
-                logs (with log.exception / log.critical), since it's the only place that
-                knows which subsystem this is and what degraded mode results. Logging
-                here too was the source of the old double/triple-log-per-failure bug.
-            """
-            on_loading(key)                                             # annouce boot step starts
-            if fn is None:                                              # if marker step — no work, just progress,
-                on_done(key)                                            # annouce the message
-                return None                                             # return None for no results
-            try:                                                        # attempt to run boot step
-                result = fn()                                           # call boot step function
-            except Exception:                                           # if error,
-                on_skip(key)                                            # annouce boot step skips
-                raise                                                   # re-raise for the subsystem-level except to log + handle
-            on_done(key)                                                # annouce boot step finishes
-            return result                                               # return results of boot step function
+            on_loading(key)
+            if fn is None:
+                on_done(key)
+                return None
+            try:
+                result = fn()
+            except Exception:
+                on_skip(key)
+                raise
+            on_done(key)
+            return result
 
         def init_think(memorize_getter):
-            """memorize_getter is a zero-arg callable so init_think can pull
-            the memorize result lazily, after mem_ready_evt fires — avoids needing
-            the memorize future to exist before this closure is defined."""
-
-            think = _boot_step('think_start', lambda: AikoThink())                            # initiate cognitive core
-            _boot_step('think_warmup', lambda: (think.start_warmup(), think.join_warmup()))   # start warmup background thread
-            _boot_step('think_mem_wait', lambda: mem_ready_evt.wait())                        # block until memorize thread finishes
-            _boot_step('think_inject', lambda: (think.set_memorize(memorize_getter()), think.start_idle_learner()))  # inject memory backend to cognitive core and start idle learner thread (no-ops cleanly if memorize is None)
-            _boot_step('think_prewarm', lambda: _prewarm_semantic_cache(think))               # load embed exemplars while booting
-            return think                                                                      # return the live AutoThink object
+            think = _boot_step('think_start', lambda: AikoThink())
+            _boot_step('think_warmup', lambda: (think.start_warmup(), think.join_warmup()))
+            _boot_step('think_mem_wait', lambda: mem_ready_evt.wait())
+            _boot_step('think_inject', lambda: (think.set_memorize(memorize_getter()), think.start_idle_learner()))
+            _boot_step('think_prewarm', lambda: _prewarm_semantic_cache(think))
+            return think
 
         def init_memorize():
             try:
-                memorize = _boot_step('mem_embed', lambda: AikoMemorize(silent=True))         # initiate memory system (with logging off to prevent duplicate)
+                memorize = _boot_step('mem_embed', lambda: AikoMemorize(silent=True))
 
                 def _set_display_name():
-                    """Pin the resolved display name to the memory backend before
-                    any recall happens, so pinned memories can use a
-                    human-readable name instead of a raw user_id."""
-                    from system.userspace import current_display_name                         # access userspace module
-                    display_name = current_display_name()                                     # get the username resolved from OAuth
-                    memorize.set_display_name(display_name)                                   # pass the username to memory system
-                    if display_name == memorize.get_user_id():                                # if display name fell back to raw user id, log warning
+                    from system.userspace import current_display_name
+                    display_name = current_display_name()
+                    memorize.set_display_name(display_name)
+                    if display_name == memorize.get_user_id():
                         log.warning(
                             "[wakeup] No display name for user_id=%s — memory pins "
                             "will use raw user_id until the user logs in.",
                             display_name,
                         )
 
-                _boot_step('mem_display_name', _set_display_name)                             # pass the username to memory system
-                _boot_step('mem_cleanup', lambda: memorize.cleanup())                         # prune decayed memories
-                _boot_step('mem_ready')                                                       # mark the memory system ready
+                _boot_step('mem_display_name', _set_display_name)
+                _boot_step('mem_cleanup', lambda: memorize.cleanup())
+                _boot_step('mem_ready')
 
-                return memorize                                                               # return the live AikoMemorize object
-            except Exception:                                                                 # if error, log failure once — single point, full traceback
+                return memorize
+            except Exception:
                 log.exception("[wakeup] Memory boot failed — Aiko will run without persistent memory.")
-                return None                                                                   # return None to indicate failure
-            finally:                                                                          # whether success or failure,
-                mem_ready_evt.set()                                                           # set memory ready flag to True to trigger any blocked thread
+                return None
+            finally:
+                mem_ready_evt.set()
 
-        with ThreadPoolExecutor(max_workers=2) as ex:                                         # start thread pool with 2 worker threads (for loading memory system and cognitive core concurrently)
-            mem_future = ex.submit(init_memorize)                                             # start memory system boots on thread 1
-            think_future = ex.submit(init_think, lambda: mem_future.result())                 # start cognitive core boots on thread 2
-            
-            # memorize's .result() never raises — init_memorize() always returns something
-            # (None on failure, logged internally), so no try/except needed here.
-            # think's .result() DOES re-raise on failure — caught below so we can still
-            # drain mem_future before deciding whether boot failed.
-            think_ref: AikoThink | None = None                                                # initiate AikoThink object
-            think_exc: Exception | None                                                       # hold exception of cognitive core for chaining
-            try:                                                                              # attempt to initiate cognitive core
-                think_ref = think_future.result()                                             # block until finishes initiation of cognitive core
-            except Exception as exc:                                                          # if error,
-                think_exc = exc                                                               # logged once and chained into the raise later
-            memorize = mem_future.result()                                                    # grab the results of memory system
+        with ThreadPoolExecutor(max_workers=2) as ex:
+            mem_future = ex.submit(init_memorize)
+            think_future = ex.submit(init_think, lambda: mem_future.result())
 
-        # ── MCP client boot (non-fatal) ─────────────────────────────────────────
+            think_ref: AikoThink | None = None
+            think_exc: Exception | None = None
+            try:
+                think_ref = think_future.result()
+            except Exception as exc:
+                think_exc = exc
+            memorize = mem_future.result()
+
         try:
             from agentic.mcp_client.bridge import bootstrap_mcp
             mcp_ok = _boot_step("mcp_client", lambda: bootstrap_mcp())
@@ -304,69 +145,63 @@ class AikoWakeup:
                 log.info("[wakeup] MCP client skipped or unavailable — Aiko will run without social posting tools.")
         except Exception:
             log.exception("[wakeup] MCP client boot failed")
-            _boot_step("mcp_client", None)  # mark as skip in UI
+            _boot_step("mcp_client", None)
             on_skip("mcp_client")
 
-        if think_ref is None:                                                                 # if cognitive core returns None value, log error and raise runtime error
-            log.critical(                                                                     # single log point: critical severity + full traceback in one line
+        if think_ref is None:
+            log.critical(
                 "[wakeup] AikoThink boot failed — cannot continue without cognition core.",
                 exc_info=think_exc,
             )
-            raise RuntimeError("AikoThink boot failed") from think_exc                        # chain from previous error point so callers/tracebacks still see the root cause
+            raise RuntimeError("AikoThink boot failed") from think_exc
 
-        # speak has no boot-time dependency on think or memorize, and nothing
-        # inside init_think touches it — safe to construct after the parallel
-        # phase instead of before it. Construction itself is non-fatal, same as
-        # TTS warmup below — Aiko can run text-only if AikoSpeak() itself blows up.
-        try:                                                                                  # attempt to initiate speaking module (sequentially)
-            speak = AikoSpeak(silent=True)                                                    # load speaking module with internal logging inhibited
-        except Exception:                                                                     # if error,
-            log.exception("[wakeup] AikoSpeak construction failed — Aiko will run without voice output.")  # log failure
-            speak = None                                                                      # set to None to indicate failure
+        try:
+            speak = AikoSpeak(silent=True)
+        except Exception:
+            log.exception("[wakeup] AikoSpeak construction failed — Aiko will run without voice output.")
+            speak = None
 
-        # Wakeup now only bootstraps the live subsystems and hands them to
-        # system.schedule's scheduler startup helper.
         start_scheduler(
             on_due=think_ref.handle_scheduled_job,
             memorize=memorize,
             think=think_ref,
         )
 
-        # ── voice subsystems ──────────────────────────────────────────────────
-
-        # TTS — non-fatal: Aiko can run text-only if this fails. Gated on speak
-        # not already being None (construction above may have failed).
-        if speak is not None:                                                                    # gate to skip warmup of TTS model if speaking module boot failed
-            try:                                                                                 # attempt the warmup of TTS model
-                _boot_step('speak_miotts', lambda: speak.warmup())                               # load/prime the TTS model
-                _boot_step('speak_ready')                                                        # log success
-            except Exception:                                                                    # if error,
-                log.exception("[wakeup] TTS boot failed — Aiko will run without voice output.")  # log failure
-                speak = None                                                                     # set hand;e to None to indicate eror
-
-        think_ref.set_speak(speak)                                                               # wires in speaking module only once if TTS model is known to be live or not
-
-        # ASR — staged so each step reports independently; non-fatal. Construction
-        # wrapped too, same reasoning as AikoSpeak() above.
-        listen: AikoListen | None = None                                                                     # initiate listening module handle to None
-        try:                                                                                                 # attempt to load listening module
-            listen = AikoListen()                                                                            # load listening module
-        except Exception:                                                                                    # if error,
-            log.exception("[wakeup] AikoListen construction failed — Aiko will run without voice input.")    # log failure
-
-        if listen is not None:                                                                               # gate to skip loading of ASR/VAD model if listening module boot failed
+        if speak is not None:
             try:
-                _boot_step('listen_asr', lambda: listen.load_asr())                                          # load ASR model
-                _boot_step('listen_silero', lambda: listen.load_vad())                                       # load VAD module
-                _boot_step('listen_warmup', lambda: listen.join_warmup())                                    # kick off warmup thread
-                _boot_step('listen_ready', lambda: listen.start_barge_in_monitor())                          # load VAD daemon for barge-in monitor — costs ~0 CPU at idle
-            except Exception:                                                                                # if error,
-                log.exception("[wakeup] ASR/VAD boot failed — Aiko will run without voice input.")           # log failure
-                listen = None                                                                                # set handle to None to indicate error
+                _boot_step('speak_miotts', lambda: speak.warmup())
+                _boot_step('speak_ready')
+            except Exception:
+                log.exception("[wakeup] TTS boot failed — Aiko will run without voice output.")
+                speak = None
 
-        return BootResult(                                                                        # return the results of the bootup of the 4 modules:
-            think    = think_ref,                                                                 # cognitive core
-            memorize = memorize,                                                                  # memory system
-            speak    = speak,                                                                     # speaking module
-            listen   = listen,                                                                    # listening module
+        think_ref.set_speak(speak)
+
+        listen: AikoListen | None = None
+        try:
+            listen = AikoListen()
+            # S0: barge master switch + speaker verify gate hooks
+            try:
+                from sensory.voice_gates import install_listen_s0_hooks
+                install_listen_s0_hooks(listen)
+            except Exception:
+                log.exception("[wakeup] S0 voice gate hooks failed — continuing without them")
+        except Exception:
+            log.exception("[wakeup] AikoListen construction failed — Aiko will run without voice input.")
+
+        if listen is not None:
+            try:
+                _boot_step('listen_asr', lambda: listen.load_asr())
+                _boot_step('listen_silero', lambda: listen.load_vad())
+                _boot_step('listen_warmup', lambda: listen.join_warmup())
+                _boot_step('listen_ready', lambda: listen.start_barge_in_monitor())
+            except Exception:
+                log.exception("[wakeup] ASR/VAD boot failed — Aiko will run without voice input.")
+                listen = None
+
+        return BootResult(
+            think    = think_ref,
+            memorize = memorize,
+            speak    = speak,
+            listen   = listen,
         )


### PR DESCRIPTION
## S1 — reduce clipped onsets

`PRE_SPEECH_BUFS`: **10 → 22** (~320ms → ~**700ms** at 512-sample / 16kHz frames).

Helps "Hey Aiko" / soft starts that were cut by late energy-VAD onset.

## Depends on
Prefer merge **#66 (S0)** first — this branch is based on S0 tip. If you merge S0 into `dev` first, rebase this PR if GitHub shows conflicts (should be none on `vad.js` alone after S0 lands).

## Risk
Low — single constant. Slightly more audio on speech start (still only when gated speech begins).

## Merge
Safe to merge soon after S0 once hard-refresh WebUI (cache `vad.js`).
