### PR TITLE
feat(asr): S2 post-ASR name corrections (no finetune)

### DIFF
--- a/config/sensory.yaml
+++ b/config/sensory.yaml
@@ -9,6 +9,11 @@ ASR_LANGUAGE: "auto"  # Transcription language; options: auto, en, ja, zh, ko, y
 ASR_NUM_THREADS: "4"  # CPU inference threads for ASR.
 ASR_MODEL: "csukuangfj/sherpa-onnx-sense-voice-zh-en-ja-ko-yue-2024-07-17"  # sherpa-onnx SenseVoice model id/path; first run may download files.
 
+# -- Post-ASR name / phrase fixes (S2, no finetune) --
+# Pipe-separated "heard->fixed" pairs. Applied after SenseVoice (longest match first).
+# Built-in defaults already cover Aiko / OppaAI mangling; extend here as you observe errors.
+ASR_CORRECTIONS: ""  # e.g. "op ai->OppaAI|hey iko->hey Aiko|my project x->Project X"
+
 # -- Voice activity detection --
 LISTEN_VAD_SILENCE_MS: "300"  # Silence duration before ending an utterance, in milliseconds.
 LISTEN_VAD_PAD_MS: "100"  # Audio padding around detected speech, in milliseconds.
@@ -41,7 +46,8 @@ BARGE_IN_ALWAYS_ON: "0"  # Also monitor outside TTS wait; options: 1/0, true/fal
 # English word). Blank disables wake-word gating entirely — Aiko responds
 # to every utterance as before.
 WAKE_WORD: ""  # Phrase that wakes Aiko from idle, e.g. "hey aiko". "" disables.
-WAKE_WORD_ALIASES: ""  # "|"-separated extra candidate phrases for observed ASR mishearings, e.g. "hey iko|hey eco|hey ecko".
+# Suggested aliases when WAKE_WORD is set (SenseVoice often mangles "Aiko"):
+WAKE_WORD_ALIASES: "hey iko|hey eco|hey ecko|hey echo|hey ico|hey aico|hi aiko|hi iko"
 WAKE_FUZZY_THRESHOLD: "70"  # Fuzzy match score (0-100) required to count as a wake-word hit.
 
 # -- Trigger phrase --

--- a/sensory/asr_correct.py
+++ b/sensory/asr_correct.py
@@ -1,0 +1,103 @@
+"""
+sensory/asr_correct.py
+
+S2: lightweight post-ASR text fixes for names / common SenseVoice mangling.
+No model finetune — ordered phrase replacements (longest first).
+
+Configure via ASR_CORRECTIONS env/yaml:
+  "op ai->OppaAI|oppa ai->OppaAI|hey iko->hey Aiko|..."
+
+Built-in defaults cover Aiko / OppaAI; user map is applied on top (wins on same key).
+"""
+from __future__ import annotations
+
+import os
+import re
+from functools import lru_cache
+
+# phrase (lowercase) -> replacement (display form)
+_DEFAULT_PAIRS: tuple[tuple[str, str], ...] = (
+    ("hey aiko", "hey Aiko"),
+    ("hey iko", "hey Aiko"),
+    ("hey eco", "hey Aiko"),
+    ("hey ecko", "hey Aiko"),
+    ("hey echo", "hey Aiko"),
+    ("hey ico", "hey Aiko"),
+    ("hey aico", "hey Aiko"),
+    ("hi aiko", "hi Aiko"),
+    ("hi iko", "hi Aiko"),
+    ("aiko", "Aiko"),
+    ("oppaai", "OppaAI"),
+    ("oppa ai", "OppaAI"),
+    ("op ai", "OppaAI"),
+    ("oppa a i", "OppaAI"),
+    ("opper ai", "OppaAI"),
+    ("opa ai", "OppaAI"),
+)
+
+
+def _parse_user_map(raw: str) -> list[tuple[str, str]]:
+    out: list[tuple[str, str]] = []
+    for part in (raw or "").split("|"):
+        part = part.strip()
+        if not part or "->" not in part:
+            continue
+        src, dst = part.split("->", 1)
+        src, dst = src.strip(), dst.strip()
+        if src and dst:
+            out.append((src.lower(), dst))
+    return out
+
+
+@lru_cache(maxsize=4)
+def _pairs_cached(user_raw: str) -> tuple[tuple[str, str], ...]:
+    user = _parse_user_map(user_raw)
+    # User entries first so they override defaults when sources collide
+    seen: set[str] = set()
+    merged: list[tuple[str, str]] = []
+    for src, dst in list(user) + list(_DEFAULT_PAIRS):
+        key = src.casefold()
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append((src, dst))
+    # Longest source first so "hey aiko" wins over "aiko"
+    merged.sort(key=lambda p: len(p[0]), reverse=True)
+    return tuple(merged)
+
+
+def correction_pairs() -> tuple[tuple[str, str], ...]:
+    return _pairs_cached(os.getenv("ASR_CORRECTIONS", "").strip())
+
+
+def correct_asr_text(text: str) -> str:
+    """Apply name/phrase corrections; preserves non-matched regions."""
+    if not text or not text.strip():
+        return text
+    out = text
+    for src, dst in correction_pairs():
+        # Word-boundary-ish match, case-insensitive
+        pattern = re.compile(rf"(?i)(?<!\w){re.escape(src)}(?!\w)")
+        out = pattern.sub(dst, out)
+    return out
+
+
+def install_asr_correct_hooks() -> None:
+    """Wrap AikoListen._transcribe to run correct_asr_text (idempotent)."""
+    from sensory import listen as mod
+
+    cls = mod.AikoListen
+    if getattr(cls, "_s2_asr_correct_installed", False):
+        return
+
+    orig = cls._transcribe
+
+    def _transcribe(self, audio):
+        text = orig(self, audio)
+        try:
+            return correct_asr_text(text)
+        except Exception:
+            return text
+
+    cls._transcribe = _transcribe
+    cls._s2_asr_correct_installed = True

