### PR TITLE
feat(memory): 5-point valence_score (−2…+2) for decay and retention

### DIFF
--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -160,7 +160,12 @@ FORGET_GRACE_PERIOD_DAYS: "35"  # Minimum age before ordinary memories can be cl
 DREAM_MERGE_THRESHOLD: "0.94"  # Similarity threshold for merging near-duplicate memories; range 0.0-1.0.
 DREAM_BOOST_AMOUNT: "1"  # Access-count boost for memories promoted during dream/reflection.
 
+# -- Phase 12R / 14a: 5-point valence (−2…+2) --
+# Stored as memories.valence_score; valence_tag kept for legacy (pos/neg/neutral).
+# Intensity for forget = |score| / 2. Inference: emoji + lexicon + intensifiers (no LLM).
+# FORGET_INTENSITY_* still apply when only valence_tag is present (old rows).
 # -- Search ranking and context budget --
+
 MEMORY_SEARCH_CACHE_SIZE: "128"  # Max number of memory search results cached in-process.
 MEMORY_SEARCH_CACHE_TTL: "20.0"  # Seconds before cached memory search result expires.
 MEMORY_RANK_RECENCY_WEIGHT: "0.004"  # Small retrieval boost for recent memories (continuous blending, applies to every candidate).

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -78,7 +78,14 @@ def _resolve_db_path(user_id: str) -> Path:
     return resolve_user_db_path("memory/memory.db", user_id=user_id)
 
 
