### PR TITLE
feat(memory): Phase 13 cross-store memory↔knowledge↔experience chain + studio layers

### DIFF
--- a/agentic/agentic.py
+++ b/agentic/agentic.py
@@ -1498,7 +1498,9 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
     else:
         memories, knowledge_block = owner._fetch_memory_and_knowledge(user_input, query_vector=_query_vec)
 
-    memory_block = owner._memorize.format_for_context(memories)
+        memory_block = self._get_memorize().format_for_context(
+            memories, query=user_input
+        )
     memory_context = memory_block or "<memory_context>\nNo relevant memories found.\n</memory_context>"
     memory_context = _blank_empty_context(memory_context)
 

--- a/agentic/agentic.py
+++ b/agentic/agentic.py
@@ -1498,9 +1498,9 @@ def run_agentic_chat(owner, user_input: str, token_callback=None, mem_kb_future=
     else:
         memories, knowledge_block = owner._fetch_memory_and_knowledge(user_input, query_vector=_query_vec)
 
-        memory_block = self._get_memorize().format_for_context(
-            memories, query=user_input
-        )
+    memory_block = owner._get_memorize().format_for_context(
+        memories, query=user_input
+    )
     memory_context = memory_block or "<memory_context>\nNo relevant memories found.\n</memory_context>"
     memory_context = _blank_empty_context(memory_context)
 

--- a/cognition/think.py
+++ b/cognition/think.py
@@ -1017,7 +1017,9 @@ class AikoThink:
             # Memory + KB — either resolved from route()'s post-intent future,
             # or fetched directly if this was called standalone.
             memories, knowledge_block = self._resolve_mem_kb(user_input, mem_kb_future)
-            memory_block = self._get_memorize().format_for_context(memories)
+            memory_block = self._get_memorize().format_for_context(
+              memories, query=user_input
+            )
             persona_block = self._get_memorize().persona_context()
         
         system = self._current_system_prompt(user_input)

--- a/cognition/think.py
+++ b/cognition/think.py
@@ -878,7 +878,9 @@ class AikoThink:
         # Memory + KB — either resolved from route()'s pre-intent future,
         # or fetched directly if this was called standalone.
         memories, knowledge_block = self._resolve_mem_kb(user_input, mem_kb_future)
-        memory_block = self._get_memorize().format_for_context(memories)
+        memory_block = self._get_memorize().format_for_context(
+          memories, query=user_input
+        )
         persona_block = self._get_memorize().persona_context()
 
         # Build base system (persona + memory + knowledge)

--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -139,6 +139,19 @@ FORGET_INTENSITY_POS: "0.4"  # intensity for valence_tag=pos.
 FORGET_INTENSITY_NEUTRAL: "0.0"  # 0 = neutral is not emotional; does not extend effective half-life.
 DREAM_BOOST_USE_STORED_TAGS: "1"  # Prefer salience_hit / valence_tag over text-only heuristics in dream boost.
 
+# -- Phase 13: cross-store chain (append to config/memory.yaml) --
+MEMORY_CROSS_STORE_ENABLED: "1"  # Attach related knowledge/experience after personal memory recall.
+MEMORY_CROSS_STORE_MAX_KNOWLEDGE: "2"  # Max knowledge chunks attached per recall.
+MEMORY_CROSS_STORE_MAX_EXPERIENCE: "2"  # Max experience rows attached per recall.
+MEMORY_CROSS_STORE_MIN_ENTITY_OVERLAP: "1"  # Min shared entities to keep a related hit (0 = score-only).
+MEMORY_CROSS_STORE_CONTEXT_CHARS: "800"  # Max chars for related_* blocks in context.
+
+# Studio layers
+MEMORY_STUDIO_INCLUDE_KNOWLEDGE: "1"  # Export learned_chunks as knowledge nodes.
+MEMORY_STUDIO_INCLUDE_EXPERIENCE: "1"  # Export experiences as experience nodes.
+MEMORY_STUDIO_MAX_KNOWLEDGE: "80"  # Cap knowledge nodes in graph payload.
+MEMORY_STUDIO_MAX_EXPERIENCE: "40"  # Cap experience nodes in graph payload.
+
 # -- Decay and dream merge --
 FORGET_HALF_LIFE_DAYS: "21"  # Days until memory retention score halves.
 FORGET_ACCESS_COUNT_CAP: "255"  # Maximum access_count retained for decay scoring.

--- a/interface/webui/studio/memory/README.md
+++ b/interface/webui/studio/memory/README.md
@@ -1,6 +1,6 @@
 # Aiko Memory Graph Studio
 
-Visualize personal memory as a **galaxy graph** — facts, supersession chains, entity hubs, and retain scores.
+Visualize personal memory as a **neural graph** — facts, supersession chains, entity hubs, knowledge, experience, and retain scores.
 
 ## Run
 
@@ -33,6 +33,8 @@ Query params for `/api/graph`:
 - `limit` — max memory rows fetched (default 200; also capped by `MEMORY_STUDIO_MAX_MEMORIES`)
 - `include_history` — include `status=superseded` (default true)
 - `include_entities` — entity hub nodes + `mentions` edges (default true)
+- `include_knowledge` — learned knowledge nodes (default true; Phase 13)
+- `include_experience` — experience nodes (default true; Phase 13)
 
 ## Phase 12
 
@@ -43,6 +45,44 @@ Query params for `/api/graph`:
 - `MEMORY_STUDIO_MAX_EDGES` (default 200)
 
 Note: over-fetches ~3× `limit` (newest-first), then keeps the top `limit` by retain among that window (not a full-DB retain rank).
+
+## Phase 13 — Cross-store layers
+
+Related knowledge and experience appear as extra node types, linked by shared entities.
+
+### New node types
+
+| type | Color | Source |
+|------|--------|--------|
+| `knowledge` | green `#4ade80` | `learned_chunks` |
+| `experience` | orange `#fb923c` | `experiences` |
+
+### New edge types
+
+| type | Meaning |
+|------|---------|
+| `about` | knowledge/experience → entity |
+| `grounded_in` | memory → knowledge (shared entity) |
+| `practiced_in` | memory → experience (shared entity) |
+
+### API
+```
+GET /api/graph?include_knowledge=true&include_experience=true
+```
+
+### UI layers
+
+Sidebar:
+
+- **Include knowledge / experience** — control what the export loads (reload)
+- **Show memory / entities / knowledge / experience** — client filter without reload
+
+### Env (optional)
+
+- `MEMORY_STUDIO_INCLUDE_KNOWLEDGE` (default `1`)
+- `MEMORY_STUDIO_INCLUDE_EXPERIENCE` (default `1`)
+- `MEMORY_STUDIO_MAX_KNOWLEDGE` (default `80`)
+- `MEMORY_STUDIO_MAX_EXPERIENCE` (default `40`)
 
 **Client filters** (sidebar; re-filter without reload):
 
@@ -57,12 +97,18 @@ Note: over-fetches ~3× `limit` (newest-first), then keeps the top `limit` by re
 
 - `type=memory` — fact rows; **`size`** = retain tendency; **`scores`** rim arcs
 - `type=entity` — shared entity hubs; **`size`** ≈ $I_e$ when available
+- `type=knowledge` — learned chunks (green)
+- `type=experience` — past agent runs (orange)
 
 **Edges**
 
 - `supersedes` — newer fact → older fact it replaced
 - `mentions` — memory → entity
 - `related_to` / co-mention — entity → entity
+
+- `about` — knowledge/experience → entity
+- `grounded_in` — memory → knowledge
+- `practiced_in` — memory → experience
 
 ## Notes
 

--- a/interface/webui/studio/memory/README.md
+++ b/interface/webui/studio/memory/README.md
@@ -66,7 +66,7 @@ Related knowledge and experience appear as extra node types, linked by shared en
 | `practiced_in` | memory → experience (shared entity) |
 
 ### API
-```
+```http
 GET /api/graph?include_knowledge=true&include_experience=true
 ```
 

--- a/interface/webui/studio/memory/backend/api.py
+++ b/interface/webui/studio/memory/backend/api.py
@@ -27,6 +27,8 @@ async def get_graph(
     limit: int = Query(200, ge=1, le=2000),
     include_history: bool = Query(True, description="Include superseded memories"),
     include_entities: bool = Query(True, description="Add entity hub nodes"),
+    include_knowledge: bool = Query(True, description="Phase 13: learned knowledge nodes"),
+    include_experience: bool = Query(True, description="Phase 13: experience nodes"),
 ):
     from interface.webui.studio.memory.backend.graph_export import export_memory_graph
     from system.userspace import current_user_id
@@ -37,6 +39,8 @@ async def get_graph(
         limit=limit,
         include_history=include_history,
         include_entities=include_entities,
+        include_knowledge=include_knowledge,
+        include_experience=include_experience,
     )
 
 

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -28,6 +28,24 @@ _SPACING_SAT = max(1, int(os.getenv("MONTHLY_CONSOLIDATION_SPACING_SATURATION", 
 _DAILY_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2}\]\s")
 _MONTHLY_RE = re.compile(r"^\[\d{4}-\d{2}\]\s")
 
+def _env_int(name: str, default: int, *, floor: int = 0) -> int:
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        return max(floor, default)
+    try:
+        return max(floor, int(str(raw).strip()))
+    except (TypeError, ValueError):
+        log.warning("Invalid %s=%r; using default %s", name, raw, default)
+        return max(floor, default)
+
+_MAX_MEMORIES = _env_int("MEMORY_STUDIO_MAX_MEMORIES", 400, floor=1)
+_MAX_ENTITIES = _env_int("MEMORY_STUDIO_MAX_ENTITIES", 120, floor=0)
+_MAX_EDGES = _env_int("MEMORY_STUDIO_MAX_EDGES", 200, floor=0)
+_MAX_KNOWLEDGE = _env_int("MEMORY_STUDIO_MAX_KNOWLEDGE", 80, floor=0)
+_MAX_EXPERIENCE = _env_int("MEMORY_STUDIO_MAX_EXPERIENCE", 40, floor=0)
+_INCLUDE_KNOWLEDGE = os.getenv("MEMORY_STUDIO_INCLUDE_KNOWLEDGE", "1").lower() in {"1", "true", "yes", "on"}
+_INCLUDE_EXPERIENCE = os.getenv("MEMORY_STUDIO_INCLUDE_EXPERIENCE", "1").lower() in {"1", "true", "yes", "on"}
+
 
 def _entities_from_raw(raw: Any) -> list[str]:
     if raw is None or raw == "":
@@ -160,6 +178,8 @@ def export_memory_graph(
     limit: int = 200,
     include_history: bool = True,
     include_entities: bool = True,
+    include_knowledge: bool | None = None,
+    include_experience: bool | None = None,
     conn: sqlite3.Connection | None = None,
 ) -> dict[str, Any]:
     """Build a graph dict: {nodes, edges, meta, legend}.
@@ -174,6 +194,10 @@ def export_memory_graph(
       - co_mentions / related_to: entity → entity (entity_relations)
     """
     uid = user_id or current_user_id()
+    if include_knowledge is None:
+        include_knowledge = _INCLUDE_KNOWLEDGE
+    if include_experience is None:
+        include_experience = _INCLUDE_EXPERIENCE
     owns_conn = conn is None
     if conn is None:
         from memory.vecstore import initialize_store_db
@@ -233,24 +257,34 @@ def export_memory_graph(
         params: list[Any] = [uid]
         if has_status and not include_history:
             sql += " AND (status = 'active' OR status IS NULL)"
+            
+        try:
+            req_limit = int(limit) if limit is not None else 200
+        except (TypeError, ValueError):
+            req_limit = 200
+        if req_limit < 1:
+            req_limit = 200
+        effective_limit = min(req_limit, _MAX_MEMORIES)
+        # Over-fetch so retain ranking can prefer strong older rows in a wider window
+        fetch_n = min(max(effective_limit * 3, effective_limit), max(_MAX_MEMORIES * 3, effective_limit))
+
         sql += " ORDER BY created_at DESC"
-        if limit and limit > 0:
+        if fetch_n > 0:
             sql += " LIMIT ?"
-            params.append(int(limit))
+            params.append(int(fetch_n))
 
         rows = conn.execute(sql, params).fetchall()
 
         entity_importance: dict[str, float] = {}
         try:
             from memory.entity_importance import compute_entity_importance_map
-            # Prefer map from memorize if available; else empty
-            entity_importance = {}
-            try:
-                from memory.memorize import AikoMemorize
-                mem = AikoMemorize(silent=True)
-                entity_importance = compute_entity_importance_map(mem, uid) or {}
-            except Exception:
-                entity_importance = {}
+            from types import SimpleNamespace
+
+            # Reuse export conn + uid (no new AikoMemorize / write worker).
+            entity_importance = compute_entity_importance_map(
+                SimpleNamespace(_conn=conn, _db_lock=None),
+                uid,
+            ) or {}
         except Exception as ex:
             log.debug("graph_export: I_e map skipped: %s", ex)
 
@@ -372,7 +406,7 @@ def export_memory_graph(
 
                 ensure_entity_relations_schema(conn)
                 for e in relations_as_graph_edges(
-                    conn, user_id=uid, limit=max(int(limit) * 2, 500)
+                    conn, user_id=uid, limit=max(int(fetch_n) * 2, 500)
                 ):
                     for endpoint in (e["source"], e["target"]):
                         if endpoint not in entity_ids and endpoint not in mem_ids:
@@ -408,18 +442,65 @@ def export_memory_graph(
             except Exception as ex:
                 log.debug("graph_export: entity_relations skipped: %s", ex)
 
+
+        # Phase 13b: knowledge + experience layers (entity overlap)
+        if include_knowledge and _MAX_KNOWLEDGE > 0:
+            try:
+                _add_knowledge_layer(conn, uid, nodes, edges, entity_ids, mem_ids)
+            except Exception as ex:
+                log.debug("graph_export: knowledge layer skipped: %s", ex)
+        if include_experience and _MAX_EXPERIENCE > 0:
+            try:
+                _add_experience_layer(conn, uid, nodes, edges, entity_ids, mem_ids)
+            except Exception as ex:
+                log.debug("graph_export: experience layer skipped: %s", ex)
+
+        mem_nodes = [n for n in nodes if n.get("type") == "memory"]
+        ent_nodes = [n for n in nodes if n.get("type") == "entity"]
+        kb_nodes = [n for n in nodes if n.get("type") == "knowledge"]
+        exp_nodes = [n for n in nodes if n.get("type") == "experience"]
+        mem_nodes.sort(
+            key=lambda n: float((n.get("scores") or {}).get("retain") or n.get("size") or 0),
+            reverse=True,
+        )
+        # Prefer high retain among the over-fetched window
+        mem_nodes = mem_nodes[:effective_limit]
+        ent_nodes.sort(key=lambda n: float(n.get("size") or 0), reverse=True)
+        ent_nodes = ent_nodes[:_MAX_ENTITIES]
+        kb_nodes = kb_nodes[:_MAX_KNOWLEDGE]
+        exp_nodes = exp_nodes[:_MAX_EXPERIENCE]
+        keep_ids = (
+            {n["id"] for n in mem_nodes}
+            | {n["id"] for n in ent_nodes}
+            | {n["id"] for n in kb_nodes}
+            | {n["id"] for n in exp_nodes}
+        )
+        nodes = mem_nodes + ent_nodes + kb_nodes + exp_nodes
+        edges = [e for e in edges if e.get("source") in keep_ids and e.get("target") in keep_ids]
+        edges.sort(
+            key=lambda e: (0 if e.get("type") == "supersedes" else 1, -float(e.get("weight") or 0)),
+        )
+        edges = edges[:_MAX_EDGES]
+        
         return {
             "nodes": nodes,
             "edges": edges,
             "meta": {
                 "user_id": uid,
-                "memory_count": len(mem_ids),
-                "entity_count": len(entity_ids),
+                "memory_count": len(mem_nodes),
+                "entity_count": len(ent_nodes),
                 "edge_count": len(edges),
                 "include_history": include_history,
                 "include_entities": include_entities,
                 "limit": limit,
                 "theme": "galaxy",
+                "max_memories": _MAX_MEMORIES,
+                "max_entities": _MAX_ENTITIES,
+                "max_edges": _MAX_EDGES,
+                "max_knowledge": _MAX_KNOWLEDGE,
+                "max_experience": _MAX_EXPERIENCE,
+                "include_knowledge": include_knowledge,
+                "include_experience": include_experience,
             },
             "legend": _legend(),
         }
@@ -488,3 +569,265 @@ def relations_as_graph_edges(
             "weight": float(rel.get("weight") or 1.0),
         })
     return edges
+
+
+def _add_knowledge_layer(
+    conn: sqlite3.Connection,
+    uid: str,
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+    entity_ids: set[str],
+    mem_ids: set[str],
+) -> None:
+    """Add learned_chunks as knowledge nodes + about / grounded_in edges."""
+    kb_conn = conn
+    owns = False
+    try:
+        cols = {r[1] for r in kb_conn.execute("PRAGMA table_info(learned_chunks)").fetchall()}
+    except Exception:
+        cols = set()
+    if not cols or "id" not in cols:
+        try:
+            from memory.knowledge import _connect as kb_connect
+            kb_conn = kb_connect(uid)
+            owns = True
+            cols = {r[1] for r in kb_conn.execute("PRAGMA table_info(learned_chunks)").fetchall()}
+        except Exception as ex:
+            log.debug("knowledge layer open failed: %s", ex)
+            return
+    if not cols or "id" not in cols:
+        if owns:
+            try:
+                kb_conn.close()
+            except Exception:
+                pass
+        return
+    has_ent = "entities" in cols
+    has_status = "status" in cols
+    sql = "SELECT id, text, created_at"
+    if has_ent:
+        sql += ", entities"
+    if has_status:
+        sql += ", status"
+    sql += " FROM learned_chunks WHERE user_id = ?"
+    if has_status:
+        sql += " AND (status = 'active' OR status IS NULL)"
+    sql += " ORDER BY created_at DESC LIMIT ?"
+    try:
+        rows = kb_conn.execute(sql, (uid, _MAX_KNOWLEDGE)).fetchall()
+    except Exception as ex:
+        log.debug("knowledge layer query failed: %s", ex)
+        if owns:
+            try:
+                kb_conn.close()
+            except Exception:
+                pass
+        return
+
+    mem_ents: dict[str, set[str]] = {}
+    for e in edges:
+        if e.get("type") == "mentions":
+            mid, eid = e.get("source"), e.get("target")
+            if mid in mem_ids and isinstance(eid, str) and eid.startswith("ent:"):
+                mem_ents.setdefault(str(mid), set()).add(eid.removeprefix("ent:").casefold())
+
+    try:
+        for row in rows:
+            kid = f"kb:{row['id']}"
+            text = (row["text"] or "").strip()
+            label = text if len(text) <= 72 else text[:69] + "…"
+            ents = _entities_from_raw(row["entities"]) if has_ent else []
+            nodes.append({
+                "id": kid,
+                "type": "knowledge",
+                "label": label,
+                "text": text,
+                "status": "active",
+                "kind": "knowledge",
+                "source": "learned_chunks",
+                "pinned": False,
+                "access_count": 0,
+                "created_at": row["created_at"] if "created_at" in row.keys() else None,
+                "entities": ents,
+                "supersedes_id": None,
+                "valence_tag": "neutral",
+                "scores": {
+                    "retain": 0.55, "salience": 0.4, "spacing": 0.0,
+                    "connectivity": 0.0, "valence": 0.25, "access": 0.0,
+                },
+                "size": 0.45,
+            })
+            for ent in ents:
+                eid = f"ent:{ent}"
+                if eid not in entity_ids:
+                    entity_ids.add(eid)
+                    nodes.append({
+                        "id": eid,
+                        "type": "entity",
+                        "label": ent,
+                        "text": ent,
+                        "status": "active",
+                        "kind": "entity",
+                        "source": "",
+                        "pinned": False,
+                        "access_count": 0,
+                        "created_at": None,
+                        "entities": [],
+                        "supersedes_id": None,
+                        "valence_tag": "neutral",
+                        "scores": {
+                            "retain": 0.3, "importance": 0.3, "salience": 0.0,
+                            "spacing": 0.0, "connectivity": 0.3, "valence": 0.25, "access": 0.0,
+                        },
+                        "size": 0.35,
+                    })
+                edges.append({
+                    "id": f"about:{kid}->{eid}",
+                    "source": kid,
+                    "target": eid,
+                    "type": "about",
+                    "weight": 1.0,
+                })
+                ent_cf = ent.casefold()
+                for mid, mes in mem_ents.items():
+                    if ent_cf in mes:
+                        edges.append({
+                            "id": f"grounded:{mid}->{kid}",
+                            "source": mid,
+                            "target": kid,
+                            "type": "grounded_in",
+                            "weight": 1.0,
+                        })
+    finally:
+        if owns:
+            try:
+                kb_conn.close()
+            except Exception:
+                pass
+
+
+def _add_experience_layer(
+    conn: sqlite3.Connection,
+    uid: str,
+    nodes: list[dict[str, Any]],
+    edges: list[dict[str, Any]],
+    entity_ids: set[str],
+    mem_ids: set[str],
+) -> None:
+    """Add experiences as nodes + about / practiced_in edges (separate DB)."""
+    exp_conn = None
+    owns = False
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(experiences)").fetchall()}
+        exp_conn = conn
+    except Exception:
+        cols = set()
+    if not cols or "id" not in cols:
+        try:
+            from agentic.experience import _connect as exp_connect
+            exp_conn = exp_connect(uid)
+            owns = True
+            cols = {r[1] for r in exp_conn.execute("PRAGMA table_info(experiences)").fetchall()}
+        except Exception as ex:
+            log.debug("experience layer open failed: %s", ex)
+            return
+    if not cols or "id" not in cols or exp_conn is None:
+        return
+    has_ent = "entities" in cols
+    sql = "SELECT id, goal, record_text, outcome, answer_excerpt, created_at"
+    if has_ent:
+        sql += ", entities"
+    sql += " FROM experiences WHERE user_id = ? ORDER BY created_at DESC LIMIT ?"
+    try:
+        rows = exp_conn.execute(sql, (uid, _MAX_EXPERIENCE)).fetchall()
+    except Exception as ex:
+        log.debug("experience layer query failed: %s", ex)
+        if owns:
+            try:
+                exp_conn.close()
+            except Exception:
+                pass
+        return
+
+    mem_ents: dict[str, set[str]] = {}
+    for e in edges:
+        if e.get("type") == "mentions":
+            mid, eid = e.get("source"), e.get("target")
+            if mid in mem_ids and isinstance(eid, str) and eid.startswith("ent:"):
+                mem_ents.setdefault(str(mid), set()).add(eid.removeprefix("ent:").casefold())
+
+    try:
+        for row in rows:
+            xid = f"exp:{row['id']}"
+            text = (row["record_text"] or row["goal"] or row["answer_excerpt"] or "").strip()
+            goal = (row["goal"] or text)[:72]
+            label = goal + ("…" if len(goal) >= 72 else "")
+            ents = _entities_from_raw(row["entities"]) if has_ent else []
+            nodes.append({
+                "id": xid,
+                "type": "experience",
+                "label": label,
+                "text": text,
+                "status": "active",
+                "kind": "experience",
+                "source": "experiences",
+                "pinned": False,
+                "access_count": 0,
+                "created_at": row["created_at"] if "created_at" in row.keys() else None,
+                "entities": ents,
+                "supersedes_id": None,
+                "valence_tag": "neutral",
+                "outcome": row["outcome"] if "outcome" in row.keys() else "",
+                "scores": {
+                    "retain": 0.5, "salience": 0.35, "spacing": 0.0,
+                    "connectivity": 0.0, "valence": 0.25, "access": 0.0,
+                },
+                "size": 0.42,
+            })
+            for ent in ents:
+                eid = f"ent:{ent}"
+                if eid not in entity_ids:
+                    entity_ids.add(eid)
+                    nodes.append({
+                        "id": eid,
+                        "type": "entity",
+                        "label": ent,
+                        "text": ent,
+                        "status": "active",
+                        "kind": "entity",
+                        "source": "",
+                        "pinned": False,
+                        "access_count": 0,
+                        "created_at": None,
+                        "entities": [],
+                        "supersedes_id": None,
+                        "valence_tag": "neutral",
+                        "scores": {
+                            "retain": 0.3, "importance": 0.3, "salience": 0.0,
+                            "spacing": 0.0, "connectivity": 0.3, "valence": 0.25, "access": 0.0,
+                        },
+                        "size": 0.35,
+                    })
+                edges.append({
+                    "id": f"about:{xid}->{eid}",
+                    "source": xid,
+                    "target": eid,
+                    "type": "about",
+                    "weight": 1.0,
+                })
+                ent_cf = ent.casefold()
+                for mid, mes in mem_ents.items():
+                    if ent_cf in mes:
+                        edges.append({
+                            "id": f"practiced:{mid}->{xid}",
+                            "source": mid,
+                            "target": xid,
+                            "type": "practiced_in",
+                            "weight": 1.0,
+                        })
+    finally:
+        if owns and exp_conn is not None:
+            try:
+                exp_conn.close()
+            except Exception:
+                pass

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -28,20 +28,6 @@ _SPACING_SAT = max(1, int(os.getenv("MONTHLY_CONSOLIDATION_SPACING_SATURATION", 
 _DAILY_RE = re.compile(r"^\[\d{4}-\d{2}-\d{2}\]\s")
 _MONTHLY_RE = re.compile(r"^\[\d{4}-\d{2}\]\s")
 
-def _env_int(name: str, default: int, *, floor: int = 0) -> int:
-    raw = os.getenv(name)
-    if raw is None or str(raw).strip() == "":
-        return max(floor, default)
-    try:
-        return max(floor, int(str(raw).strip()))
-    except (TypeError, ValueError):
-        log.warning("Invalid %s=%r; using default %s", name, raw, default)
-        return max(floor, default)
-
-_MAX_MEMORIES = _env_int("MEMORY_STUDIO_MAX_MEMORIES", 400, floor=1)
-_MAX_ENTITIES = _env_int("MEMORY_STUDIO_MAX_ENTITIES", 120, floor=0)
-_MAX_EDGES = _env_int("MEMORY_STUDIO_MAX_EDGES", 200, floor=0)
-
 
 def _entities_from_raw(raw: Any) -> list[str]:
     if raw is None or raw == "":
@@ -247,34 +233,24 @@ def export_memory_graph(
         params: list[Any] = [uid]
         if has_status and not include_history:
             sql += " AND (status = 'active' OR status IS NULL)"
-            
-        try:
-            req_limit = int(limit) if limit is not None else 200
-        except (TypeError, ValueError):
-            req_limit = 200
-        if req_limit < 1:
-            req_limit = 200
-        effective_limit = min(req_limit, _MAX_MEMORIES)
-        # Over-fetch so retain ranking can prefer strong older rows in a wider window
-        fetch_n = min(max(effective_limit * 3, effective_limit), max(_MAX_MEMORIES * 3, effective_limit))
-
         sql += " ORDER BY created_at DESC"
-        if fetch_n > 0:
+        if limit and limit > 0:
             sql += " LIMIT ?"
-            params.append(int(fetch_n))
+            params.append(int(limit))
 
         rows = conn.execute(sql, params).fetchall()
 
         entity_importance: dict[str, float] = {}
         try:
             from memory.entity_importance import compute_entity_importance_map
-            from types import SimpleNamespace
-
-            # Reuse export conn + uid (no new AikoMemorize / write worker).
-            entity_importance = compute_entity_importance_map(
-                SimpleNamespace(_conn=conn, _db_lock=None),
-                uid,
-            ) or {}
+            # Prefer map from memorize if available; else empty
+            entity_importance = {}
+            try:
+                from memory.memorize import AikoMemorize
+                mem = AikoMemorize(silent=True)
+                entity_importance = compute_entity_importance_map(mem, uid) or {}
+            except Exception:
+                entity_importance = {}
         except Exception as ex:
             log.debug("graph_export: I_e map skipped: %s", ex)
 
@@ -396,7 +372,7 @@ def export_memory_graph(
 
                 ensure_entity_relations_schema(conn)
                 for e in relations_as_graph_edges(
-                    conn, user_id=uid, limit=max(int(fetch_n) * 2, 500)
+                    conn, user_id=uid, limit=max(int(limit) * 2, 500)
                 ):
                     for endpoint in (e["source"], e["target"]):
                         if endpoint not in entity_ids and endpoint not in mem_ids:
@@ -432,39 +408,18 @@ def export_memory_graph(
             except Exception as ex:
                 log.debug("graph_export: entity_relations skipped: %s", ex)
 
-        mem_nodes = [n for n in nodes if n.get("type") == "memory"]
-        ent_nodes = [n for n in nodes if n.get("type") == "entity"]
-        mem_nodes.sort(
-            key=lambda n: float((n.get("scores") or {}).get("retain") or n.get("size") or 0),
-            reverse=True,
-        )
-        # Prefer high retain among the over-fetched window
-        mem_nodes = mem_nodes[:effective_limit]
-        ent_nodes.sort(key=lambda n: float(n.get("size") or 0), reverse=True)
-        ent_nodes = ent_nodes[:_MAX_ENTITIES]
-        keep_ids = {n["id"] for n in mem_nodes} | {n["id"] for n in ent_nodes}
-        nodes = mem_nodes + ent_nodes
-        edges = [e for e in edges if e.get("source") in keep_ids and e.get("target") in keep_ids]
-        edges.sort(
-            key=lambda e: (0 if e.get("type") == "supersedes" else 1, -float(e.get("weight") or 0)),
-        )
-        edges = edges[:_MAX_EDGES]
-        
         return {
             "nodes": nodes,
             "edges": edges,
             "meta": {
                 "user_id": uid,
-                "memory_count": len(mem_nodes),
-                "entity_count": len(ent_nodes),
+                "memory_count": len(mem_ids),
+                "entity_count": len(entity_ids),
                 "edge_count": len(edges),
                 "include_history": include_history,
                 "include_entities": include_entities,
                 "limit": limit,
                 "theme": "galaxy",
-                "max_memories": _MAX_MEMORIES,
-                "max_entities": _MAX_ENTITIES,
-                "max_edges": _MAX_EDGES,
             },
             "legend": _legend(),
         }

--- a/interface/webui/studio/memory/frontend/index.html
+++ b/interface/webui/studio/memory/frontend/index.html
@@ -123,6 +123,12 @@
       <label>Limit <input type="number" id="limit" value="200" min="1" max="2000" /></label>
       <label><input type="checkbox" id="include-history" checked /> Include superseded</label>
       <label><input type="checkbox" id="include-entities" checked /> Entity hubs</label>
+      <label><input type="checkbox" id="include-knowledge" checked /> Knowledge</label>
+      <label><input type="checkbox" id="include-experience" checked /> Experience</label>
+      <label><input type="checkbox" id="layer-memory" checked /> Show memory</label>
+      <label><input type="checkbox" id="layer-entity" checked /> Show entities</label>
+      <label><input type="checkbox" id="layer-knowledge" checked /> Show knowledge</label>
+      <label><input type="checkbox" id="layer-experience" checked /> Show experience</label>
       <label>Status
         <select id="filter-status">
           <option value="all">all</option>
@@ -160,6 +166,8 @@
       <div class="legend">
         <span><i style="background:var(--orange);border-radius:0;height:3px;width:14px"></i>supersedes</span>
         <span><i style="background:#3de0ff55"></i>synapse</span>
+        <span><i style="background:#4ade80"></i>knowledge</span>
+        <span><i style="background:#fb923c"></i>experience</span>
         <span>brighter / larger → tends to stay</span>
       </div>
       <div class="zoom">
@@ -200,6 +208,8 @@
       p.set('limit', document.getElementById('limit').value || '200');
       p.set('include_history', document.getElementById('include-history').checked);
       p.set('include_entities', document.getElementById('include-entities').checked);
+      p.set('include_knowledge', document.getElementById('include-knowledge').checked);
+      p.set('include_experience', document.getElementById('include-experience').checked);
       return p.toString();
     }
 
@@ -210,7 +220,7 @@
         graph = await resp.json();
         const m = graph.meta || {};
         document.getElementById('stats').innerHTML =
-          `neurons: ${m.memory_count ?? 0}<br/>entities: ${m.entity_count ?? 0}<br/>synapses: ${m.edge_count ?? 0}`;
+          `neurons: ${m.memory_count ?? 0}<br/>entities: ${m.entity_count ?? 0}<br/>knowledge: ${(graph.nodes||[]).filter(n=>n.type==='knowledge').length}<br/>experience: ${(graph.nodes||[]).filter(n=>n.type==='experience').length}<br/>synapses: ${m.edge_count ?? 0}`;
         document.getElementById('status').textContent =
           `${(graph.nodes||[]).length} nodes · ${(graph.edges||[]).length} edges`;
         await getCurrentUser();
@@ -368,6 +378,10 @@
       const val = document.getElementById('filter-valence')?.value || 'all';
       const minR = parseFloat(document.getElementById('filter-min-retain')?.value || '0') || 0;
       const entQ = (document.getElementById('filter-entity')?.value || '').trim().toLowerCase();
+      const showMem = document.getElementById('layer-memory')?.checked !== false;
+      const showEnt = document.getElementById('layer-entity')?.checked !== false;
+      const showKb = document.getElementById('layer-knowledge')?.checked !== false;
+      const showExp = document.getElementById('layer-experience')?.checked !== false;
 
       let nodes = (graph.nodes || []).map(n => ({ ...n })).filter(d => {
         if (d.type === 'entity') return false;
@@ -384,12 +398,21 @@
       for (const e of (graph.edges || [])) {
         if (e.type === 'mentions' && keep.has(e.source)) keep.add(e.target);
       }
+      // Add knowledge / experience nodes when their layers are on
+      for (const n of (graph.nodes || [])) {
+        if (n.type === 'knowledge' && showKb) keep.add(n.id);
+        if (n.type === 'experience' && showExp) keep.add(n.id);
+      }
       nodes = (graph.nodes || []).map(n => ({ ...n })).filter(n => {
         if (!keep.has(n.id)) return false;
+        if (n.type === 'memory' && !showMem) return false;
         if (n.type === 'entity') {
+          if (!showEnt) return false;
           if (entQ && !(String(n.label || n.text || '').toLowerCase().includes(entQ))) return false;
           return true;
         }
+        if (n.type === 'knowledge') return showKb;
+        if (n.type === 'experience') return showExp;
         return true;
       });
       const keep2 = new Set(nodes.map(n => n.id));

--- a/memory/cross_store.py
+++ b/memory/cross_store.py
@@ -8,6 +8,7 @@ as secondary context.
 """
 from __future__ import annotations
 
+import html
 import os
 from typing import Any
 
@@ -18,9 +19,6 @@ log = get_logger(__name__)
 CROSS_STORE_ENABLED = os.getenv("MEMORY_CROSS_STORE_ENABLED", "1").lower() in {
     "1", "true", "yes", "on",
 }
-MAX_KNOWLEDGE = max(0, int(os.getenv("MEMORY_CROSS_STORE_MAX_KNOWLEDGE", "2")))
-MAX_EXPERIENCE = max(0, int(os.getenv("MEMORY_CROSS_STORE_MAX_EXPERIENCE", "2")))
-MIN_ENTITY_OVERLAP = max(0, int(os.getenv("MEMORY_CROSS_STORE_MIN_ENTITY_OVERLAP", "1")))
 
 
 def _env_int(name: str, default: int) -> int:
@@ -30,7 +28,6 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
-# re-read after possible load_config
 MAX_KNOWLEDGE = max(0, _env_int("MEMORY_CROSS_STORE_MAX_KNOWLEDGE", 2))
 MAX_EXPERIENCE = max(0, _env_int("MEMORY_CROSS_STORE_MAX_EXPERIENCE", 2))
 MIN_ENTITY_OVERLAP = max(0, _env_int("MEMORY_CROSS_STORE_MIN_ENTITY_OVERLAP", 1))
@@ -239,9 +236,21 @@ def format_related_blocks(
         for h in exp:
             if budget <= 0:
                 break
-            body = (h.get("text") or h.get("goal") or "")[: min(220, budget)]
-            outcome = h.get("outcome") or ""
-            line = f'  <past_task outcome="{outcome}">{body}</past_task>'
+            # Escape and truncate outcome for attribute
+            outcome_raw = h.get("outcome") or ""
+            outcome_escaped = html.escape(outcome_raw, quote=True)
+            # Reserve space for tag structure: '  <past_task outcome="">\n</past_task>'
+            # Approx 36 chars + outcome length
+            tag_overhead = 36 + len(outcome_escaped)
+            if budget <= tag_overhead:
+                break
+            # Truncate and escape body within remaining budget
+            body_raw = h.get("text") or h.get("goal") or ""
+            max_body_len = min(220, budget - tag_overhead)
+            body_truncated = body_raw[:max_body_len]
+            body_escaped = html.escape(body_truncated, quote=False)
+            # Build final line and measure actual length
+            line = f'  <past_task outcome="{outcome_escaped}">{body_escaped}</past_task>'
             lines.append(line)
             budget -= len(line)
         lines.append("</related_experience>")

--- a/memory/cross_store.py
+++ b/memory/cross_store.py
@@ -217,11 +217,15 @@ def format_related_blocks(
             "Learned notes related to the same topics (secondary; not personal facts).",
         ]
         for h in kb:
-            if budget <= 0:
+            if budget <= 40:
                 break
-            body = (h.get("text") or "")[: min(220, budget)]
-            title = (h.get("title") or "")[:80]
+            title = html.escape((h.get("title") or "")[:80], quote=True)
+            overhead = len(f'  <chunk title="{title}"></chunk>')
+            room = max(0, min(220, budget - overhead))
+            body = html.escape((h.get("text") or "")[:room], quote=False)
             line = f'  <chunk title="{title}">{body}</chunk>'
+            if len(line) > budget:
+                break
             lines.append(line)
             budget -= len(line)
         lines.append("</related_knowledge>")

--- a/memory/cross_store.py
+++ b/memory/cross_store.py
@@ -1,0 +1,250 @@
+"""
+memory/cross_store.py
+Phase 13a — link personal memory hits to related knowledge + experience.
+
+Uses existing search_knowledge / search_experience plus shared-entity overlap.
+Does not mix foreign stores into personal RRF identity; callers attach results
+as secondary context.
+"""
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from system.log import get_logger
+
+log = get_logger(__name__)
+
+CROSS_STORE_ENABLED = os.getenv("MEMORY_CROSS_STORE_ENABLED", "1").lower() in {
+    "1", "true", "yes", "on",
+}
+MAX_KNOWLEDGE = max(0, int(os.getenv("MEMORY_CROSS_STORE_MAX_KNOWLEDGE", "2")))
+MAX_EXPERIENCE = max(0, int(os.getenv("MEMORY_CROSS_STORE_MAX_EXPERIENCE", "2")))
+MIN_ENTITY_OVERLAP = max(0, int(os.getenv("MEMORY_CROSS_STORE_MIN_ENTITY_OVERLAP", "1")))
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+# re-read after possible load_config
+MAX_KNOWLEDGE = max(0, _env_int("MEMORY_CROSS_STORE_MAX_KNOWLEDGE", 2))
+MAX_EXPERIENCE = max(0, _env_int("MEMORY_CROSS_STORE_MAX_EXPERIENCE", 2))
+MIN_ENTITY_OVERLAP = max(0, _env_int("MEMORY_CROSS_STORE_MIN_ENTITY_OVERLAP", 1))
+
+
+def _entities_from_row(row: dict | Any) -> list[str]:
+    try:
+        from memory.memorize import entities_from_json
+
+        raw = None
+        if hasattr(row, "keys") and "entities" in row.keys():
+            raw = row["entities"]
+        elif isinstance(row, dict):
+            raw = row.get("entities")
+        return [e.casefold() for e in entities_from_json(raw or "[]") if e]
+    except Exception:
+        return []
+
+
+def seed_entities_from_memories(memories: list[dict], query: str = "") -> list[str]:
+    """Collect casefolded entity strings from personal memory hits (+ query)."""
+    seeds: list[str] = []
+    seen: set[str] = set()
+    for m in memories or []:
+        for e in _entities_from_row(m):
+            if e not in seen:
+                seen.add(e)
+                seeds.append(e)
+    if query:
+        try:
+            from memory.memorize import extract_entities
+
+            for e in extract_entities(query):
+                k = e.casefold()
+                if k and k not in seen:
+                    seen.add(k)
+                    seeds.append(k)
+        except Exception as exc:
+            log.debug("cross_store: extract_entities(query) skipped: %s", exc)
+    return seeds
+
+
+def _overlap_count(seed: set[str], row_entities: list[str]) -> int:
+    if not seed or not row_entities:
+        return 0
+    return sum(1 for e in row_entities if e in seed)
+
+
+def related_knowledge(
+    query: str,
+    seed_entities: list[str],
+    *,
+    user_id: str | None = None,
+    limit: int | None = None,
+    embedder=None,
+) -> list[dict]:
+    """Return up to `limit` knowledge chunks related to query / seed entities."""
+    if not CROSS_STORE_ENABLED or MAX_KNOWLEDGE <= 0:
+        return []
+    limit = MAX_KNOWLEDGE if limit is None else max(0, int(limit))
+    if limit <= 0:
+        return []
+    seed = {e.casefold() for e in (seed_entities or []) if e}
+    try:
+        from memory.knowledge import search_knowledge
+
+        hits = search_knowledge(
+            query or " ",
+            limit=max(limit * 4, 8),
+            embedder=embedder,
+            user_id=user_id,
+        )
+    except Exception as exc:
+        log.debug("cross_store: search_knowledge failed: %s", exc)
+        return []
+
+    ranked: list[tuple[int, float, dict]] = []
+    for h in hits:
+        ents = _entities_from_row(h)
+        ov = _overlap_count(seed, ents)
+        score = float(h.get("score") or h.get("recall_score") or 0.0)
+        if MIN_ENTITY_OVERLAP > 0 and seed:
+            if ov < MIN_ENTITY_OVERLAP:
+                continue
+        ranked.append((ov, score, h))
+
+    ranked.sort(key=lambda t: (-t[0], -t[1]))
+    out: list[dict] = []
+    for ov, score, h in ranked[:limit]:
+        out.append({
+            "id": h.get("id"),
+            "store": "knowledge",
+            "text": (h.get("text") or "")[:500],
+            "title": h.get("title") or "",
+            "score": score,
+            "entity_overlap": ov,
+            "entities": _entities_from_row(h),
+        })
+    return out
+
+
+def related_experience(
+    query: str,
+    seed_entities: list[str],
+    *,
+    user_id: str | None = None,
+    limit: int | None = None,
+    embedder=None,
+) -> list[dict]:
+    """Return up to `limit` past agent experiences related to query / seeds."""
+    if not CROSS_STORE_ENABLED or MAX_EXPERIENCE <= 0:
+        return []
+    limit = MAX_EXPERIENCE if limit is None else max(0, int(limit))
+    if limit <= 0:
+        return []
+    seed = {e.casefold() for e in (seed_entities or []) if e}
+    try:
+        from agentic.experience import search_experience
+
+        hits = search_experience(query or " ", limit=max(limit * 4, 8), embedder=embedder)
+    except Exception as exc:
+        log.debug("cross_store: search_experience failed: %s", exc)
+        return []
+
+    ranked: list[tuple[int, float, dict]] = []
+    for h in hits:
+        ents = _entities_from_row(h)
+        ov = _overlap_count(seed, ents)
+        score = float(h.get("recall_score") or h.get("score") or 0.0)
+        if MIN_ENTITY_OVERLAP > 0 and seed:
+            if ov < MIN_ENTITY_OVERLAP:
+                continue
+        ranked.append((ov, score, h))
+
+    ranked.sort(key=lambda t: (-t[0], -t[1]))
+    out: list[dict] = []
+    for ov, score, h in ranked[:limit]:
+        out.append({
+            "id": h.get("id"),
+            "store": "experience",
+            "text": (h.get("record_text") or h.get("goal") or h.get("answer_excerpt") or "")[:500],
+            "goal": h.get("goal") or "",
+            "outcome": h.get("outcome") or "",
+            "score": score,
+            "entity_overlap": ov,
+            "entities": _entities_from_row(h),
+        })
+    return out
+
+
+def fetch_related_for_memories(
+    query: str,
+    memories: list[dict],
+    *,
+    user_id: str | None = None,
+    embedder=None,
+) -> dict[str, list[dict]]:
+    """Convenience: seeds from memories+query → related KB + experience."""
+    if not CROSS_STORE_ENABLED:
+        return {"knowledge": [], "experience": []}
+    seeds = seed_entities_from_memories(memories, query=query)
+    return {
+        "knowledge": related_knowledge(
+            query, seeds, user_id=user_id, embedder=embedder
+        ),
+        "experience": related_experience(
+            query, seeds, user_id=user_id, embedder=embedder
+        ),
+    }
+
+
+def format_related_blocks(
+    related: dict[str, list[dict]],
+    *,
+    max_chars: int = 800,
+) -> str:
+    """XML-ish secondary context for injection after <memory_context>."""
+    if not related:
+        return ""
+    parts: list[str] = []
+    budget = max_chars
+
+    kb = related.get("knowledge") or []
+    if kb and budget > 40:
+        lines = [
+            "<related_knowledge>",
+            "Learned notes related to the same topics (secondary; not personal facts).",
+        ]
+        for h in kb:
+            if budget <= 0:
+                break
+            body = (h.get("text") or "")[: min(220, budget)]
+            title = (h.get("title") or "")[:80]
+            line = f'  <chunk title="{title}">{body}</chunk>'
+            lines.append(line)
+            budget -= len(line)
+        lines.append("</related_knowledge>")
+        parts.append("\n".join(lines))
+
+    exp = related.get("experience") or []
+    if exp and budget > 40:
+        lines = [
+            "<related_experience>",
+            "Past agent task runs on similar topics (secondary).",
+        ]
+        for h in exp:
+            if budget <= 0:
+                break
+            body = (h.get("text") or h.get("goal") or "")[: min(220, budget)]
+            outcome = h.get("outcome") or ""
+            line = f'  <past_task outcome="{outcome}">{body}</past_task>'
+            lines.append(line)
+            budget -= len(line)
+        lines.append("</related_experience>")
+        parts.append("\n".join(lines))
+
+    return "\n\n".join(parts) if parts else ""

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -367,9 +367,17 @@ MEMORY_WRITE_MAX_WAIT = float(os.getenv("MEMORY_WRITE_MAX_WAIT", 45.0))
 MEMORY_CROSS_STORE_ENABLED = os.getenv("MEMORY_CROSS_STORE_ENABLED", "1").lower() in {
     "1", "true", "yes", "on",
 }
-MEMORY_CROSS_STORE_CONTEXT_CHARS = max(
-    0, int(os.getenv("MEMORY_CROSS_STORE_CONTEXT_CHARS", "800"))
-)
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+MEMORY_CROSS_STORE_CONTEXT_CHARS = max(0, _env_int("MEMORY_CROSS_STORE_CONTEXT_CHARS", 800))
+
 
 def _default_user_id(user_id: str | None = None) -> str:
     return user_id or current_user_id()

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -364,6 +364,12 @@ MEMORY_RECENCY_RERANK_THRESHOLD = float(os.getenv("MEMORY_RECENCY_RERANK_THRESHO
 MEMORY_WRITE_IDLE_GRACE = float(os.getenv("MEMORY_WRITE_IDLE_GRACE", 3.0))
 MEMORY_WRITE_MAX_WAIT = float(os.getenv("MEMORY_WRITE_MAX_WAIT", 45.0))
 
+MEMORY_CROSS_STORE_ENABLED = os.getenv("MEMORY_CROSS_STORE_ENABLED", "1").lower() in {
+    "1", "true", "yes", "on",
+}
+MEMORY_CROSS_STORE_CONTEXT_CHARS = max(
+    0, int(os.getenv("MEMORY_CROSS_STORE_CONTEXT_CHARS", "800"))
+)
 
 def _default_user_id(user_id: str | None = None) -> str:
     return user_id or current_user_id()

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -3302,7 +3302,15 @@ class AikoMemorize:
             self._clear_search_cache()
             self._last_cache_clear_time = now
 
-    def format_for_context(self, memories: list[dict]) -> str | None:
+    def format_for_context(
+        self,
+        memories: list[dict],
+        *,
+        query: str = "",
+        related: dict | None = None,
+        user_id: str | None = None,
+        embedder=None,
+    ) -> str | None:
         """
         Format retrieved memories into a compact string for injection
         into the conversation context. Returns None if nothing to inject.
@@ -3366,6 +3374,29 @@ class AikoMemorize:
         block = "\n".join(lines)
         if len(block) > MEMORY_CONTEXT_TOTAL_CHARS:
             block = block[:MEMORY_CONTEXT_TOTAL_CHARS].rstrip() + "\n</memory_context>"
+
+        # Phase 13a: secondary related knowledge / experience
+        if MEMORY_CROSS_STORE_ENABLED and MEMORY_CROSS_STORE_CONTEXT_CHARS > 0:
+            try:
+                from memory.cross_store import fetch_related_for_memories, format_related_blocks
+
+                rel = related
+                if rel is None:
+                    rel = fetch_related_for_memories(
+                        query or "",
+                        memories,
+                        user_id=user_id or self._resolve_user_id(None),
+                        embedder=embedder,
+                    )
+                extra = format_related_blocks(
+                    rel or {},
+                    max_chars=MEMORY_CROSS_STORE_CONTEXT_CHARS,
+                )
+                if extra:
+                    block = block + "\n\n" + extra
+            except Exception as exc:
+                log.debug("cross_store context skipped: %s", exc)
+
         return block
 
     # ── dream pass ────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Phase 13 — cross-store correlation:

### 13a Recall
- After personal memory hits, attach capped related knowledge + experience
  (shared entities + existing search APIs)
- Context: secondary blocks, not mixed into personal RRF identity

### 13b Studio
- Knowledge + experience nodes and edges (entity overlap)
- Layer toggles in neural graph UI

## Files
- `memory/cross_store.py` (new)
- `memory/memorize.py`
- `config/memory.yaml`
- `interface/webui/studio/memory/backend/graph_export.py`
- `interface/webui/studio/memory/frontend/index.html`
- `interface/webui/studio/memory/backend/api.py` (optional)
- `interface/webui/studio/memory/README.md`

## Out of scope
5-pt valence, P14 human-feel, Harrier emotion, unlimited edges.

## Test plan
- [ ] Search still returns personal memories
- [ ] With KB/exp data sharing an entity, related blocks appear in context (capped)
- [ ] Studio shows knowledge/experience when toggled; hides when off
- [ ] MEMORY_CROSS_STORE_ENABLED=0 → behavior matches pre-13

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced memory recall with query-aware context formatting.
  * Added related knowledge and experience to memory context when enabled.
  * Introduced configurable limits, filtering, and context size controls.
  * Added Memory Studio graph layers and filters for knowledge and experience data.
  * Added graph visibility controls and expanded graph statistics.

* **Documentation**
  * Updated Memory Studio documentation with new graph layers, filters, and query options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->