### PR TITLE
feat(memory): Phase 15 LLM valence on extract + studio size/brightness contrast

### DIFF
--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -236,3 +236,6 @@ MEMORY_STUDIO_MAX_EDGES: "200"  # Max co-mention + mention edges.
 
 # -- Phase 11: hard source-id provenance before day-pin delete --
 MONTHLY_CONSOLIDATION_HARD_SOURCE_PROVENANCE: "1"  # Require every kept day-pin id in some LLM source_ids before delete. Soft coverage still applies. 0 = soft only.
+# Phase 15
+MEMORY_VALENCE_FROM_LLM: "1"   # use extract valence_score when present
+# Studio curves live in graph_export / index.html for now

--- a/eval/eval_memory_extraction.py
+++ b/eval/eval_memory_extraction.py
@@ -214,7 +214,8 @@ def run_eval(verbose: bool = False) -> dict:
     hedge_leaks = 0
 
     for case in GOLDEN_SET:
-        extracted = backend._extract_facts(case["conversation"], display_name="Oppa")
+        pairs = backend._extract_facts(case["conversation"], display_name="Oppa")
+        extracted = [f for f, _ in pairs]
         match = _match_facts(extracted, case["expected_facts"], embed_fn)
         leaked = _contains_forbidden(extracted, case["forbidden_facts"], embed_fn)
 

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -346,7 +346,9 @@ def export_memory_graph(
                 entities=ents,
                 entity_importance=entity_importance,
             )