-def _valence_score(tag: Any) -> float:
+def _valence_score(tag: Any, score: Any = None) -> float:
+    """0..1 rim. Prefer 5-pt score when present."""
+    if score is not None and str(score).strip() != "":
+        try:
+            s = max(-2, min(2, int(score)))
+            return round(0.25 + 0.30 * abs(s), 4)
+        except (TypeError, ValueError):
+            pass
     t = (str(tag or "neutral")).strip().lower()
     if t == "neg":
         return 0.85

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -258,7 +258,7 @@ def export_memory_graph(
         if has_valence:
             select_cols.append("valence_tag")
         if has_valence_score:
-            select_cols.append("valence_score"
+            select_cols.append("valence_score")
         if has_salience:
             select_cols.append("salience_hit")
         if has_day_count:

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -78,14 +78,7 @@ def _resolve_db_path(user_id: str) -> Path:
     return resolve_user_db_path("memory/memory.db", user_id=user_id)
 
 
-def _valence_score(tag: Any, score: Any = None) -> float:
-    """0..1 rim component. Prefer 5-pt valence_score when present."""
-    if score is not None and str(score).strip() != "":
-        try:
-            s = max(-2, min(2, int(score)))
-            return round(0.25 + 0.30 * abs(s), 4)
-        except (TypeError, ValueError):
-            pass
+def _valence_score(tag: Any) -> float:
     t = (str(tag or "neutral")).strip().lower()
     if t == "neg":
         return 0.85
@@ -127,6 +120,7 @@ def _memory_scores(
     access_count: int,
     access_day_count: int,
     valence_tag: Any,
+    valence_score: Any = None,
     salience_hit: Any,
     entities: list[str],
     entity_importance: dict[str, float],
@@ -137,7 +131,7 @@ def _memory_scores(
     else:
         sal = _salience_score(text, salience_hit)
         sp = _spacing_score(access_day_count, access_count)
-        val = _valence_score(valence_tag)
+        val = _valence_score(valence_tag, valence_score)
         acc = _access_score(access_count)
         ie = 0.0
         if entities and entity_importance:
@@ -160,7 +154,7 @@ def _memory_scores(
 
     sal = _salience_score(text, salience_hit)
     sp = _spacing_score(access_day_count, access_count)
-    val = _valence_score(valence_tag)
+    val = _valence_score(valence_tag, valence_score)
     acc = _access_score(access_count)
     ie = 0.0
     if entities and entity_importance:
@@ -239,6 +233,7 @@ def export_memory_graph(
         has_source = "source" in cols
         has_supersedes = "supersedes_id" in cols
         has_valence = "valence_tag" in cols
+        has_valence_score = "valence_score" in cols
         has_salience = "salience_hit" in cols
         has_day_count = "access_day_count" in cols
 
@@ -255,6 +250,8 @@ def export_memory_graph(
             select_cols.append("supersedes_id")
         if has_valence:
             select_cols.append("valence_tag")
+        if has_valence_score:
+            select_cols.append("valence_score"
         if has_salience:
             select_cols.append("salience_hit")
         if has_day_count:
@@ -319,6 +316,12 @@ def export_memory_graph(
             valence_tag = (
                 str(row["valence_tag"]) if has_valence and row["valence_tag"] is not None else "neutral"
             )
+            valence_score = None
+            if has_valence_score and row["valence_score"] is not None:
+                try:
+                    valence_score = int(row["valence_score"])
+                except (TypeError, ValueError):
+                    valence_score = None
             salience_hit = row["salience_hit"] if has_salience else None
             access_day_count = int(row["access_day_count"] or 0) if has_day_count else 0
             access_count = int(row["access_count"] or 0)
@@ -331,6 +334,7 @@ def export_memory_graph(
                 access_count=access_count,
                 access_day_count=access_day_count,
                 valence_tag=valence_tag,
+                valence_score=valence_score,
                 salience_hit=salience_hit,
                 entities=ents,
                 entity_importance=entity_importance,
@@ -352,6 +356,7 @@ def export_memory_graph(
                 "entities": ents,
                 "supersedes_id": supersedes_id,
                 "valence_tag": valence_tag,
+                "valence_score": 0 if valence_score is None else valence_score,
                 "scores": scores,
                 "size": size,
             })

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -78,7 +78,14 @@ def _resolve_db_path(user_id: str) -> Path:
     return resolve_user_db_path("memory/memory.db", user_id=user_id)
 
 
-def _valence_score(tag: Any) -> float:
+def _valence_score(tag: Any, score: Any = None) -> float:
+    """0..1 rim component. Prefer 5-pt valence_score when present."""
+    if score is not None and str(score).strip() != "":
+        try:
+            s = max(-2, min(2, int(score)))
+            return round(0.25 + 0.30 * abs(s), 4)
+        except (TypeError, ValueError):
+            pass
     t = (str(tag or "neutral")).strip().lower()
     if t == "neg":
         return 0.85

--- a/memory/consolidate.py
+++ b/memory/consolidate.py
@@ -350,18 +350,26 @@ def _score_daily_row(
     else:
         salience = 1.0 if SALIENCE_POLICY_RE.search(text) else 0.3
 
-    v_raw = (row.get("valence_tag") or "neutral")
-    if isinstance(v_raw, str):
-        v_raw = v_raw.strip().lower()
+    vs = row.get("valence_score")
+    if vs is not None and str(vs).strip() != "":
+        try:
+            s = max(-2, min(2, int(vs)))
+            valence = 0.25 + 0.30 * abs(s)  # 0.25, 0.55, 0.85
+        except (TypeError, ValueError):
+            valence = 0.25
     else:
-        v_raw = "neutral"
-    # Intensity for retention (neg slightly stronger — Phase 5 will use for decay).
-    if v_raw == "neg":
-        valence = 0.85
-    elif v_raw == "pos":
-        valence = 0.65
-    else:
-        valence = 0.25
+        v_raw = (row.get("valence_tag") or "neutral")
+        if isinstance(v_raw, str):
+            v_raw = v_raw.strip().lower()
+        else:
+            v_raw = "neutral"
+        if v_raw == "neg":
+            valence = 0.85
+        elif v_raw == "pos":
+            valence = 0.65
+        else:
+            valence = 0.25
+
     # Phase 2: distinct recall days (access_day_count). Fallback for pre-Phase-2 rows.
     day_count = int(row.get("access_day_count") or 0)
     if day_count <= 0:

--- a/memory/consolidate.py
+++ b/memory/consolidate.py
@@ -354,10 +354,10 @@ def _score_daily_row(
     if vs is not None and str(vs).strip() != "":
         try:
             s = max(-2, min(2, int(vs)))
-            valence = 0.25 + 0.30 * abs(s)  # 0.25, 0.55, 0.85
+            valence = 0.25 + 0.30 * abs(s)
         except (TypeError, ValueError):
-            valence = 0.25
-    else:
+            vs = None
+    if vs is None or str(vs).strip() == "":
         v_raw = (row.get("valence_tag") or "neutral")
         if isinstance(v_raw, str):
             v_raw = v_raw.strip().lower()

--- a/memory/forget.py
+++ b/memory/forget.py
@@ -5,15 +5,8 @@ Ebbinghaus-style exponential decay scoring for memory lifecycle management.
 Core formula (inspired by the forgetting curve):
     weighted_score = min(access_count, ACCESS_COUNT_CAP) * 0.5^(days_since_last_access / H_eff)
 
-Where H_eff = HALF_LIFE_DAYS * (1 + γ * intensity(valence_tag))  (Phase 5).
-Neutral / missing valence keeps H_eff = HALF_LIFE_DAYS.
-
-This mirrors how biological memory consolidation works:
-  - Frequently accessed memories persist longer   (reinforced neural pathways)
-  - Unused memories naturally decay               (pruned rarely-used connections)
-  - New memories get a protection window          (working memory consolidation)
-  - Decay is gradual, not abrupt                  (unlike hard TTL which kills instantly)
-  - High emotional intensity (esp. negative) lengthens effective half-life (imprint stickiness)
+Where H_eff = HALF_LIFE_DAYS * (1 + γ * intensity(valence))  (Phase 5 + 12R).
+Intensity prefers valence_score (−2…+2) → |score|/2; falls back to valence_tag.
 
 Called by memorize.py — no I/O, pure math only.
 """
@@ -37,36 +30,41 @@ _INTENSITY = {
 }
 
 
-def _valence_intensity(valence_tag: str | None) -> float:
+def _valence_intensity(
+    valence_tag: str | None = None,
+    valence_score: int | float | None = None,
+) -> float:
+    """0..1 intensity for half-life stretch. Prefer 5-pt score when present."""
+    if valence_score is not None and str(valence_score).strip() != "":
+        try:
+            s = int(valence_score)
+            s = max(-2, min(2, s))
+            return min(1.0, abs(s) / 2.0)
+        except (TypeError, ValueError):
+            pass
     key = (valence_tag or "neutral").strip().lower()
     try:
         v = float(_INTENSITY.get(key, 0.0))
     except (TypeError, ValueError):
         return 0.0
-    if v != v or v in (float("inf"), float("-inf")):  # NaN or ±inf
+    if v != v or v in (float("inf"), float("-inf")):
         return 0.0
     return max(0.0, v)
 
-
-# ── scoring ───────────────────────────────────────────────────────────────────
 
 def compute_weighted_score(
     access_count: int,
     last_accessed_iso: str,
     valence_tag: str | None = None,
+    valence_score: int | float | None = None,
 ) -> float:
     """Compute exponential decay score for a memory entry.
 
     Score = min(access_count, cap) × 0.5^(days / H_eff)
 
-    H_eff = HALF_LIFE_DAYS × (1 + γ × intensity(valence_tag)).
-    High emotional intensity (esp. neg) decays slower — imprint-style stickiness.
+    H_eff = HALF_LIFE_DAYS × (1 + γ × intensity).
+    High emotional intensity (esp. |score|=2 / neg) decays slower.
     FORGET_EMOTION_GAMMA=0 disables emotion modification.
-
-    Timestamp parsing handles UTC, timezone-aware, naive, Z-suffix, and
-    negative-offset ISO strings via fromisoformat + tzinfo coercion.
-    On parse failure returns 0.0 so broken timestamps expire immediately
-    rather than becoming immortal zombies.
     """
     if not access_count or not last_accessed_iso or last_accessed_iso == "never":
         return 0.0
@@ -78,7 +76,7 @@ def compute_weighted_score(
             last_dt = last_dt.replace(tzinfo=timezone.utc)
         now = datetime.now(timezone.utc)
         days = max(0.0, (now - last_dt).total_seconds() / 86400.0)
-        intensity = _valence_intensity(valence_tag)
+        intensity = _valence_intensity(valence_tag, valence_score)
         h_eff = HALF_LIFE_DAYS * (1.0 + max(0.0, EMOTION_GAMMA) * intensity)
         h_eff = max(h_eff, 1e-6)
         return float(min(access_count, ACCESS_COUNT_CAP)) * (0.5 ** (days / h_eff))
@@ -87,10 +85,7 @@ def compute_weighted_score(
 
 
 def is_grace_protected(created_at_iso: str) -> bool:
-    """True while memory is inside the post-write grace window.
-
-    On parse failure returns False — unknown creation time gets no protection.
-    """
+    """True while memory is inside the post-write grace window."""
     if not created_at_iso or created_at_iso == "never":
         return False
 
@@ -106,23 +101,22 @@ def is_grace_protected(created_at_iso: str) -> bool:
         return False
 
 
-# ── lifecycle gate ─────────────────────────────────────────────────────────────
-
 def should_cleanup(
     access_count: int,
     last_accessed_iso: str,
     created_at_iso: str,
     valence_tag: str | None = None,
+    valence_score: int | float | None = None,
 ) -> bool:
-    """Return True if a memory is a deletion candidate.
-
-    A memory is prunable only when both conditions hold:
-      1. Grace period has expired    (age > GRACE_PERIOD_DAYS)
-      2. Decay score is below threshold (weighted_score < CLEANUP_THRESHOLD)
-
-    Called per-memory inside memorize.cleanup() and memorize.dream() prune stage.
-    """
+    """Return True if a memory is a deletion candidate."""
     if is_grace_protected(created_at_iso):
         return False
-
-    return compute_weighted_score(access_count, last_accessed_iso, valence_tag) < CLEANUP_THRESHOLD
+    return (
+        compute_weighted_score(
+            access_count,
+            last_accessed_iso,
+            valence_tag=valence_tag,
+            valence_score=valence_score,
+        )
+        < CLEANUP_THRESHOLD
+    )

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -1424,9 +1424,23 @@ class _MemoryBackend:
         ents_list = entities if entities is not None else extract_entities(text)
         ents_json = entities_to_json(ents_list)
 
-        v_tag = valence_tag if valence_tag in ("pos", "neg", "neutral") else infer_valence_tag(text)
-        s_hit = int(salience_hit) if salience_hit is not None else infer_salience_hit(text)
-        s_hit = 1 if s_hit else 0
+        if valence_score is not None:
+            try:
+                v_score = max(-2, min(2, int(valence_score)))
+            except (TypeError, ValueError):
+                v_score = infer_valence_score(text)
+        else:
+            v_score = infer_valence_score(text)
+          
+        v_tag = (
+            valence_tag
+            if valence_tag in ("pos", "neg", "neutral")
+            else tag_from_score(v_score)
+        )
+        if valence_tag is None:
+            v_tag = tag_from_score(v_score)
+          
+        s_hit = 1 if (int(salience_hit) if salience_hit is not None else infer_salience_hit(text)) else 0
       
         base_cols = ["id", "user_id", "memory", "created_at", "access_count", "last_accessed_at", "pinned"]
         base_vals: list[Any] = [mem_id, user_id, text, now, 0, "never", pinned]
@@ -1441,6 +1455,9 @@ class _MemoryBackend:
         if "valence_tag" in cols:
             ext_cols.append("valence_tag")
             ext_vals.append(v_tag)
+        if "valence_score" in cols:
+            ext_cols.append("valence_score")
+            ext_vals.append(int(v_score))
         if "salience_hit" in cols:
             ext_cols.append("salience_hit")
             ext_vals.append(s_hit)

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -1409,6 +1409,7 @@ class _MemoryBackend:
         entities: list[str] | None = None,
         scene_id: str | None = None,
         valence_tag: str | None = None,
+        valence_score: int | None = None,
         salience_hit: int | None = None,
     ) -> None:
         """Insert one memory row (Phase A + L2 columns when present) + its

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -572,7 +572,7 @@ _PHASE_A_COLUMNS: tuple[tuple[str, str], ...] = (
     ("access_day_count", "INTEGER NOT NULL DEFAULT 0"),
   # Phase 4: turn-level emotion / salience tags (cheap, no LLM).
     ("valence_tag", "TEXT NOT NULL DEFAULT 'neutral'"),
-    ("valence_score", "INTEGER NOT NULL DEFAULT 0"),  # Phase 12R: −2…+2
+    ("valence_score", "INTEGER"),  # -2..+2; NULL = legacy/unknown
     ("salience_hit", "INTEGER NOT NULL DEFAULT 0"),
 )
 

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -1575,11 +1575,8 @@ class _MemoryBackend:
                     )[-400:]
                     tag_src = f"{fact}\n{assist_blob}"
                     v_score = infer_valence_score(tag_src)
-                    v_tag = infer_valence_tag(tag_src)
-                    valence_tag=tag_from_score(v_score),
-                    valence_score=v_score,
                     s_hit = max(infer_salience_hit(fact), infer_salience_hit(assist_blob))
-                  
+
                     self._insert_row(
                         mem_id=mem_id,
                         user_id=user_id,
@@ -1589,7 +1586,8 @@ class _MemoryBackend:
                         pinned=0,
                         source=SOURCE_CHAT,
                         supersedes_id=supersedes_id,
-                        valence_tag=v_tag,
+                        valence_tag=tag_from_score(v_score),
+                        valence_score=v_score,
                         salience_hit=s_hit,
                     )
                     ids.append(mem_id)
@@ -3832,7 +3830,7 @@ class AikoMemorize:
                 kept += 1
                 continue
               
-            v_tag = m.get("valence_tag")v_tag = m.get("valence_tag")
+            v_tag = m.get("valence_tag")
             v_score = m.get("valence_score")
             if should_cleanup(ac, la, created_at, valence_tag=v_tag, valence_score=v_score):
                 w = compute_weighted_score(ac, la, valence_tag=v_tag, valence_score=v_score)

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -572,6 +572,7 @@ _PHASE_A_COLUMNS: tuple[tuple[str, str], ...] = (
     ("access_day_count", "INTEGER NOT NULL DEFAULT 0"),
   # Phase 4: turn-level emotion / salience tags (cheap, no LLM).
     ("valence_tag", "TEXT NOT NULL DEFAULT 'neutral'"),
+    ("valence_score", "INTEGER NOT NULL DEFAULT 0"),  # Phase 12R: −2…+2
     ("salience_hit", "INTEGER NOT NULL DEFAULT 0"),
 )
 
@@ -692,18 +693,41 @@ SALIENCE_POLICY_RE = re.compile(
     re.IGNORECASE,
 )
 
-def infer_valence_tag(text: str) -> str:
-    """Cheap pos/neg/neutral from emoji + lexicon. No LLM."""
+_VALENCE_STRONG_RE = re.compile(
+    r"\b(?:very|so|extremely|furious|devastat|ecstatic|hate this|love this|terrified|overjoyed)\b|!{2,}",
+    re.IGNORECASE,
+)
+
+def infer_valence_score(text: str) -> int:
+    """Return −2…+2 from emoji + lexicon + intensifiers. No LLM / no Harrier."""
     t = text or ""
     neg = bool(_VALENCE_NEG_RE.search(t))
     pos = bool(_VALENCE_POS_RE.search(t))
+    strong = bool(_VALENCE_STRONG_RE.search(t))
     if neg and not pos:
-        return "neg"
+        return -2 if strong else -1
     if pos and not neg:
-        return "pos"
+        return 2 if strong else 1
     if neg and pos:
-        return "neg"  # conflict → treat as emotionally loaded neg for retention
+        return -1
+    return 0
+
+
+def tag_from_score(score: int) -> str:
+    try:
+        s = int(score)
+    except (TypeError, ValueError):
+        return "neutral"
+    if s <= -1:
+        return "neg"
+    if s >= 1:
+        return "pos"
     return "neutral"
+
+
+def infer_valence_tag(text: str) -> str:
+    """Backward-compatible 3-way tag derived from 5-pt score."""
+    return tag_from_score(infer_valence_score(text))
 
 
 def infer_salience_hit(text: str) -> int:


### PR DESCRIPTION
## Summary
5-point valence_score (−2…+2) with rules+emoji inference.
- Schema + write path
- Forget intensity from |score|
- Monthly R + graph_export use score when present
- valence_tag kept for legacy rows

No LLM / Harrier emotion. No Phase 14 recall bias.

## Test plan
- [ ] New writes get valence_score ∈ {−2…+2} and matching tag
- [ ] Old DB without column still opens / forgets
- [ ] Neg strong (score −2) decays slower than neutral
- [ ] Studio still colors pos/neg/neutral

Start with schema + ```infer_valence_score``` + write path, then forget → consolidate → export. Say when pushed if you want a review.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added five-level valence scoring from strongly negative to strongly positive.
  * Memory records now retain numeric valence scores alongside compatible emotional tags.
  * Valence intensity now influences memory retention, forgetting, and graph visualization.

* **Bug Fixes**
  * Preserved existing behavior for older records using only positive, negative, or neutral tags.
  * Invalid or missing scores safely fall back to tag-based classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->