### PR TITLE
feat(memory): Phase 4 turn-level valence_tag + salience_hit

### DIFF
--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -102,6 +102,14 @@ MEMORY_RANK_ENTITY_IMPORTANCE_WEIGHT: "0.008"  # Flat recall score boost × max 
 MEMORY_SUPERSESSION_CHAIN_EXPAND: "1"  # Expand supersedes_id lineage on reflective / identity-plan hits.
 MEMORY_SUPERSESSION_CHAIN_KINDS: "identity,preference,plan"  # Kinds that always expand chain when hit.
 
+# -- Phase 4: turn-level valence + salience tags --
+MONTHLY_CONSOLIDATION_W_VALENCE: "0.10"  # Weight for |emotional intensity|. Neuroscience: high-valence ↔ fast consolidation.
+# Rebalance of Phase 1 weights when valence is present (should sum ~1.0 with W_VALENCE):
+MONTHLY_CONSOLIDATION_W_SALIENCE: "0.25"  # User-tagged importance or story-weight (e.g. "first piano recital").
+MONTHLY_CONSOLIDATION_W_NOVELTY: "0.22"  # Semantic distance from existing memories. Surprise/contradiction factor.
+MONTHLY_CONSOLIDATION_W_SPACING: "0.18"  # Time gaps between repeated retrievals. Spaced-rep principle.
+MONTHLY_CONSOLIDATION_W_CONNECTIVITY: "0.25"  # In-graph degree. Well-connected memories survive consolidation.
+
 # -- Decay and dream merge --
 FORGET_HALF_LIFE_DAYS: "21"  # Days until memory retention score halves.
 FORGET_ACCESS_COUNT_CAP: "255"  # Maximum access_count retained for decay scoring.

--- a/memory/consolidate.py
+++ b/memory/consolidate.py
@@ -28,6 +28,9 @@ Retention gate (Phase 1):
 
   Phase 3 entity importance: connectivity term blends co-mention edge weight
   with I_e = (1-α)·centrality + α·recency from entity_relations + last touch.