-            size = round(0.35 + 0.9 * scores["retain"], 4)
+            # Wider spread: weak ≈ 0.2, strong ≈ 1.3
+            r = float(scores["retain"])
+            size = round(0.20 + 1.10 * (r ** 1.25), 4)
 
             nodes.append({
                 "id": mid,

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -365,10 +365,11 @@ def export_memory_graph(
                 "entities": ents,
                 "supersedes_id": supersedes_id,
                 "valence_tag": valence_tag,
-                "valence_score": 0 if valence_score is None else valence_score,
-                "scores": scores,
-                "size": size,
-            })
+                    "valence_score": row.get("valence_score") if isinstance(row, dict)
+                                    else getattr(row, "valence_score", None),
+                    "size": size,
+                    "scores": scores,
+                })
 
             if supersedes_id:
                 edges.append({

--- a/interface/webui/studio/memory/backend/graph_export.py
+++ b/interface/webui/studio/memory/backend/graph_export.py
@@ -365,8 +365,7 @@ def export_memory_graph(
                 "entities": ents,
                 "supersedes_id": supersedes_id,
                 "valence_tag": valence_tag,
-                    "valence_score": row.get("valence_score") if isinstance(row, dict)
-                                    else getattr(row, "valence_score", None),
+                    "valence_score": valence_score,
                     "size": size,
                     "scores": scores,
                 })

--- a/interface/webui/studio/memory/frontend/index.html
+++ b/interface/webui/studio/memory/frontend/index.html
@@ -237,15 +237,23 @@
       const sc = d.scores || {};
       if (sc.retain != null) return Math.max(0, Math.min(1, Number(sc.retain)));
       if (d.size != null) {
-        // backend size ~ 0.35 + 0.9*retain → invert roughly
-        return Math.max(0, Math.min(1, (Number(d.size) - 0.25) / 0.95));
+        // backend size ≈ 0.20 + 1.10 * retain^1.25 → approximate invert
+        const s = Math.max(0.20, Number(d.size));
+        const t = Math.max(0, Math.min(1, (s - 0.20) / 1.10));
+        return Math.pow(t, 1 / 1.25);
       }
       return d.type === 'entity' ? 0.4 : 0.35;
     }
 
     function valenceHue(d) {
       if (d.type === 'entity') return 'entity';
-      const v = (d.valence_tag || 'neutral').toLowerCase();
+      let v = (d.valence_tag || 'neutral').toLowerCase();
+      const vs = d.valence_score;
+      if ((v === 'neutral' || !v) && vs != null && vs !== '') {
+        const s = Number(vs);
+        if (s <= -1) v = 'neg';
+        else if (s >= 1) v = 'pos';
+      }
       if (v === 'neg') return 'neg';
       if (v === 'pos') return 'pos';
       return 'neutral';
@@ -264,21 +272,21 @@
       if (d.pinned) r = Math.max(r, 0.92);
       if (d.status === 'superseded') r *= 0.45;
       // map retain → visible opacity range (dim forget ↔ bright stay)
-      return 0.22 + r * 0.78;
+      return 0.18 + r * 0.82;
     }
 
     function glowStrength(d) {
       let r = retainOf(d);
       if (d.pinned) r = Math.max(r, 0.95);
       if (d.status === 'superseded') return 0.5;
-      return 0.6 + r * 2.4; // stdDeviation-ish via filter scale
+      return 0.4 + r * 2.8; // stdDeviation-ish via filter scale
     }
 
     function nodeRadius(d) {
       let r = retainOf(d);
       if (d.pinned) r = Math.max(r, 0.85);
-      if (d.type === 'entity') return 7 + r * 10;
-      return 9 + r * 14;
+      if (d.type === 'entity') return 5 + 16 * Math.pow(r, 1.25);
+      return 5 + 24 * Math.pow(r, 1.35);
     }
 
     function edgeOpacity(e, nodeById) {

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -1432,9 +1432,10 @@ class _MemoryBackend:
         else:
             v_score = infer_valence_score(text)
 
-        v_tag = tag_from_score(v_score)
-
-        if valence_tag is None:
+        # Prefer explicit tag only if caller passed one; else derive from score
+        if valence_tag is not None:
+            v_tag = valence_tag
+        else:
             v_tag = tag_from_score(v_score)
         s_hit = int(salience_hit) if salience_hit is not None else infer_salience_hit(text)
         s_hit = 1 if s_hit else 0

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -1420,7 +1420,10 @@ class _MemoryBackend:
                 if t:
                     pairs.append((t, None))
             elif isinstance(x, dict):
-                t = (x.get("fact") or x.get("text") or "").strip()
+                raw_fact = x.get("fact") or x.get("text") or ""
+                if not isinstance(raw_fact, str):
+                    continue
+                t = raw_fact.strip()
                 sc = x.get("valence_score", x.get("valence"))
                 try:
                     sc_i = max(-2, min(2, int(sc))) if sc is not None else None
@@ -1593,6 +1596,12 @@ class _MemoryBackend:
             vectors = self._embed_batch(facts)
         except Exception as e:
             log.warning("Batch embedding failed, aborting write: %s", e)
+            return []
+        if len(vectors) != len(pairs):
+            log.warning(
+                "Batch embedding count mismatch: %d facts, %d vectors; aborting write",
+                len(pairs), len(vectors),
+            )
             return []
 
         with self._db_lock:

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -1585,8 +1585,8 @@ class _MemoryBackend:
                         pinned=0,
                         source=SOURCE_CHAT,
                         supersedes_id=supersedes_id,
-                        valence_tag=v_tag,
-                        valence_score=v_score,
+                        llm_score=v_score,
+                        valence_tag=None,
                         salience_hit=s_hit,
                     )
                     ids.append(mem_id)

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -499,6 +499,17 @@ _HEDGE_RE = re.compile(
     re.IGNORECASE,
 )
 
