### PR TITLE
feat(memory): Phase 12 studio polish — MAX caps + client filters

### DIFF
--- a/interface/webui/studio/memory/README.md
+++ b/interface/webui/studio/memory/README.md
@@ -1,21 +1,22 @@
 # Aiko Memory Graph Studio
 
-Visualize personal memory as a **galaxy graph** — facts, supersession chains, entity hubs, and Phase 10 retain scores.
+Visualize personal memory as a **galaxy graph** — facts, supersession chains, entity hubs, and retain scores.
 
 ## Run
 
 ```bash
 # from repo root (deps: fastapi uvicorn)
 uv run python -m interface.webui.studio.memory.backend.api
-# → http://localhost:8001
+# → http://127.0.0.1:8001
 ```
 
 Or:
 
 ```bash
-uv run uvicorn interface.webui.studio.memory.backend.api:app --host 0.0.0.0 --port 8001
-Local only (`127.0.0.1`). For remote access, put an authenticated TLS-terminating reverse proxy in front; do not expose plain HTTP on `0.0.0.0`.
+uv run uvicorn interface.webui.studio.memory.backend.api:app --host 127.0.0.1 --port 8001
 ```
+
+Local only (`127.0.0.1`). For remote access, put an authenticated TLS-terminating reverse proxy in front; do not expose plain HTTP on `0.0.0.0`.
 
 ## API
 
@@ -29,42 +30,39 @@ Local only (`127.0.0.1`). For remote access, put an authenticated TLS-terminatin
 Query params for `/api/graph`:
 
 - `user_id` — optional
-- `limit` — max memory rows (default 200)
+- `limit` — max memory rows fetched (default 200; also capped by `MEMORY_STUDIO_MAX_MEMORIES`)
 - `include_history` — include `status=superseded` (default true)
 - `include_entities` — entity hub nodes + `mentions` edges (default true)
+
+## Phase 12
+
+**Server caps** (`config/memory.yaml`):
+
+- `MEMORY_STUDIO_MAX_MEMORIES` (default 400) — prefer high retain
+- `MEMORY_STUDIO_MAX_ENTITIES` (default 120)
+- `MEMORY_STUDIO_MAX_EDGES` (default 200)
+
+**Client filters** (sidebar; re-filter without reload):
+
+- Status: all / active / superseded
+- Valence: all / pos / neg / neutral
+- Min retain (0–1)
+- Entity contains (substring)
 
 ## Graph model
 
 **Nodes**
 
 - `type=memory` — fact rows; **`size`** = retain tendency; **`scores`** rim arcs
-- `type=entity` — shared entity hubs; **`size`** ≈ \(I_e\) when available
-
-**Node fields (Phase 10)**
-
-- `scores.retain` — keep-likelihood proxy (not full monthly R)
-- `scores.salience | spacing | connectivity | valence | access` — rim arcs
-- `valence_tag` — pos / neg / neutral
-- `size` — derived from retain / \(I_e\)
+- `type=entity` — shared entity hubs; **`size`** ≈ $I_e$ when available
 
 **Edges**
 
 - `supersedes` — newer fact → older fact it replaced
 - `mentions` — memory → entity
-- `related_to` / co-mention — entity → entity (`entity_relations`)
-
-## Visual encoding
-
-| Channel | Meaning |
-|---------|---------|
-| **Size** | Retain tendency (memories) / entity importance |
-| **Rim arcs** | Factor breakdown |
-| **Fill** | Valence / monthly / entity / pinned |
-| **Dim** | Superseded |
+- `related_to` / co-mention — entity → entity
 
 ## Notes
 
 - Read-only — does not write memories
-- No re-embed
-- Backend: `graph_export.export_memory_graph` (scores computed at export time)
-- Scoring helpers live **inside** `graph_export.py` (no separate `studio_scores.py`)
+- Scoring helpers live inside `graph_export.py`

--- a/interface/webui/studio/memory/README.md
+++ b/interface/webui/studio/memory/README.md
@@ -42,7 +42,7 @@ Query params for `/api/graph`:
 - `MEMORY_STUDIO_MAX_ENTITIES` (default 120)
 - `MEMORY_STUDIO_MAX_EDGES` (default 200)
 