+
+  Phase 4 turn tags: valence_tag (pos/neg/neutral) and salience_hit preferred
+  over text re-scan when present; small valence intensity term in R.
   
 Called by ScheduleRunner.monthly_consolidate — not user-modifiable via schedule.json.
 """
@@ -63,10 +66,11 @@ CONSOLIDATION_MAX_MONTH        = max(CONSOLIDATION_MIN_MONTH, int(os.getenv("MON
 CONSOLIDATION_SOFT_THRESHOLD   = float(os.getenv("MONTHLY_CONSOLIDATION_SOFT_THRESHOLD", "0.4"))
 CONSOLIDATION_ANCHOR_LOOKBACK  = max(2, int(os.getenv("MONTHLY_CONSOLIDATION_ANCHOR_LOOKBACK", "50")))
 CONSOLIDATION_ANCHOR_K         = max(1, int(os.getenv("MONTHLY_CONSOLIDATION_ANCHOR_K", "5")))
-_RETENTION_W_SALIENCE     = float(os.getenv("MONTHLY_CONSOLIDATION_W_SALIENCE", "0.30"))
-_RETENTION_W_NOVELTY      = float(os.getenv("MONTHLY_CONSOLIDATION_W_NOVELTY", "0.25"))
-_RETENTION_W_SPACING      = float(os.getenv("MONTHLY_CONSOLIDATION_W_SPACING", "0.20"))
+_RETENTION_W_SALIENCE     = float(os.getenv("MONTHLY_CONSOLIDATION_W_SALIENCE", "0.25"))
+_RETENTION_W_NOVELTY      = float(os.getenv("MONTHLY_CONSOLIDATION_W_NOVELTY", "0.22"))
+_RETENTION_W_SPACING      = float(os.getenv("MONTHLY_CONSOLIDATION_W_SPACING", "0.18"))
 _RETENTION_W_CONNECTIVITY = float(os.getenv("MONTHLY_CONSOLIDATION_W_CONNECTIVITY", "0.25"))
+_RETENTION_W_VALENCE      = float(os.getenv("MONTHLY_CONSOLIDATION_W_VALENCE", "0.10"))
 _RETENTION_SPACING_SATURATION = max(1, int(os.getenv("MONTHLY_CONSOLIDATION_SPACING_SATURATION", "5")))
 
 def consolidation_state_path(user_id: str | None = None) -> Path:
@@ -253,8 +257,25 @@ def _score_daily_row(
     text = row.get("_text", "") or ""
     entities = entities_from_json(row.get("entities"))
 
-    salience = 1.0 if _SALIENCE_HIT_RE.search(text) else 0.3
+    # Phase 4: prefer stored turn tags; fall back to text scan for legacy rows.
+    stored_hit = row.get("salience_hit")
+    if stored_hit is not None and str(stored_hit) != "":
+        salience = 1.0 if int(stored_hit) else 0.3
+    else:
+        salience = 1.0 if _SALIENCE_HIT_RE.search(text) else 0.3
 
+    v_raw = (row.get("valence_tag") or "neutral")
+    if isinstance(v_raw, str):
+        v_raw = v_raw.strip().lower()
+    else:
+        v_raw = "neutral"
+    # Intensity for retention (neg slightly stronger — Phase 5 will use for decay).
+    if v_raw == "neg":
+        valence = 0.85
+    elif v_raw == "pos":
+        valence = 0.65
+    else:
+        valence = 0.25
     # Phase 2: distinct recall days (access_day_count). Fallback for pre-Phase-2 rows.
     day_count = int(row.get("access_day_count") or 0)
     if day_count <= 0:
@@ -287,6 +308,7 @@ def _score_daily_row(
         + _RETENTION_W_NOVELTY * novelty
         + _RETENTION_W_SPACING * spacing
         + _RETENTION_W_CONNECTIVITY * connectivity
+        + _RETENTION_W_VALENCE * valence
     )
 
 

--- a/memory/consolidate.py
+++ b/memory/consolidate.py
@@ -51,7 +51,7 @@ from system import bioclock
 from system.log import get_logger
 from system.userspace import current_display_name, current_user_id, user_state_path
 from memory.reflect import _extract_json_arrays, _salvage_truncated_facts
-from memory.memorize import classify_kind, entities_from_json
+from memory.memorize import classify_kind, entities_from_json, SALIENCE_POLICY_RE
 
 log = get_logger(__name__)
 
@@ -235,16 +235,6 @@ def _build_static_anchors(memorize, user_id: str) -> "np.ndarray | None":
     return np.mean(vectors, axis=0, keepdims=True)
 
 
-_SALIENCE_HIT_RE = re.compile(
-    r"\b(?:" + "|".join(re.escape(k.strip()) for k in (
-        "deadline", "birthday", "anniversary", "appointment", "hackathon",
-        "interview", "lost", "passport", "license", "wallet", "important",
-        "breakthrough", "problem", "always", "never", "favorite", "favourite",
-    )) + r")\b",
-    re.IGNORECASE,
-)
-
-
 def _score_daily_row(
     row: dict,
     *,
@@ -262,7 +252,7 @@ def _score_daily_row(
     if stored_hit is not None and str(stored_hit) != "":
         salience = 1.0 if int(stored_hit) else 0.3
     else:
-        salience = 1.0 if _SALIENCE_HIT_RE.search(text) else 0.3
+        salience = 1.0 if SALIENCE_POLICY_RE.search(text) else 0.3
 
     v_raw = (row.get("valence_tag") or "neutral")
     if isinstance(v_raw, str):

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -1503,6 +1503,17 @@ class _MemoryBackend:
                             )
                             log.info("Superseded memory %s with new fact", supersedes_id)
                     mem_id = str(uuid.uuid4())
+                  
+                    # Phase 4: tag from fact text (and soft signal from last assistant msg).
+                    assist_blob = " ".join(
+                        (m.get("content") or "")
+                        for m in messages
+                        if m.get("role") == "assistant"
+                    )[-400:]
+                    tag_src = f"{fact}\n{assist_blob}"
+                    v_tag = infer_valence_tag(tag_src)
+                    s_hit = max(infer_salience_hit(fact), infer_salience_hit(assist_blob))
+                  
                     self._insert_row(
                         mem_id=mem_id,
                         user_id=user_id,

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -690,6 +690,7 @@ def infer_valence_tag(text: str) -> str:
 
 def infer_salience_hit(text: str) -> int:
     return 1 if _TURN_SALIENCE_RE.search(text or "") else 0
+  
 def entity_overlap_score(query: str, entities: Iterable[str]) -> float:
     """Return 0..1 fraction of entities mentioned in the query (casefold)."""
     ents = [e for e in entities if e]
@@ -1523,6 +1524,8 @@ class _MemoryBackend:
                         pinned=0,
                         source=SOURCE_CHAT,
                         supersedes_id=supersedes_id,
+                        valence_tag=v_tag,
+                        salience_hit=s_hit,
                     )
                     ids.append(mem_id)
                 self._conn.commit()

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -1506,10 +1506,13 @@ class _MemoryBackend:
                     mem_id = str(uuid.uuid4())
                   
                     # Phase 4: tag from fact text (and soft signal from last assistant msg).
-                    assist_blob = " ".join(
-                        (m.get("content") or "")
-                        for m in messages
-                        if m.get("role") == "assistant"
+                    assist_blob = next(
+                        (
+                            (m.get("content") or "")
+                            for m in reversed(messages)
+                            if m.get("role") == "assistant"
+                        ),
+                        "",
                     )[-400:]
                     tag_src = f"{fact}\n{assist_blob}"
                     v_tag = infer_valence_tag(tag_src)

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -666,13 +666,13 @@ _VALENCE_NEG_RE = re.compile(
     r"\b(?:sad|angry|frustrated|afraid|scared|hate|awful|terrible|worried|anxious|cry|pain)\b",
     re.IGNORECASE,
 )
-_TURN_SALIENCE_RE = re.compile(
+# Shared salience policy (write-time tags + monthly legacy fallback).
+SALIENCE_POLICY_RE = re.compile(
     r"\b(?:deadline|birthday|anniversary|appointment|hackathon|interview|lost|"
-    r"passport|license|wallet|important|breakthrough|always|never|favorite|favourite|"
-    r"remember this|never forget)\b|[!！]{2,}",
+    r"passport|license|wallet|important|breakthrough|problem|always|never|"
+    r"favorite|favourite|remember this|never forget)\b|!{2,}",
     re.IGNORECASE,
 )
-
 
 def infer_valence_tag(text: str) -> str:
     """Cheap pos/neg/neutral from emoji + lexicon. No LLM."""
@@ -689,7 +689,7 @@ def infer_valence_tag(text: str) -> str:
 
 
 def infer_salience_hit(text: str) -> int:
-    return 1 if _TURN_SALIENCE_RE.search(text or "") else 0
+    return 1 if SALIENCE_POLICY_RE.search(text or "") else 0
   
 def entity_overlap_score(query: str, entities: Iterable[str]) -> float:
     """Return 0..1 fraction of entities mentioned in the query (casefold)."""

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -552,6 +552,9 @@ _PHASE_A_COLUMNS: tuple[tuple[str, str], ...] = (
     ("entities", "TEXT NOT NULL DEFAULT '[]'"),
   # Phase 2 spacing: distinct local calendar days this memory was recalled.
     ("access_day_count", "INTEGER NOT NULL DEFAULT 0"),
+  # Phase 4: turn-level emotion / salience tags (cheap, no LLM).
+    ("valence_tag", "TEXT NOT NULL DEFAULT 'neutral'"),
+    ("salience_hit", "INTEGER NOT NULL DEFAULT 0"),
 )
 
 # L2 scene blocks — one additive runtime column on memories. A scene row
@@ -653,6 +656,40 @@ def classify_kind(text: str, default: str = "fact") -> str:
     return default
 
 
+_VALENCE_POS_RE = re.compile(
+    r"[\U0001F600-\U0001F64F\U0001F970-\U0001F973\U0001F929\U0001F60A\U0001F60D\U0001F389]|"
+    r"\b(?:happy|glad|love|great|awesome|excited|relief|yay|wonderful|proud)\b",
+    re.IGNORECASE,
+)
+_VALENCE_NEG_RE = re.compile(
+    r"[\U0001F622\U0001F62D\U0001F614\U0001F61E\U0001F620\U0001F621\U0001F624]|"
+    r"\b(?:sad|angry|frustrated|afraid|scared|hate|awful|terrible|worried|anxious|cry|pain)\b",
+    re.IGNORECASE,
+)
+_TURN_SALIENCE_RE = re.compile(
+    r"\b(?:deadline|birthday|anniversary|appointment|hackathon|interview|lost|"
+    r"passport|license|wallet|important|breakthrough|always|never|favorite|favourite|"
+    r"remember this|never forget)\b|[!！]{2,}",
+    re.IGNORECASE,
+)
+
+
+def infer_valence_tag(text: str) -> str:
+    """Cheap pos/neg/neutral from emoji + lexicon. No LLM."""
+    t = text or ""
+    neg = bool(_VALENCE_NEG_RE.search(t))
+    pos = bool(_VALENCE_POS_RE.search(t))
+    if neg and not pos:
+        return "neg"
+    if pos and not neg:
+        return "pos"
+    if neg and pos:
+        return "neg"  # conflict → treat as emotionally loaded neg for retention
+    return "neutral"
+
+
+def infer_salience_hit(text: str) -> int:
+    return 1 if _TURN_SALIENCE_RE.search(text or "") else 0
 def entity_overlap_score(query: str, entities: Iterable[str]) -> float:
     """Return 0..1 fraction of entities mentioned in the query (casefold)."""
     ents = [e for e in entities if e]
@@ -1328,6 +1365,8 @@ class _MemoryBackend:
         kind: str | None = None,
         entities: list[str] | None = None,
         scene_id: str | None = None,
+        valence_tag: str | None = None,
+        salience_hit: int | None = None,
     ) -> None:
         """Insert one memory row (Phase A + L2 columns when present) + its
         vector, and best-effort co-mention edges for the entity graph.
