### PR TITLE
feat(memory): Phase 5 emotion-modified decay + dream boost

### DIFF
--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -110,6 +110,13 @@ MONTHLY_CONSOLIDATION_W_NOVELTY: "0.22"  # Semantic distance from existing memor
 MONTHLY_CONSOLIDATION_W_SPACING: "0.18"  # Time gaps between repeated retrievals. Spaced-rep principle.
 MONTHLY_CONSOLIDATION_W_CONNECTIVITY: "0.25"  # In-graph degree. Well-connected memories survive consolidation.
 
+# -- Phase 5: emotion imprint on decay + dream --
+FORGET_EMOTION_GAMMA: "0.5"  # H_eff = H * (1 + gamma * intensity); 0 disables emotion-modified decay.
+FORGET_INTENSITY_NEG: "1.0"  # intensity for valence_tag=neg (sticky imprint).
+FORGET_INTENSITY_POS: "0.4"  # intensity for valence_tag=pos.
+FORGET_INTENSITY_NEUTRAL: "0.0" # treat neutal is emotion or not; 0 means neutral is not emotional.
+DREAM_BOOST_USE_STORED_TAGS: "1"  # Prefer salience_hit / valence_tag over text-only heuristics in dream boost.
+
 # -- Decay and dream merge --
 FORGET_HALF_LIFE_DAYS: "21"  # Days until memory retention score halves.
 FORGET_ACCESS_COUNT_CAP: "255"  # Maximum access_count retained for decay scoring.

--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -114,7 +114,7 @@ MONTHLY_CONSOLIDATION_W_CONNECTIVITY: "0.25"  # In-graph degree. Well-connected 
 FORGET_EMOTION_GAMMA: "0.5"  # H_eff = H * (1 + gamma * intensity); 0 disables emotion-modified decay.
 FORGET_INTENSITY_NEG: "1.0"  # intensity for valence_tag=neg (sticky imprint).
 FORGET_INTENSITY_POS: "0.4"  # intensity for valence_tag=pos.
-FORGET_INTENSITY_NEUTRAL: "0.0" # treat neutal is emotion or not; 0 means neutral is not emotional.
+FORGET_INTENSITY_NEUTRAL: "0.0" # treat neutral is emotion or not; 0 means neutral is not emotional.
 DREAM_BOOST_USE_STORED_TAGS: "1"  # Prefer salience_hit / valence_tag over text-only heuristics in dream boost.
 
 # -- Decay and dream merge --

--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -114,7 +114,7 @@ MONTHLY_CONSOLIDATION_W_CONNECTIVITY: "0.25"  # In-graph degree. Well-connected 
 FORGET_EMOTION_GAMMA: "0.5"  # H_eff = H * (1 + gamma * intensity); 0 disables emotion-modified decay.
 FORGET_INTENSITY_NEG: "1.0"  # intensity for valence_tag=neg (sticky imprint).
 FORGET_INTENSITY_POS: "0.4"  # intensity for valence_tag=pos.
-FORGET_INTENSITY_NEUTRAL: "0.0" # treat neutral is emotion or not; 0 means neutral is not emotional.
+FORGET_INTENSITY_NEUTRAL: "0.0"  # 0 = neutral is not emotional; does not extend effective half-life.
 DREAM_BOOST_USE_STORED_TAGS: "1"  # Prefer salience_hit / valence_tag over text-only heuristics in dream boost.
 
 # -- Decay and dream merge --