+
+def _valence_from_llm() -> bool:
+    """Whether extract-provided valence_score overrides lexical inference.
+
+    Read from the same env/yaml source as the other MEMORY_* keys. Defaults
+    to ON (matches MEMORY_VALENCE_FROM_LLM: "1" in config/memory.yaml).
+    """
+    import os
+    return os.getenv("MEMORY_VALENCE_FROM_LLM", "1").strip().lower() not in ("0", "false", "no", "off")
+
+
 # Extraction prompt — temperature 0.0, explicit only-stated-facts rule.
 _EXTRACT_PROMPT = """\
 Extract memorable facts about {user_name} from this conversation.
@@ -517,10 +528,10 @@ valence_score is -2..+2 (user feeling: -2 strong neg … 0 neutral/technical …
 Use 0 when there is no clear emotion.
 
 Good examples:
-["{user_name}'s birthday is June 3", "{user_name} is building a robot called GRACE", "{user_name} joined the Hugging Face Hackathon", "{user_name} lost his wallet", "{user_name} has a deadline on Friday", "{user_name} dislikes mushrooms"]
+[{"fact": "{user_name}'s birthday is June 3", "valence_score": 0}, {"fact": "{user_name} is building a robot called GRACE", "valence_score": 1}, {"fact": "{user_name} joined the Hugging Face Hackathon", "valence_score": 1}, {"fact": "{user_name} lost his wallet", "valence_score": -2}, {"fact": "{user_name} has a deadline on Friday", "valence_score": -1}, {"fact": "{user_name} dislikes mushrooms", "valence_score": -1}]
 
 Bad examples (do not produce these):
-["{user_name} might like cats", "It seems {user_name} is tired", "Aiko should remember this"]
+[{"fact": "{user_name} might like cats", "valence_score": 0}, {"fact": "It seems {user_name} is tired", "valence_score": 0}, {"fact": "Aiko should remember this", "valence_score": 0}]
 
 Conversation:
 {conversation}"""
@@ -1269,9 +1280,14 @@ class _MemoryBackend:
         )
         return total >= _EXTRACT_MIN_CHARS
 
-    def _extract_facts(self, messages: list[dict], display_name: str | None = None) -> list[str]:
+    def _extract_facts(self, messages: list[dict], display_name: str | None = None) -> list[tuple[str, int | None]]:
         """
         Send conversation to the OpenAI-compatible local LLM and parse the returned JSON fact array.
+
+        Returns a list of (fact, valence_score) pairs in which each fact is a
+        cleaned short string and valence_score is the model-provided −2..+2
+        value (None when the source was a legacy string item or carried no
+        usable score).
 
         Changes from original:
           - temperature=0.0 for deterministic output — reduces confabulation.
@@ -1284,6 +1300,9 @@ class _MemoryBackend:
             remember the server doesn't support it for the rest of this
             instance's life, so we stop paying for a failing attempt every
             turn.
+          - Parser accepts both legacy string items and the newer
+            {"fact": ..., "valence_score": ...} object items, so an old model
+            output or a mixed array never crashes the write path.
         """
         if not self._should_extract(messages):
             return []
@@ -1331,7 +1350,17 @@ class _MemoryBackend:
                 "type": "json_schema",
                 "json_schema": {
                     "name": "facts",
-                    "schema": {"type": "array", "items": {"type": "string"}},
+                    "schema": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "fact": {"type": "string"},
+                                "valence_score": {"type": "integer"},
+                            },
+                            "required": ["fact"],
+                        },
+                    },
                 },
             }
         }
@@ -1376,24 +1405,40 @@ class _MemoryBackend:
         # fences or add a preamble, so salvage the first top-level JSON
         # array before parsing.
         try:
-            facts = json.loads(raw if used_schema else (_first_json_array(raw) or raw))
-            if isinstance(facts, list):
-                facts = [f.strip() for f in facts if isinstance(f, str) and f.strip()]
-            else:
+            parsed = json.loads(raw if used_schema else (_first_json_array(raw) or raw))
+            if not isinstance(parsed, list):
                 return []
         except json.JSONDecodeError:
             log.warning(f"Failed to parse extraction JSON: {raw[:200]!r}")
             return []
 
-        # drop facts containing hedging/uncertain language (word-boundary match)
-        clean_facts = []
-        for fact in facts:
+        # Normalise legacy string items and newer object items into pairs.
+        pairs: list[tuple[str, int | None]] = []
+        for x in parsed:
+            if isinstance(x, str):
+                t = x.strip()
+                if t:
+                    pairs.append((t, None))
+            elif isinstance(x, dict):
+                t = (x.get("fact") or x.get("text") or "").strip()
+                sc = x.get("valence_score", x.get("valence"))
+                try:
+                    sc_i = max(-2, min(2, int(sc))) if sc is not None else None
+                except (TypeError, ValueError):
+                    sc_i = None
+                if t:
+                    pairs.append((t, sc_i))
+
+        # drop facts containing hedging/uncertain language (word-boundary
+        # match); drop the paired score alongside the dropped fact
+        clean_pairs = []
+        for fact, sc in pairs:
             if _HEDGE_RE.search(fact):
                 log.debug(f"Dropped hedging fact: {fact!r}")
                 continue