--- a/sensory/voice_gates.py
+++ b/sensory/voice_gates.py
@@ -1,4 +1,4 @@
-"""Shared ASR/voice gate flags + S0 hooks for AikoListen (S0)."""
+"""Shared ASR/voice gate flags + S0/S2 hooks for AikoListen."""
 from __future__ import annotations
 
 import os
@@ -41,7 +41,7 @@ def speaker_verify_gate() -> bool:
 
 
 def install_listen_s0_hooks(listen: Any = None) -> None:
-    """Patch AikoListen barge + speaker-gate behavior (idempotent)."""
+    """Patch AikoListen barge + speaker-gate + S2 ASR correct (idempotent)."""
     global _HOOKS_INSTALLED
     if _HOOKS_INSTALLED:
         return
@@ -72,7 +72,6 @@ def install_listen_s0_hooks(listen: Any = None) -> None:
         chunk_source=None,
         vad_presegmented: bool = False,
     ):
-        # When barge disabled, do not wait on barge event during TTS — just wait for playback.
         if speak is not None and speak.is_playing() and not barge_in_enabled():
             if status_callback:
                 try:
@@ -81,7 +80,7 @@ def install_listen_s0_hooks(listen: Any = None) -> None:
                     pass
             while speak.is_playing():
                 time.sleep(0.05)
-            speak = None  # skip wait_or_barge_in path inside original
+            speak = None
 
         text, info = _orig_listen(
             self,
@@ -104,24 +103,26 @@ def install_listen_s0_hooks(listen: Any = None) -> None:
 
     cls.listen = listen_wrapped
 
-    # Barge monitor loop: skip work when master switch off
     _orig_loop = cls._barge_in_loop
 
     def _barge_in_loop(self) -> None:
         if not barge_in_enabled() and not barge_in_always_on():
-            # Still run loop structure but never set event when disabled —
-            # cheapest: sleep until stopped.
             while getattr(self, "_barge_in_active", False):
                 time.sleep(0.5)
             return
-        # Patch module-level ALWAYS_ON check by temporarily wrapping armed logic
-        # inside original: when not barge_in_enabled(), clear armed so loop idles.
         _orig_loop(self)
 
     cls._barge_in_loop = _barge_in_loop
 
+    # S2: post-ASR name/phrase corrections
+    try:
+        from sensory.asr_correct import install_asr_correct_hooks
+        install_asr_correct_hooks()
+    except Exception:
+        _log().exception("S2 ASR correct hooks failed")
+
     _HOOKS_INSTALLED = True
-    _log().info("ASR S0 hooks installed (BARGE_IN_ENABLED / SPEAKER_VERIFY_GATE)")
+    _log().info("ASR S0/S2 hooks installed (barge / speaker gate / asr_correct)")
 
     if listen is not None:
-        pass  # instance methods resolved from class
+        pass


### PR DESCRIPTION
## S2 — names without finetune

### What
- `sensory/asr_correct.py` — ordered phrase map after SenseVoice (`op ai`→`OppaAI`, `hey iko`→`hey Aiko`, …)
- Wired via existing `install_listen_s0_hooks` (same boot path as S0)
- `ASR_CORRECTIONS` in `config/sensory.yaml` for your own `heard->fixed|...` pairs
- Default `WAKE_WORD_ALIASES` for common Aiko mishears (only used when `WAKE_WORD` is set)

### Merge?
**Yes, safe to merge soon** — pure post-processing, no model change. Defaults are conservative (only known name confusions).

Add pairs as you observe errors:
```yaml
ASR_CORRECTIONS: "my niche term->My Niche Term"
```