--- a/memory/forget.py
+++ b/memory/forget.py
@@ -39,7 +39,13 @@ _INTENSITY = {
 
 def _valence_intensity(valence_tag: str | None) -> float:
     key = (valence_tag or "neutral").strip().lower()
-    return float(_INTENSITY.get(key, 0.0))
+    try:
+        v = float(_INTENSITY.get(key, 0.0))
+    except (TypeError, ValueError):
+        return 0.0
+    if v != v or v in (float("inf"), float("-inf")):  # NaN or ±inf
+        return 0.0
+    return max(0.0, v)
 
 
 # ── scoring ───────────────────────────────────────────────────────────────────

--- a/memory/forget.py
+++ b/memory/forget.py
@@ -3,13 +3,17 @@ memory/forget.py
 Ebbinghaus-style exponential decay scoring for memory lifecycle management.
 
 Core formula (inspired by the forgetting curve):
-    weighted_score = min(access_count, ACCESS_COUNT_CAP) * 0.5^(days_since_last_access / HALF_LIFE_DAYS)
+    weighted_score = min(access_count, ACCESS_COUNT_CAP) * 0.5^(days_since_last_access / H_eff)
+
+Where H_eff = HALF_LIFE_DAYS * (1 + γ * intensity(valence_tag))  (Phase 5).
+Neutral / missing valence keeps H_eff = HALF_LIFE_DAYS.
 
 This mirrors how biological memory consolidation works:
   - Frequently accessed memories persist longer   (reinforced neural pathways)
   - Unused memories naturally decay               (pruned rarely-used connections)
   - New memories get a protection window          (working memory consolidation)
   - Decay is gradual, not abrupt                  (unlike hard TTL which kills instantly)
+  - High emotional intensity (esp. negative) lengthens effective half-life (imprint stickiness)
 
 Called by memorize.py — no I/O, pure math only.
 """
@@ -24,49 +28,60 @@ CLEANUP_THRESHOLD = float(os.getenv("FORGET_CLEANUP_THRESHOLD", "0.02"))
 ACCESS_COUNT_CAP  = int(  os.getenv("FORGET_ACCESS_COUNT_CAP",  "255"))
 GRACE_PERIOD_DAYS = int(  os.getenv("FORGET_GRACE_PERIOD_DAYS", "35"))
 
+# Phase 5: emotion imprint — lengthens effective half-life for high-intensity valence.
+EMOTION_GAMMA = float(os.getenv("FORGET_EMOTION_GAMMA", "0.5"))
+_INTENSITY = {
+    "neg": float(os.getenv("FORGET_INTENSITY_NEG", "1.0")),
+    "pos": float(os.getenv("FORGET_INTENSITY_POS", "0.4")),
+    "neutral": float(os.getenv("FORGET_INTENSITY_NEUTRAL", "0.0")),
+}
+
+
+def _valence_intensity(valence_tag: str | None) -> float:
+    key = (valence_tag or "neutral").strip().lower()
+    return float(_INTENSITY.get(key, 0.0))
+
+
 # ── scoring ───────────────────────────────────────────────────────────────────
 
-def compute_weighted_score(access_count: int, last_accessed_iso: str) -> float:
+def compute_weighted_score(
+    access_count: int,
+    last_accessed_iso: str,
+    valence_tag: str | None = None,
+) -> float:
     """Compute exponential decay score for a memory entry.
 
-    Score = min(access_count, 255) × 0.5^(days_elapsed / HALF_LIFE_DAYS)
+    Score = min(access_count, cap) × 0.5^(days / H_eff)
 
-    access_count is capped at ACCESS_COUNT_CAP so even a memory retrieved
-    thousands of times has a bounded score — combined with half-life decay,
-    old memories reliably fade toward zero.
+    H_eff = HALF_LIFE_DAYS × (1 + γ × intensity(valence_tag)).
+    High emotional intensity (esp. neg) decays slower — imprint-style stickiness.
+    FORGET_EMOTION_GAMMA=0 disables emotion modification.
 
     Timestamp parsing handles UTC, timezone-aware, naive, Z-suffix, and
     negative-offset ISO strings via fromisoformat + tzinfo coercion.
     On parse failure returns 0.0 so broken timestamps expire immediately
     rather than becoming immortal zombies.
-
-    Examples (HALF_LIFE_DAYS=7):
-      - 3 accesses, accessed today          → 3.0
-      - 10 accesses, last seen 21 days ago  → 1.25
-      - 1 access,  last seen 33 days ago    → ~0.05  (at cleanup threshold)
     """
     if not access_count or not last_accessed_iso or last_accessed_iso == "never":
         return 0.0
 
     try:
-        ts      = last_accessed_iso.replace("Z", "+00:00")
+        ts = last_accessed_iso.replace("Z", "+00:00")
         last_dt = datetime.fromisoformat(ts)
         if last_dt.tzinfo is None:
             last_dt = last_dt.replace(tzinfo=timezone.utc)
-        now  = datetime.now(timezone.utc)
-        days = max(0, (now - last_dt).total_seconds() / 86400)
-        return float(min(access_count, ACCESS_COUNT_CAP)) * (0.5 ** (days / HALF_LIFE_DAYS))
+        now = datetime.now(timezone.utc)
+        days = max(0.0, (now - last_dt).total_seconds() / 86400.0)
+        intensity = _valence_intensity(valence_tag)
+        h_eff = HALF_LIFE_DAYS * (1.0 + max(0.0, EMOTION_GAMMA) * intensity)
+        h_eff = max(h_eff, 1e-6)
+        return float(min(access_count, ACCESS_COUNT_CAP)) * (0.5 ** (days / h_eff))
     except Exception:
-        # Timestamp parse failure → treat as expired; never leave immortal zombies
         return 0.0
 
 
 def is_grace_protected(created_at_iso: str) -> bool:
-    """Return True if a memory is still within the grace period protection window.
-
-    Grace period prevents freshly created memories from being swept by cleanup()
-    before they accumulate enough access_count to score above threshold — mirrors
-    how working memory consolidation protects new engrams before LTP sets in.
+    """True while memory is inside the post-write grace window.
 
     On parse failure returns False — unknown creation time gets no protection.
     """
@@ -74,19 +89,25 @@ def is_grace_protected(created_at_iso: str) -> bool:
         return False
 
     try:
-        ts         = created_at_iso.replace("Z", "+00:00")
+        ts = created_at_iso.replace("Z", "+00:00")
         created_dt = datetime.fromisoformat(ts)
         if created_dt.tzinfo is None:
             created_dt = created_dt.replace(tzinfo=timezone.utc)
-        now  = datetime.now(timezone.utc)
+        now = datetime.now(timezone.utc)
         days = max(0, (now - created_dt).total_seconds() / 86400)
         return days < GRACE_PERIOD_DAYS
     except Exception:
         return False
 
+
 # ── lifecycle gate ─────────────────────────────────────────────────────────────
 
-def should_cleanup(access_count: int, last_accessed_iso: str, created_at_iso: str) -> bool:
+def should_cleanup(
+    access_count: int,
+    last_accessed_iso: str,
+    created_at_iso: str,
+    valence_tag: str | None = None,
+) -> bool:
     """Return True if a memory is a deletion candidate.
 
     A memory is prunable only when both conditions hold:
@@ -98,4 +119,4 @@ def should_cleanup(access_count: int, last_accessed_iso: str, created_at_iso: st
     if is_grace_protected(created_at_iso):
         return False
 
-    return compute_weighted_score(access_count, last_accessed_iso) < CLEANUP_THRESHOLD
+    return compute_weighted_score(access_count, last_accessed_iso, valence_tag) < CLEANUP_THRESHOLD

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -3325,6 +3325,8 @@ class AikoMemorize:
         Increment access_count on memories matching salience heuristics.
         Pinned memories pass through unchanged.
         Returns count of memories boosted.
+        
+        Phase 5: prefers stored salience_hit / non-neutral valence_tag when set.
         """
         now     = datetime.now(timezone.utc)
         boost_ids: list[str] = []
@@ -3349,8 +3351,24 @@ class AikoMemorize:
                 except Exception:
                     log.warning("memorize: failed to parse created_at")
 
+            # Phase 5: prefer stored turn tags when present.
+            stored_salient = False
+            emotional = False
+            if os.getenv("DREAM_BOOST_USE_STORED_TAGS", "1").lower() in {"1", "true", "yes", "on"}:
+                try:
+                    sh = m.get("salience_hit")
+                    if sh is not None and str(sh) != "":
+                        stored_salient = bool(int(sh))
+                    vt = m.get("valence_tag") or "neutral"
+                    if isinstance(vt, str) and vt.strip().lower() in ("neg", "pos"):
+                        emotional = True
+                except Exception:
+                    pass
+
             is_salient = (
-                bool(_SALIENCE_RE.search(text))
+                stored_salient
+                or emotional
+                or bool(_SALIENCE_RE.search(text))
                 or ac >= 3
                 or is_recent
             )
@@ -3597,8 +3615,9 @@ class AikoMemorize:
                 kept += 1
                 continue
               
-            if should_cleanup(ac, la, created_at):
-                w = compute_weighted_score(ac, la)
+            v_tag = m.get("valence_tag")
+            if should_cleanup(ac, la, created_at, valence_tag=v_tag):
+                w = compute_weighted_score(ac, la, valence_tag=v_tag)
                 candidates.append({
                     "id":               mem_id,
                     "memory":           m.get("memory", "")[:120],


### PR DESCRIPTION
## Summary
Phase 5 — use Phase 4 valence/salience in the unpinned lifecycle:

- **forget**: H_eff = H × (1 + γ × intensity); neg sticks longer
- **cleanup**: passes valence_tag into decay scoring
- **dream boost**: prefers stored salience_hit / valence_tag

## Files
- `memory/forget.py`
- `memory/memorize.py`
- `config/memory.yaml`

## Out of scope
Dynamic anchors, journal promote, knowledge merge, rank penalty, studio.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added emotion-aware memory retention, allowing emotionally significant memories to persist longer.
  * Enhanced dream-based memory promotion using stored emotional tone and salience signals.
  * Added configurable settings for emotional decay and promotion behavior.

* **Bug Fixes**
  * Improved cleanup scoring by incorporating emotional context alongside access frequency and recency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->