-            clean_facts.append(fact)
+            clean_pairs.append((fact, sc))
 
-        return clean_facts
+        return clean_pairs
 
     # ── write ─────────────────────────────────────────────────────────────────
 
@@ -1530,9 +1575,10 @@ class _MemoryBackend:
 
         Returns list of new memory IDs. Empty list if nothing extracted.
         """
-        facts = self._extract_facts(messages, display_name=display_name)
-        if not facts:
+        pairs = self._extract_facts(messages, display_name=display_name)
+        if not pairs:
             return []
+        facts = [f for f, _ in pairs]
 
         # created_at is UTC everywhere (matches add_raw()/_touch_memories()/
         # pin()) — see the class docstring's "Fixes applied" note. Mixing
@@ -1551,7 +1597,7 @@ class _MemoryBackend:
 
         with self._db_lock:
             try:
-                for fact, vector in zip(facts, vectors):
+                for (fact, llm_sc), vector in zip(pairs, vectors):
                     op, supersedes_id = self._maybe_supersede_neighbor(user_id, vector, fact)
                     if op == "noop":
                         log.debug("Skipping near-duplicate fact: %r", fact)
@@ -1588,7 +1634,7 @@ class _MemoryBackend:
                         pinned=0,
                         source=SOURCE_CHAT,
                         supersedes_id=supersedes_id,
-                        llm_score=v_score,
+                        llm_score=llm_sc if (_valence_from_llm() and llm_sc is not None) else v_score,
                         valence_tag=None,
                         salience_hit=s_hit,
                     )

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -511,7 +511,10 @@ Rules:
 - No uncertain language: never use might, probably, seems, maybe, perhaps, appears.
 - If nothing is worth remembering, return: []
 
-Return ONLY a JSON array of short strings. No markdown. No explanation.
+Return ONLY a JSON array of objects. No markdown. No explanation.
+Each object: {"fact": "<one short self-contained sentence>", "valence_score": <int>}
+valence_score is -2..+2 (user feeling: -2 strong neg … 0 neutral/technical … +2 strong pos).
+Use 0 when there is no clear emotion.
 
 Good examples:
 ["{user_name}'s birthday is June 3", "{user_name} is building a robot called GRACE", "{user_name} joined the Hugging Face Hackathon", "{user_name} lost his wallet", "{user_name} has a deadline on Friday", "{user_name} dislikes mushrooms"]

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -1424,18 +1424,16 @@ class _MemoryBackend:
         ents_list = entities if entities is not None else extract_entities(text)
         ents_json = entities_to_json(ents_list)
 
-        if valence_score is not None:
+        if llm_score is not None:
             try:
-                v_score = max(-2, min(2, int(valence_score)))
+                v_score = max(-2, min(2, int(llm_score)))
             except (TypeError, ValueError):
                 v_score = infer_valence_score(text)
         else:
             v_score = infer_valence_score(text)
-        v_tag = (
-            valence_tag
-            if valence_tag in ("pos", "neg", "neutral")
-            else tag_from_score(v_score)
-        )
+
+        v_tag = tag_from_score(v_score)
+
         if valence_tag is None:
             v_tag = tag_from_score(v_score)
         s_hit = int(salience_hit) if salience_hit is not None else infer_salience_hit(text)
@@ -1586,7 +1584,7 @@ class _MemoryBackend:
                         pinned=0,
                         source=SOURCE_CHAT,
                         supersedes_id=supersedes_id,
-                        valence_tag=tag_from_score(v_score),
+                        valence_tag=v_tag,
                         valence_score=v_score,
                         salience_hit=s_hit,
                     )

--- a/memory/memorize.py
+++ b/memory/memorize.py
@@ -1457,7 +1457,7 @@ class _MemoryBackend:
         entities: list[str] | None = None,
         scene_id: str | None = None,
         valence_tag: str | None = None,
-        valence_score: int | None = None,
+        llm_score: int | None = None,
         salience_hit: int | None = None,
     ) -> None:
         """Insert one memory row (Phase A + L2 columns when present) + its