-Note: among the newest `limit` rows, export prefers higher retain when applying the memory cap (not a full-DB retain rank).
+Note: over-fetches ~3× `limit` (newest-first), then keeps the top `limit` by retain among
 
 **Client filters** (sidebar; re-filter without reload):
 

--- a/interface/webui/studio/memory/README.md
+++ b/interface/webui/studio/memory/README.md
@@ -36,11 +36,13 @@ Query params for `/api/graph`:
 
 ## Phase 12
 
-**Server caps** (`config/memory.yaml`):
+**Server caps** (env vars read by `graph_export.py`; set via deploy / `.env` — `config/memory.yaml` is the documented source when your config loader exports them to the environment):
 
-- `MEMORY_STUDIO_MAX_MEMORIES` (default 400) — prefer high retain
+- `MEMORY_STUDIO_MAX_MEMORIES` (default 400)
 - `MEMORY_STUDIO_MAX_ENTITIES` (default 120)
 - `MEMORY_STUDIO_MAX_EDGES` (default 200)
+
+Note: among the newest `limit` rows, export prefers higher retain when applying the memory cap (not a full-DB retain rank).
 
 **Client filters** (sidebar; re-filter without reload):
 

--- a/interface/webui/studio/memory/backend/api.py
+++ b/interface/webui/studio/memory/backend/api.py
@@ -98,4 +98,5 @@ async def serve_studio():
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8001)
+    # Local only — use a TLS reverse proxy for remote access.
+    uvicorn.run(app, host="127.0.0.1", port=8001)

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -27,9 +27,20 @@ log = get_logger(__name__)
 _SPACING_SAT = max(1, int(os.getenv("MONTHLY_CONSOLIDATION_SPACING_SATURATION", "5")))
 _DAILY_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2}\]\s")
 _MONTHLY_RE = re.compile(r"^\[\d{4}-\d{2}\]\s")
-_MAX_MEMORIES = max(1, int(os.getenv("MEMORY_STUDIO_MAX_MEMORIES", "400")))
-_MAX_ENTITIES = max(0, int(os.getenv("MEMORY_STUDIO_MAX_ENTITIES", "120")))
-_MAX_EDGES = max(0, int(os.getenv("MEMORY_STUDIO_MAX_EDGES", "200")))
+
+def _env_int(name: str, default: int, *, floor: int = 0) -> int:
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        return max(floor, default)
+    try:
+        return max(floor, int(str(raw).strip()))
+    except (TypeError, ValueError):
+        log.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return max(floor, default)
+
+_MAX_MEMORIES = _env_int("MEMORY_STUDIO_MAX_MEMORIES", 400, floor=1)
+_MAX_ENTITIES = _env_int("MEMORY_STUDIO_MAX_ENTITIES", 120, floor=0)
+_MAX_EDGES = _env_int("MEMORY_STUDIO_MAX_EDGES", 200, floor=0)
 
 
 def _entities_from_raw(raw: Any) -> list[str]:

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -247,8 +247,16 @@ def export_memory_graph(
         params: list[Any] = [uid]
         if has_status and not include_history:
             sql += " AND (status = 'active' OR status IS NULL)"
+            
+        try:
+            req_limit = int(limit) if limit is not None else 200
+        except (TypeError, ValueError):
+            req_limit = 200
+        if req_limit < 1:
+            req_limit = 200
+        effective_limit = min(req_limit, _MAX_MEMORIES)
+
         sql += " ORDER BY created_at DESC"
-        effective_limit = min(int(limit or 200), _MAX_MEMORIES) if limit else _MAX_MEMORIES
         if effective_limit > 0:
             sql += " LIMIT ?"
             params.append(int(effective_limit))
@@ -386,7 +394,7 @@ def export_memory_graph(
 
                 ensure_entity_relations_schema(conn)
                 for e in relations_as_graph_edges(
-                    conn, user_id=uid, limit=max(int(limit) * 2, 500)
+                    conn, user_id=uid, limit=max(int(effective_limit) * 2, 500)
                 ):
                     for endpoint in (e["source"], e["target"]):
                         if endpoint not in entity_ids and endpoint not in mem_ids:

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -27,6 +27,9 @@ log = get_logger(__name__)
 _SPACING_SAT = max(1, int(os.getenv("MONTHLY_CONSOLIDATION_SPACING_SATURATION", "5")))
 _DAILY_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2}\]\s")
 _MONTHLY_RE = re.compile(r"^\[\d{4}-\d{2}\]\s")
