### PR TITLE
docs(asr): S4 dual-VAD policy — energy + server Silero

### DIFF
--- a/docs/DEBUG_AUDIO.md
+++ b/docs/DEBUG_AUDIO.md
@@ -5,6 +5,19 @@ exactly which file to open and what to add/check.
 
 ---
 
+## Dual VAD policy (S4)
+
+**Canonical setup:** browser **energy** gate + server **Silero** authority.
+Do **not** run Silero in the browser on top of server Silero, and do **not**
+unload Jetson Silero to save RAM. Full write-up: [`sensory/VAD_POLICY.md`](../sensory/VAD_POLICY.md).
+
+| Path | Client | Server |
+|------|--------|--------|
+| WebUI | Energy (`vad.js`) filters uplink | Silero decides speech |
+| Local `parec` | — | Silero only |
+
+---
+
 ## Step 0 — Environment & connectivity sanity
 
 **Files:** none yet — just DevTools
@@ -135,6 +148,10 @@ console.log('[mic] streaming enabled, gate=', browserVadGate);
 - [ ] Console/UI shows `vad ready` (Silero loaded), not `vad fallback`.
 - ❌ Fallback unexpectedly → re-check Step 3 (missing ORT/onnx assets).
 
+**Note (S4):** Server Silero is still the authority even when the browser
+falls back to energy-only gating. Client Silero assets are optional polish;
+the canonical Web path is **energy filter + server Silero**.
+
 ---
 
 ## Step 7 — VAD is actually detecting your speech
@@ -158,7 +175,7 @@ console.log('[vad] rms=', rms, '_speaking=', _speaking);
 ```
 
 - [ ] Value clearly crosses `VAD_THRESHOLD = 0.5` (Silero) or
-      `ENERGY_START_RMS = 0.018` (fallback) when you talk.
+      `ENERGY_START_RMS` (fallback / current energy path) when you talk.
 - ❌ Never crosses → mic gain too low. Try setting `autoGainControl: false`
   in **`webui.js`** → `startMic()`:
   ```js

--- a/sensory/VAD_POLICY.md
+++ b/sensory/VAD_POLICY.md
@@ -1,0 +1,48 @@
+# S4 — Dual VAD policy
+
+Locked architecture for Aiko voice input. **No code change required** — this documents what S0–S3 already implement.
+
+## Authority split
+
+| Mode | Client | Server (Jetson) |
+|------|--------|------------------|
+| **WebUI** | Energy gate in `vad.js` (filter uplink) | **Silero** = authority on every chunk |
+| **Local robot (`parec`)** | — | **Silero** only |
+
+**Rule:** browser decides *worth sending*; Jetson Silero decides *speech vs silence* for ASR.
+
+## Keep energy + Silero (not double Silero)
+
+| Choice | Status |
+|--------|--------|
+| Client **energy** + server **Silero** | **Canonical** — current setup |
+| Client Silero + server Silero | **Not adopted** — extra ONNX/ORT in the browser for little gain |
+| Client-only VAD (no server Silero) | **Rejected** — phones/tabs/throttle produce bad transcripts |
+| Unload server Silero “to save RAM” | **Rejected** — Silero is tiny; SenseVoice is the real cost |
+
+If browser energy is noisy on a bad device, tune `ENERGY_START_RMS` / min frames first. Only revisit client Silero as an experiment; never remove server Silero.
+
+## Why dual (energy + Silero)
+
+1. **Uplink filter** — energy drops silence frames so the Jetson is not flooded.
+2. **Server authority** — Silero is consistent across devices; browser energy is not.
+3. **Barge-in** — local Silero monitor (when `BARGE_IN_ENABLED=1`) uses the same family of thresholds as listen VAD, independent of the browser gate.
+
+## Related knobs
+
+See `config/sensory.yaml` and `docs/DEBUG_AUDIO.md`.
+
+| Area | Keys / files |
+|------|----------------|
+| Server VAD | `LISTEN_VAD_*`, `LISTEN_SILENCE_CHUNKS`, … |
+| Browser gate | `interface/webui/static/vad.js` (`ENERGY_*`, `PRE_SPEECH_BUFS`) |
+| Barge | `BARGE_IN_ENABLED`, `BARGE_IN_ECHO_GUARD_MS`, … |
+| Web gate flag | `WEBUI_BROWSER_VAD_GATE` in `webui.py` |
+
+## S0–S5 map
+
+| Phase | Role |
+|-------|------|
+| S0–S3 | Barge, pre-roll, name correct, echo guard — **done** |
+| **S4** | This policy (docs only) |
+| S5 | Optional metrics / Opus / streaming / local AEC |


### PR DESCRIPTION
## S4 — Dual VAD policy (docs only)

Locks the architecture you already run. **No runtime change.**

### Policy

| Mode | Client | Server |
|------|--------|--------|
| **WebUI** | Energy gate (`vad.js`) filters uplink | **Silero** = authority |
| **Local `parec`** | — | Silero only |

**Canonical:** energy + server Silero.  
**Not adopted:** double Silero (browser ONNX + server).  
**Rejected:** unload Jetson Silero “to save RAM.”

### Files
- `sensory/VAD_POLICY.md` — full write-up
- `docs/DEBUG_AUDIO.md` — short S4 pointer at the top

### Merge?
Yes anytime — documentation only. Core voice track is **S0–S4** complete after this; **S5** remains optional (metrics / Opus / streaming / local AEC).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on the dual voice-activity detection policy, including browser-side audio filtering and server-side speech authority.
  * Documented fallback behavior, barge-in handling, configuration references, and implementation phases.
  * Updated audio debugging steps and clarified that server-side speech detection remains authoritative during browser fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->