--- a/tests/unit/test_memorize.py
+++ b/tests/unit/test_memorize.py
@@ -1070,7 +1070,7 @@ class TestCrossStoreUserScoping:
         conn1.execute(
             "INSERT INTO experiences(id,user_id,goal,record_text,steps_json,outcome,score,answer_excerpt,entities,created_at) "
             "VALUES(?,?,?,?,?,?,?,?,?,?)",
-            (exp_id, "user1", "user1 task", "test record", '[]', "done", 1.0, "excerpt", '[]', "2024-01-01T00:00:00")
+            (exp_id, "user1", "user1 task", "user1 task", '[]', "done", 1.0, "excerpt", '[]', "2024-01-01T00:00:00")
         )
         conn1.execute(
             "INSERT INTO experiences_vec(id,embedding) VALUES(?,?)",
@@ -1078,7 +1078,7 @@ class TestCrossStoreUserScoping:
         )
         conn1.execute(
             "INSERT INTO experiences_fts(rowid, record_text, id) VALUES(?,?,?)",
-            (1, "test record", exp_id)
+            (1, "user1 task", exp_id)
         )
         conn1.commit()
         conn1.close()

--- a/tests/unit/test_memorize.py
+++ b/tests/unit/test_memorize.py
@@ -1054,7 +1054,8 @@ class TestCrossStoreUserScoping:
                 h = hashlib.sha256(t.encode()).digest()
                 raw = (h * (640 // len(h) + 1))[:2560]
                 arr = np.frombuffer(raw, dtype=np.uint8).astype(np.float32)[:640]/255.0*2-1
-                n = np.linalg.norm(arr); return arr/n if n else arr
+                n = np.linalg.norm(arr)
+                return arr / n if n else arr
 
         fe = FE()
         exp_id = str(uuid.uuid4())

--- a/tests/unit/test_memorize.py
+++ b/tests/unit/test_memorize.py
@@ -1043,16 +1043,14 @@ class TestCrossStoreUserScoping:
     """Cross-store experience leg should respect explicit user_id."""
 
     def test_search_experience_threads_user_id(self, tmp_path):
-        db = tmp_path / "exp.db"
-        from agentic.experience import _connect as exp_connect, search_experience, record_experience
+        from agentic.experience import _connect as exp_connect, search_experience
         import numpy as np
         import hashlib
 
+        # Seed one experience for user1 directly
         conn = exp_connect("user1")
-        # Seed one experience for user1
-        record_experience(None, "user1 task", [{"tool": "test", "ok": True}], "done", True, 1.0, conn=conn)
 
-        # search_experience with explicit user_id should find it
+        # Create a matching embedder for the seeded data
         class FE:
             def embed_query(self, t, instruct=""):
                 h = hashlib.sha256(t.encode()).digest()
@@ -1060,12 +1058,31 @@ class TestCrossStoreUserScoping:
                 arr = np.frombuffer(raw, dtype=np.uint8).astype(np.float32)[:640]/255.0*2-1
                 n = np.linalg.norm(arr); return arr/n if n else arr
 
-        hits = search_experience("user1", limit=5, embedder=FE(), user_id="user1")
+        fe = FE()
+        vec = fe.embed_query("user1 task")
+        import sqlite_vec
+        conn.execute(
+            "INSERT INTO experiences(id,user_id,goal,record_text,steps_json,outcome,score,answer_excerpt,entities,created_at) "
+            "VALUES(?,?,?,?,?,?,?,?,?,?)",
+            ("exp-1", "user1", "user1 task", "test record", '[]', "done", 1.0, "excerpt", '[]', "2024-01-01T00:00:00")
+        )
+        conn.execute(
+            "INSERT INTO experiences_vec(id,embedding) VALUES(?,?)",
+            ("exp-1", sqlite_vec.serialize_float32(vec.tolist()))
+        )
+        conn.execute(
+            "INSERT INTO experiences_fts(id,goal,record_text) VALUES(?,?,?)",
+            ("exp-1", "user1 task", "test record")
+        )
+        conn.commit()
+
+        # search_experience with explicit user_id should find it
+        hits = search_experience("user1 task", limit=5, embedder=fe, user_id="user1")
         assert len(hits) >= 1
         assert hits[0]["user_id"] == "user1"
 
         # With different user_id should return empty (separate DB)
-        hits2 = search_experience("user1", limit=5, embedder=FE(), user_id="user2")
+        hits2 = search_experience("user1 task", limit=5, embedder=fe, user_id="user2")
         assert hits2 == []
 
         conn.close()

--- a/tests/unit/test_memorize.py
+++ b/tests/unit/test_memorize.py
@@ -1046,10 +1046,7 @@ class TestCrossStoreUserScoping:
         from agentic.experience import _connect as exp_connect, search_experience
         import numpy as np
         import hashlib
-
-        # Use unique DB paths per user
-        db1 = tmp_path / "exp_user1.db"
-        db2 = tmp_path / "exp_user2.db"
+        import uuid
 
         # Create a matching embedder for the seeded data
         class FE:
@@ -1060,6 +1057,7 @@ class TestCrossStoreUserScoping:
                 n = np.linalg.norm(arr); return arr/n if n else arr
 
         fe = FE()
+        exp_id = str(uuid.uuid4())
         vec = fe.embed_query("user1 task")
         import sqlite_vec
 
@@ -1068,15 +1066,15 @@ class TestCrossStoreUserScoping:
         conn1.execute(
             "INSERT INTO experiences(id,user_id,goal,record_text,steps_json,outcome,score,answer_excerpt,entities,created_at) "
             "VALUES(?,?,?,?,?,?,?,?,?,?)",
-            ("exp-1", "user1", "user1 task", "test record", '[]', "done", 1.0, "excerpt", '[]', "2024-01-01T00:00:00")
+            (exp_id, "user1", "user1 task", "test record", '[]', "done", 1.0, "excerpt", '[]', "2024-01-01T00:00:00")
         )
         conn1.execute(
             "INSERT INTO experiences_vec(id,embedding) VALUES(?,?)",
-            ("exp-1", sqlite_vec.serialize_float32(vec.tolist()))
+            (exp_id, sqlite_vec.serialize_float32(vec.tolist()))
         )
         conn1.execute(
             "INSERT INTO experiences_fts(id,goal,record_text) VALUES(?,?,?)",
-            ("exp-1", "user1 task", "test record")
+            (exp_id, "user1 task", "test record")
         )
         conn1.commit()
         conn1.close()

--- a/tests/unit/test_memorize.py
+++ b/tests/unit/test_memorize.py
@@ -1042,11 +1042,14 @@ class TestValenceColumnsInIterAll:
 class TestCrossStoreUserScoping:
     """Cross-store experience leg should respect explicit user_id."""
 
-    def test_search_experience_threads_user_id(self, tmp_path):
+    def test_search_experience_threads_user_id(self, tmp_path, monkeypatch):
         from agentic.experience import _connect as exp_connect, search_experience
+        import agentic.experience as exp_mod
         import numpy as np
         import hashlib
         import uuid
+
+        monkeypatch.setattr(exp_mod, "EXPERIENCE_DB_PATH", str(tmp_path / "experience_test.db"))
 
         # Create a matching embedder for the seeded data
         class FE:
@@ -1082,8 +1085,7 @@ class TestCrossStoreUserScoping:
 
         # search_experience with explicit user_id should find it
         hits = search_experience("user1 task", limit=5, embedder=fe, user_id="user1")
-        assert len(hits) >= 1
-        assert hits[0]["user_id"] == "user1"
+        assert any(hit["id"] == exp_id for hit in hits)
 
         # With different user_id should return empty (separate DB)
         hits2 = search_experience("user1 task", limit=5, embedder=fe, user_id="user2")

--- a/tests/unit/test_memorize.py
+++ b/tests/unit/test_memorize.py
@@ -1047,8 +1047,9 @@ class TestCrossStoreUserScoping:
         import numpy as np
         import hashlib
 
-        # Seed one experience for user1 directly
-        conn = exp_connect("user1")
+        # Use unique DB paths per user
+        db1 = tmp_path / "exp_user1.db"
+        db2 = tmp_path / "exp_user2.db"
 
         # Create a matching embedder for the seeded data
         class FE:
@@ -1061,20 +1062,24 @@ class TestCrossStoreUserScoping:
         fe = FE()
         vec = fe.embed_query("user1 task")
         import sqlite_vec
-        conn.execute(
+
+        # Seed one experience for user1
+        conn1 = exp_connect("user1")
+        conn1.execute(
             "INSERT INTO experiences(id,user_id,goal,record_text,steps_json,outcome,score,answer_excerpt,entities,created_at) "
             "VALUES(?,?,?,?,?,?,?,?,?,?)",
             ("exp-1", "user1", "user1 task", "test record", '[]', "done", 1.0, "excerpt", '[]', "2024-01-01T00:00:00")
         )
-        conn.execute(
+        conn1.execute(
             "INSERT INTO experiences_vec(id,embedding) VALUES(?,?)",
             ("exp-1", sqlite_vec.serialize_float32(vec.tolist()))
         )
-        conn.execute(
+        conn1.execute(
             "INSERT INTO experiences_fts(id,goal,record_text) VALUES(?,?,?)",
             ("exp-1", "user1 task", "test record")
         )
-        conn.commit()
+        conn1.commit()
+        conn1.close()
 
         # search_experience with explicit user_id should find it
         hits = search_experience("user1 task", limit=5, embedder=fe, user_id="user1")
@@ -1084,5 +1089,3 @@ class TestCrossStoreUserScoping:
         # With different user_id should return empty (separate DB)
         hits2 = search_experience("user1 task", limit=5, embedder=fe, user_id="user2")
         assert hits2 == []
-
-        conn.close()

--- a/tests/unit/test_memorize.py
+++ b/tests/unit/test_memorize.py
@@ -1073,8 +1073,8 @@ class TestCrossStoreUserScoping:
             (exp_id, sqlite_vec.serialize_float32(vec.tolist()))
         )
         conn1.execute(
-            "INSERT INTO experiences_fts(id,goal,record_text) VALUES(?,?,?)",
-            (exp_id, "user1 task", "test record")
+            "INSERT INTO experiences_fts(rowid, record_text, id) VALUES(?,?,?)",
+            (1, "test record", exp_id)
         )
         conn1.commit()
         conn1.close()


### PR DESCRIPTION
## Summary

Phase 15 — make emotion visible and Studio nodes easier to tell apart.

### 15a Valence
- Prefer `valence_score` (−2…+2) when available at write time
- Rules (`infer_valence_score`) remain fallback when score is missing/invalid
- Keep `valence_tag` for compatibility (`tag_from_score`)
- (If included) extract prompt/parser accepts `{"fact", "valence_score"}`

### 15b Studio
- Wider size mapping from retain (stronger contrast high vs low)
- Frontend radius/opacity curves so dim vs bright is obvious
- Color from `valence_score` when tag is neutral

### Out of scope
- Full DB rebuild / re-embed
- Harrier or second LLM-only emotion pass
- Phase 16 human-feel recall (state tags, neg-avoid, “I used to think…”)

## Test plan
- [ ] Emotional message → `SELECT text, valence_tag, valence_score … ORDER BY created_at DESC` shows non-neutral when expected
- [ ] Technical fact → score 0 / neutral
- [ ] Studio: clear size gap between high- and low-retain nodes
- [ ] Studio: cyan/gold on emotional nodes (not all gray)
- [ ] Old rows without score still load; no crash

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Memory extraction can now assign sentiment/valence scores to stored facts.
  - Memory visualization reflects retention and valence with more informative node sizes, colors, opacity, and glow effects.
  - Studio graph exports include the updated visualization curves.

- **Improvements**
  - Existing memory formats remain supported.
  - Memory search and storage behavior now provide stronger isolation between users.
  - Valence scores are normalized consistently and applied during memory storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->