+_MAX_MEMORIES = max(1, int(os.getenv("MEMORY_STUDIO_MAX_MEMORIES", "400")))
+_MAX_ENTITIES = max(0, int(os.getenv("MEMORY_STUDIO_MAX_ENTITIES", "120")))
+_MAX_EDGES = max(0, int(os.getenv("MEMORY_STUDIO_MAX_EDGES", "200")))
 
 
 def _entities_from_raw(raw: Any) -> list[str]:
@@ -234,9 +237,10 @@ def export_memory_graph(
         if has_status and not include_history:
             sql += " AND (status = 'active' OR status IS NULL)"
         sql += " ORDER BY created_at DESC"
-        if limit and limit > 0:
+        effective_limit = min(int(limit or 200), _MAX_MEMORIES) if limit else _MAX_MEMORIES
+        if effective_limit > 0:
             sql += " LIMIT ?"
-            params.append(int(limit))
+            params.append(int(effective_limit))
 
         rows = conn.execute(sql, params).fetchall()
 
@@ -407,18 +411,38 @@ def export_memory_graph(
             except Exception as ex:
                 log.debug("graph_export: entity_relations skipped: %s", ex)
 
+        mem_nodes = [n for n in nodes if n.get("type") == "memory"]
+        ent_nodes = [n for n in nodes if n.get("type") == "entity"]
+        mem_nodes.sort(
+            key=lambda n: float((n.get("scores") or {}).get("retain") or n.get("size") or 0),
+            reverse=True,
+        )
+        ent_nodes.sort(key=lambda n: float(n.get("size") or 0), reverse=True)
+        mem_nodes = mem_nodes[:_MAX_MEMORIES]
+        ent_nodes = ent_nodes[:_MAX_ENTITIES]
+        keep_ids = {n["id"] for n in mem_nodes} | {n["id"] for n in ent_nodes}
+        nodes = mem_nodes + ent_nodes
+        edges = [e for e in edges if e.get("source") in keep_ids and e.get("target") in keep_ids]
+        edges.sort(
+            key=lambda e: (0 if e.get("type") == "supersedes" else 1, -float(e.get("weight") or 0)),
+        )
+        edges = edges[:_MAX_EDGES]
+        
         return {
             "nodes": nodes,
             "edges": edges,
             "meta": {
                 "user_id": uid,
-                "memory_count": len(mem_ids),
-                "entity_count": len(entity_ids),
+                "memory_count": len(mem_nodes),
+                "entity_count": len(ent_nodes),
                 "edge_count": len(edges),
                 "include_history": include_history,
                 "include_entities": include_entities,
                 "limit": limit,
                 "theme": "galaxy",
+                "max_memories": _MAX_MEMORIES,
+                "max_entities": _MAX_ENTITIES,
+                "max_edges": _MAX_EDGES,
             },
             "legend": _legend(),
         }

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -255,11 +255,13 @@ def export_memory_graph(
         if req_limit < 1:
             req_limit = 200
         effective_limit = min(req_limit, _MAX_MEMORIES)
+        # Over-fetch so retain ranking can prefer strong older rows in a wider window
+        fetch_n = min(max(effective_limit * 3, effective_limit), max(_MAX_MEMORIES * 3, effective_limit))
 
         sql += " ORDER BY created_at DESC"
-        if effective_limit > 0:
+        if fetch_n > 0:
             sql += " LIMIT ?"
-            params.append(int(effective_limit))
+            params.append(int(fetch_n))
 
         rows = conn.execute(sql, params).fetchall()
 
@@ -394,7 +396,7 @@ def export_memory_graph(
 
                 ensure_entity_relations_schema(conn)
                 for e in relations_as_graph_edges(
-                    conn, user_id=uid, limit=max(int(effective_limit) * 2, 500)
+                    conn, user_id=uid, limit=max(int(fetch_n) * 2, 500)
                 ):
                     for endpoint in (e["source"], e["target"]):
                         if endpoint not in entity_ids and endpoint not in mem_ids:
@@ -436,8 +438,9 @@ def export_memory_graph(
             key=lambda n: float((n.get("scores") or {}).get("retain") or n.get("size") or 0),
             reverse=True,
         )
+        # Prefer high retain among the over-fetched window
+        mem_nodes = mem_nodes[:effective_limit]
         ent_nodes.sort(key=lambda n: float(n.get("size") or 0), reverse=True)
-        mem_nodes = mem_nodes[:_MAX_MEMORIES]
         ent_nodes = ent_nodes[:_MAX_ENTITIES]
         keep_ids = {n["id"] for n in mem_nodes} | {n["id"] for n in ent_nodes}
         nodes = mem_nodes + ent_nodes

--- a/interface/webui/studio/memory/frontend/index.html
+++ b/interface/webui/studio/memory/frontend/index.html
@@ -278,9 +278,44 @@
           .attr('opacity', 0.12 + Math.random() * 0.35);
       }
 
-      const nodes = (graph.nodes || []).map(n => ({ ...n }));
-      const links = (graph.edges || []).map(e => ({ ...e }));
-      const links = (graph.edges || []).map(e => ({ ...e }));
+      const st = document.getElementById('filter-status')?.value || 'all';
+      const val = document.getElementById('filter-valence')?.value || 'all';
+      const minR = parseFloat(document.getElementById('filter-min-retain')?.value || '0') || 0;
+      const entQ = (document.getElementById('filter-entity')?.value || '').trim().toLowerCase();
+
+      let nodes = (graph.nodes || []).map(n => ({ ...n })).filter(d => {
+        if (d.type === 'entity') {
+          if (entQ && !(String(d.label || d.text || '').toLowerCase().includes(entQ))) return false;
+          return true;
+        }
+        if (st !== 'all' && (d.status || 'active') !== st) return false;
+        if (val !== 'all' && (d.valence_tag || 'neutral') !== val) return false;
+        const r = Number((d.scores || {}).retain ?? d.size ?? 0);
+        if (r < minR) return false;
+        if (entQ) {
+          const ents = (d.entities || []).map(e => String(e).toLowerCase());
+          if (!ents.some(e => e.includes(entQ))) return false;
+        }
+        return true;
+      });
+      const keep = new Set(nodes.map(n => n.id));
+      // Keep entity hubs linked to visible memories
+      for (const e of (graph.edges || [])) {
+        if (e.type === 'mentions' && keep.has(e.source)) keep.add(e.target);
+        if (e.type === 'mentions' && keep.has(e.target)) keep.add(e.source);
+      }
+      nodes = (graph.nodes || []).map(n => ({ ...n })).filter(n => {
+        if (!keep.has(n.id)) return false;
+        if (n.type === 'entity') return true;
+        if (st !== 'all' && (n.status || 'active') !== st) return false;
+        if (val !== 'all' && (n.valence_tag || 'neutral') !== val) return false;
+        const r = Number((n.scores || {}).retain ?? n.size ?? 0);
+        if (r < minR) return false;
+        return true;
+      });
+      const keep2 = new Set(nodes.map(n => n.id));
+      const links = (graph.edges || []).map(e => ({ ...e }))
+        .filter(e => keep2.has(e.source) && keep2.has(e.target));
       if (!nodes.length) {
         svg.append('text').attr('x', w/2).attr('y', h/2).attr('text-anchor','middle')
           .attr('fill','var(--dim)').text('No memories yet');

--- a/interface/webui/studio/memory/frontend/index.html
+++ b/interface/webui/studio/memory/frontend/index.html
@@ -83,7 +83,25 @@
       <label>Limit <input type="number" id="limit" value="200" min="1" max="2000" /></label>
       <label><input type="checkbox" id="include-history" checked /> Include superseded</label>
       <label><input type="checkbox" id="include-entities" checked /> Entity hubs</label>
+            <label>Status
+        <select id="filter-status">
+          <option value="all">all</option>
+          <option value="active">active</option>
+          <option value="superseded">superseded</option>
+        </select>
+      </label>
+      <label>Valence
+        <select id="filter-valence">
+          <option value="all">all</option>
+          <option value="pos">pos</option>
+          <option value="neg">neg</option>
+          <option value="neutral">neutral</option>
+        </select>
+      </label>
+      <label>Min retain <input type="number" id="filter-min-retain" value="0" min="0" max="1" step="0.05" /></label>
+      <label>Entity contains <input type="text" id="filter-entity" placeholder="e.g. ros2" /></label>
       <button class="btn btn-primary" id="apply" style="width:100%;margin-top:10px">Apply</button>
+      <button class="btn" id="apply-filters" style="width:100%;margin-top:6px">Re-filter (no reload)</button>
       <h2>Stats</h2>
       <div class="stat" id="stats">—</div>
       <h2>Legend</h2>

--- a/interface/webui/studio/memory/frontend/index.html
+++ b/interface/webui/studio/memory/frontend/index.html
@@ -284,27 +284,6 @@
       const entQ = (document.getElementById('filter-entity')?.value || '').trim().toLowerCase();
 
       let nodes = (graph.nodes || []).map(n => ({ ...n })).filter(d => {
-        if (d.type === 'entity') {
-          if (entQ && !(String(d.label || d.text || '').toLowerCase().includes(entQ))) return false;
-          return true;
-        }
-        if (st !== 'all' && (d.status || 'active') !== st) return false;
-        if (val !== 'all' && (d.valence_tag || 'neutral') !== val) return false;
-        const r = Number((d.scores || {}).retain ?? d.size ?? 0);
-        if (r < minR) return false;
-        if (entQ) {
-          const ents = (d.entities || []).map(e => String(e).toLowerCase());
-          if (!ents.some(e => e.includes(entQ))) return false;
-        }
-        return true;
-      });
-      const keep = new Set(nodes.map(n => n.id));
-      // Keep entity hubs linked to visible memories
-      for (const e of (graph.edges || [])) {
-        if (e.type === 'mentions' && keep.has(e.source)) keep.add(e.target);
-        if (e.type === 'mentions' && keep.has(e.target)) keep.add(e.source);
-      }
-      let nodes = (graph.nodes || []).map(n => ({ ...n })).filter(d => {
         if (d.type === 'entity') return false;
         if (st !== 'all' && (d.status || 'active') !== st) return false;
         if (val !== 'all' && (d.valence_tag || 'neutral') !== val) return false;

--- a/interface/webui/studio/memory/frontend/index.html
+++ b/interface/webui/studio/memory/frontend/index.html
@@ -304,13 +304,28 @@
         if (e.type === 'mentions' && keep.has(e.source)) keep.add(e.target);
         if (e.type === 'mentions' && keep.has(e.target)) keep.add(e.source);
       }
+      let nodes = (graph.nodes || []).map(n => ({ ...n })).filter(d => {
+        if (d.type === 'entity') return false;
+        if (st !== 'all' && (d.status || 'active') !== st) return false;
+        if (val !== 'all' && (d.valence_tag || 'neutral') !== val) return false;
+        const r = Number((d.scores || {}).retain ?? d.size ?? 0);
+        if (r < minR) return false;
+        if (entQ) {
+          const ents = (d.entities || []).map(e => String(e).toLowerCase());
+          if (!ents.some(e => e.includes(entQ))) return false;
+        }
+        return true;
+      });
+      const keep = new Set(nodes.map(n => n.id));
+      for (const e of (graph.edges || [])) {
+        if (e.type === 'mentions' && keep.has(e.source)) keep.add(e.target);
+      }
       nodes = (graph.nodes || []).map(n => ({ ...n })).filter(n => {
         if (!keep.has(n.id)) return false;
-        if (n.type === 'entity') return true;
-        if (st !== 'all' && (n.status || 'active') !== st) return false;
-        if (val !== 'all' && (n.valence_tag || 'neutral') !== val) return false;
-        const r = Number((n.scores || {}).retain ?? n.size ?? 0);
-        if (r < minR) return false;
+        if (n.type === 'entity') {
+          if (entQ && !(String(n.label || n.text || '').toLowerCase().includes(entQ))) return false;
+          return true;
+        }
         return true;
       });
       const keep2 = new Set(nodes.map(n => n.id));

--- a/interface/webui/studio/memory/frontend/index.html
+++ b/interface/webui/studio/memory/frontend/index.html
@@ -32,6 +32,7 @@
     .sidebar { border-right: 1px solid var(--border); background: var(--bg2); padding: 14px; overflow-y: auto; font-size: 12px; }
     .sidebar h2 { font-size: 10px; letter-spacing: .18em; color: var(--pink); text-transform: uppercase; margin: 12px 0 8px; }
     .sidebar label { display: flex; gap: 8px; align-items: center; margin: 6px 0; color: var(--dim); }
+    .sidebar select,
     .sidebar input[type=number], .sidebar input[type=text] {
       width: 100%; background: #120a1c; border: 1px solid var(--dim); color: var(--text);
       padding: 6px 8px; border-radius: 3px; font-size: 12px;
@@ -279,6 +280,7 @@
 
       const nodes = (graph.nodes || []).map(n => ({ ...n }));
       const links = (graph.edges || []).map(e => ({ ...e }));
+      const links = (graph.edges || []).map(e => ({ ...e }));
       if (!nodes.length) {
         svg.append('text').attr('x', w/2).attr('y', h/2).attr('text-anchor','middle')
           .attr('fill','var(--dim)').text('No memories yet');
@@ -384,6 +386,7 @@
 
     document.getElementById('refresh').onclick = loadGraph;
     document.getElementById('apply').onclick = loadGraph;
+    document.getElementById('apply-filters').onclick = () => render();
     document.getElementById('search-btn').onclick = runSearch;
     document.getElementById('search-q').addEventListener('keydown', (e) => { if (e.key === 'Enter') runSearch(); });
     document.getElementById('export').onclick = () => {


### PR DESCRIPTION
## Summary

**Phase 12 — Memory Studio polish**

- Enforce `MEMORY_STUDIO_MAX_MEMORIES` / `ENTITIES` / `EDGES` in `graph_export` (prefer high retain when capping)
- Sidebar client filters: status, valence, min retain, entity contains (+ re-filter without reload)
- Local uvicorn bind `127.0.0.1`; README updated

## Files

| File | Change |
|------|--------|
| `graph_export.py` | MAX_* caps + effective_limit |
| `frontend/index.html` | Filter controls + client filter in `render()` |
| `backend/api.py` | `host=127.0.0.1` |
| `README.md` | Phase 12 docs |

`config/memory.yaml` already has MAX_* keys — no change.

## Test plan

- [ ] Open studio → graph loads with scores/size
- [ ] Large DB respects MAX_* (meta shows max_* )
- [ ] Filters: status / valence / min retain / entity — Re-filter works without reload
- [ ] Apply still refetches from API

## Notes

If `graph_export.py` / `index.html` still need the Phase 12 patches on this branch, apply the snippets from the PR discussion / agent artifacts before undrafting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added memory graph filters for node status, valence, retention score, and entity text.
  - Added no-reload filtering and improved graph display with connected entity context.
  - Added configurable limits for exported memories, entities, and relationships, with retained-count details.
- **Bug Fixes**
  - Corrected graph filtering behavior to prevent invalid results and keep displayed relationships consistent.
- **Documentation**
  - Updated local server setup, graph limits, current model guidance, and remote-access security recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->