@@ -1341,6 +1380,10 @@ class _MemoryBackend:
         ents_list = entities if entities is not None else extract_entities(text)
         ents_json = entities_to_json(ents_list)
 
+        v_tag = valence_tag if valence_tag in ("pos", "neg", "neutral") else infer_valence_tag(text)
+        s_hit = int(salience_hit) if salience_hit is not None else infer_salience_hit(text)
+        s_hit = 1 if s_hit else 0
+      
         base_cols = ["id", "user_id", "memory", "created_at", "access_count", "last_accessed_at", "pinned"]
         base_vals: list[Any] = [mem_id, user_id, text, now, 0, "never", pinned]
         ext_cols: list[str] = []
@@ -1351,6 +1394,12 @@ class _MemoryBackend:
         if "scene_id" in cols:
             ext_cols.append("scene_id")
             ext_vals.append(scene_id)
+        if "valence_tag" in cols:
+            ext_cols.append("valence_tag")
+            ext_vals.append(v_tag)
+        if "salience_hit" in cols:
+            ext_cols.append("salience_hit")
+            ext_vals.append(s_hit)
         all_cols = base_cols + ext_cols
         placeholders = ", ".join("?" * len(all_cols))
         self._conn.execute(


### PR DESCRIPTION
Added phase 4 parameters for memory consolidation ## Summary
Phase 4 — cheap turn-level tags at encode time (no LLM, no decay change):

- `valence_tag`: `pos` | `neg` | `neutral` (emoji + lexicon on fact / assistant text)
- `salience_hit`: 0/1 (keyword hit at write)
- Monthly retention prefers stored tags; small valence term in R

## Out of scope (Phase 5+)
Emotion-modified decay λ, dynamic anchors, journal promote, knowledge merge, studio filters.

## Files
| File | Change |
|------|--------|
| `memory/memorize.py` | Schema columns + tag at `_insert_row` |
| `memory/consolidate.py` | Prefer stored tags in R + valence weight |
| `config/memory.yaml` | Weights / knobs |

## Test plan
- [ ] Boot existing memory.db (additive ALTER only)
- [ ] New facts get valence_tag / salience_hit when keywords/emoji present
- [ ] Old rows default neutral / 0 and still score via text fallback
- [ ] Monthly dry-run still runs retention gatewith valence and salience weights.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added emotion valence and salience metadata to stored memories.
  * Memory retention scoring now considers emotional intensity and salience alongside novelty, spacing, and connectivity.
  * Existing memories remain supported through fallback scoring when metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->