### PR TITLE
docs(asr): S4 CodeRabbit follow-up — energy-only client, received chunks, ALWAYS_ON

### DIFF
--- a/docs/DEBUG_AUDIO.md
+++ b/docs/DEBUG_AUDIO.md
@@ -8,12 +8,12 @@ exactly which file to open and what to add/check.
 ## Dual VAD policy (S4)
 
 **Canonical setup:** browser **energy** gate + server **Silero** authority.
-Do **not** run Silero in the browser on top of server Silero, and do **not**
+Browser Silero is **intentionally absent** (`vad.js` is energy-only). Do **not**
 unload Jetson Silero to save RAM. Full write-up: [`sensory/VAD_POLICY.md`](../sensory/VAD_POLICY.md).
 
 | Path | Client | Server |
 |------|--------|--------|
-| WebUI | Energy (`vad.js`) filters uplink | Silero decides speech |
+| WebUI | Energy (`vad.js`) filters uplink | Silero scores every **received** chunk |
 | Local `parec` | — | Silero only |
 
 ---
@@ -64,25 +64,19 @@ if (!window.isSecureContext || !navigator.mediaDevices?.getUserMedia) {
 
 ---
 
-## Step 3 — Static asset routing (worklet + VAD files reachable)
+## Step 3 — Static asset routing (worklet reachable)
 
 **File:** `webui.js` — `startMic()`:
 ```js
 await micContext.audioWorklet.addModule('./pcm-worklet.js');
 ```
-**File:** `webui.js` — `loadOptionalOrt()`:
-```js
-const required = [
-  './ort.min.js', './silero_vad.onnx',
-  './ort-wasm-simd-threaded.jsep.mjs', './ort-wasm-simd-threaded.jsep.wasm',
-];
-```
 
-- [ ] DevTools → Network tab → filter each filename above → all `200 OK`.
+- [ ] DevTools → Network tab → `pcm-worklet.js` → `200 OK`.
 - ❌ 404 on `pcm-worklet.js` → tunnel/proxy isn't routing static paths correctly
   (check whatever fronts `webui.py`'s HTTP server, e.g. Cloudflare Tunnel/DuckDNS config).
-- ❌ 404 on any ORT/onnx file → files missing from `interface/webui/static/` on the
-  Jetson — copy them there.
+
+(Legacy ORT / `silero_vad.onnx` browser assets are **not** part of the canonical
+S4 path — browser VAD is energy-only in `vad.js`.)
 
 ---
 
@@ -141,31 +135,23 @@ console.log('[mic] streaming enabled, gate=', browserVadGate);
 
 ---
 
-## Step 6 — VAD model loaded (Silero vs. fallback)
+## Step 6 — Browser energy VAD ready
 
-**File:** `webui.js` — `loadOptionalOrt().then(() => initVAD())...` block near top
+**File:** `vad.js` — `initVAD()` returns `{ mode: 'energy', ready: true }`
 
-- [ ] Console/UI shows `vad ready` (Silero loaded), not `vad fallback`.
-- ❌ Fallback unexpectedly → re-check Step 3 (missing ORT/onnx assets).
+- [ ] Console/UI shows energy VAD ready (browser path is **energy-only** by design).
+- [ ] Server-side Silero remains the authority for speech/silence on every
+      **received** chunk — independent of the browser gate.
 
-**Note (S4):** Server Silero is still the authority even when the browser
-falls back to energy-only gating. Client Silero assets are optional polish;
-the canonical Web path is **energy filter + server Silero**.
+**Note (S4):** Client/browser Silero is **intentionally absent**. The canonical
+Web path is **energy filter + server Silero**. Do not expect “Silero loaded” in
+the browser.
 
 ---
 
-## Step 7 — VAD is actually detecting your speech
+## Step 7 — Energy VAD is detecting your speech
 
-**File:** `vad.js` — inside `processVADFrame` (Silero path), right after:
-```js
-const prob = out.output.data[0];
-```
-add:
-```js
-console.log('[vad] prob=', prob, '_speaking=', _speaking);
-```
-
-**File:** `vad.js` — inside `processEnergyVADFrame` (fallback path), right after:
+**File:** `vad.js` — inside `processEnergyVADFrame`, right after:
 ```js
 const rms = _rms(frame);
 ```
@@ -174,8 +160,7 @@ add:
 console.log('[vad] rms=', rms, '_speaking=', _speaking);
 ```
 
-- [ ] Value clearly crosses `VAD_THRESHOLD = 0.5` (Silero) or
-      `ENERGY_START_RMS` (fallback / current energy path) when you talk.
+- [ ] Value clearly crosses `ENERGY_START_RMS` / dynamic start threshold when you talk.
 - ❌ Never crosses → mic gain too low. Try setting `autoGainControl: false`
   in **`webui.js`** → `startMic()`:
   ```js

--- a/sensory/VAD_POLICY.md
+++ b/sensory/VAD_POLICY.md
@@ -6,27 +6,27 @@ Locked architecture for Aiko voice input. **No code change required** — this d
 
 | Mode | Client | Server (Jetson) |
 |------|--------|------------------|
-| **WebUI** | Energy gate in `vad.js` (filter uplink) | **Silero** = authority on every chunk |
+| **WebUI** | Energy gate in `vad.js` (filter uplink) | **Silero** = authority on every **received** chunk |
 | **Local robot (`parec`)** | — | **Silero** only |
 
-**Rule:** browser decides *worth sending*; Jetson Silero decides *speech vs silence* for ASR.
+**Rule:** browser decides *worth sending*; Jetson Silero decides *speech vs silence* for audio that actually arrives (frames dropped by the energy gate are never scored).
 
 ## Keep energy + Silero (not double Silero)
 
 | Choice | Status |
 |--------|--------|
-| Client **energy** + server **Silero** | **Canonical** — current setup |
-| Client Silero + server Silero | **Not adopted** — extra ONNX/ORT in the browser for little gain |
+| Client **energy** + server **Silero** | **Canonical** — current setup (`vad.js` is energy-gate only) |
+| Client Silero + server Silero | **Not adopted / not supported** — no browser Silero path |
 | Client-only VAD (no server Silero) | **Rejected** — phones/tabs/throttle produce bad transcripts |
 | Unload server Silero “to save RAM” | **Rejected** — Silero is tiny; SenseVoice is the real cost |
 
-If browser energy is noisy on a bad device, tune `ENERGY_START_RMS` / min frames first. Only revisit client Silero as an experiment; never remove server Silero.
+If browser energy is noisy on a bad device, tune `ENERGY_START_RMS` / min frames first. Do **not** add client Silero; never remove server Silero.
 
 ## Why dual (energy + Silero)
 
 1. **Uplink filter** — energy drops silence frames so the Jetson is not flooded.
 2. **Server authority** — Silero is consistent across devices; browser energy is not.
-3. **Barge-in** — local Silero monitor (when `BARGE_IN_ENABLED=1`) uses the same family of thresholds as listen VAD, independent of the browser gate.
+3. **Barge-in** — local Silero monitor (when `BARGE_IN_ENABLED=1`) uses the same family of thresholds as listen VAD, independent of the browser gate. Outside TTS wait, that monitor runs only when **`BARGE_IN_ALWAYS_ON=1`** as well; with `ALWAYS_ON=0` it runs only while TTS wait is armed.
 
 ## Related knobs
 
@@ -35,8 +35,8 @@ See `config/sensory.yaml` and `docs/DEBUG_AUDIO.md`.
 | Area | Keys / files |
 |------|----------------|
 | Server VAD | `LISTEN_VAD_*`, `LISTEN_SILENCE_CHUNKS`, … |
-| Browser gate | `interface/webui/static/vad.js` (`ENERGY_*`, `PRE_SPEECH_BUFS`) |
-| Barge | `BARGE_IN_ENABLED`, `BARGE_IN_ECHO_GUARD_MS`, … |
+| Browser gate | `interface/webui/static/vad.js` (`ENERGY_*`, `PRE_SPEECH_BUFS`) — energy only |
+| Barge | `BARGE_IN_ENABLED`, `BARGE_IN_ALWAYS_ON`, `BARGE_IN_ECHO_GUARD_MS`, … |
 | Web gate flag | `WEBUI_BROWSER_VAD_GATE` in `webui.py` |
 
 ## S0–S5 map


### PR DESCRIPTION
## Follow-up to #70 (CodeRabbit)

All three findings verified against code (`vad.js` energy-only; `voice_gates.barge_in_always_on()` requires both flags).

| Finding | Fix |
|---------|-----|
| Client Silero implied as optional polish | Browser Silero **intentionally absent**; Step 6 rewritten for energy-only |
| “every chunk” vs filtered uplink | **every received chunk** |
| Barge monitor outside TTS | Requires `BARGE_IN_ENABLED=1` **and** `BARGE_IN_ALWAYS_ON=1` |

Docs only — safe to merge.
