### PR TITLE
fix(memory): correct user vs Aiko subject in fact extraction

### DIFF
--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -528,7 +528,7 @@ def _valence_from_llm() -> bool:
 # Extraction prompt — temperature 0.0, explicit only-stated-facts rule.
 _EXTRACT_PROMPT = """\
 Extract memorable facts from this conversation.
-{user_name} is the user (he/him). Aiko is the assistant. Attribute each fact to the correct person.
+{user_name} is the user. Aiko is the assistant. Attribute each fact to the correct person.
 
 Rules:
 - Only include facts the speaker stated explicitly. Never infer or assume.

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -527,8 +527,8 @@ def _valence_from_llm() -> bool:
 
 # Extraction prompt — temperature 0.0, explicit only-stated-facts rule.
 _EXTRACT_PROMPT = """\
-Extract memorable facts about {user_name} from this conversation.
-{user_name} is the user (he/him). You are Aiko, the assistant.
+Extract memorable facts from this conversation.
+{user_name} is the user (he/him). Aiko is the assistant. Attribute each fact to the correct person.
 
 Rules:
 - Only include facts the speaker stated explicitly. Never infer or assume.
@@ -544,13 +544,17 @@ Each object: {{"fact": "<one short self-contained sentence>", "valence_score": <
 valence_score is -2..+2 (user feeling: -2 strong neg … 0 neutral/technical … +2 strong pos).
 Use 0 when there is no clear emotion.
 
-Speaker attribution: 'Aiko: I am off limits to others' → {{"fact": "Aiko is off limits to others"}}. NOT '{{user_name}} says he is off limits to others'.
+Speaker attribution (critical):
+- 'Aiko: I am off limits to others' → {{"fact": "Aiko is off limits to others"}}. NEVER "{user_name} is off limits..." or "{user_name} says he is off limits...".
+- 'Aiko: I dislike being treated as human-like' → {{"fact": "Aiko dislikes being treated as human-like"}}. NEVER "{user_name} dislikes being human-like".
+- '{user_name}: follow my rules' / rules for the assistant → {{"fact": "Aiko should follow {user_name}'s rules"}}. NEVER "{user_name} needs to follow {user_name}'s rules".
+- '{user_name}: I prefer dark mode' → {{"fact": "{user_name} prefers dark mode"}}.
 
 Good examples:
-[{{"fact": "{user_name}'s birthday is June 3", "valence_score": 0}}, {{"fact": "{user_name} is building a robot called GRACE", "valence_score": 1}}, {{"fact": "{user_name} joined the Hugging Face Hackathon", "valence_score": 1}}, {{"fact": "{user_name} lost his wallet", "valence_score": -2}}, {{"fact": "{user_name} has a deadline on Friday", "valence_score": -1}}, {{"fact": "{user_name} dislikes mushrooms", "valence_score": -1}}, {{"fact": "Aiko is off limits to others", "valence_score": 0}}]
+[{{"fact": "{user_name}'s birthday is June 3", "valence_score": 0}}, {{"fact": "{user_name} is building a robot called GRACE", "valence_score": 1}}, {{"fact": "{user_name} joined the Hugging Face Hackathon", "valence_score": 1}}, {{"fact": "{user_name} lost his wallet", "valence_score": -2}}, {{"fact": "{user_name} has a deadline on Friday", "valence_score": -1}}, {{"fact": "{user_name} dislikes mushrooms", "valence_score": -1}}, {{"fact": "Aiko is off limits to others", "valence_score": 0}}, {{"fact": "Aiko dislikes being treated as human-like", "valence_score": -1}}, {{"fact": "Aiko should follow {user_name}'s rules", "valence_score": 0}}]
 
 Bad examples (do not produce these):
-[{{"fact": "{user_name} might like cats", "valence_score": 0}}, {{"fact": "It seems {user_name} is tired", "valence_score": 0}}, {{"fact": "Aiko should remember this", "valence_score": 0}}, {{"fact": "{user_name} says he is off limits to others", "valence_score": 0}}]
+[{{"fact": "{user_name} might like cats", "valence_score": 0}}, {{"fact": "It seems {user_name} is tired", "valence_score": 0}}, {{"fact": "Aiko should remember this", "valence_score": 0}}, {{"fact": "{user_name} says he is off limits to others", "valence_score": 0}}, {{"fact": "{user_name} dislikes being human-like", "valence_score": -1}}, {{"fact": "{user_name} needs to follow {user_name}'s rules", "valence_score": 0}}]
 
 Conversation:
 {conversation}"""
@@ -1461,7 +1465,13 @@ class _MemoryBackend:
                 continue
             clean_pairs.append((fact, sc))
 
-        return clean_pairs
+        # Repair common user/assistant subject swaps (Oppa vs Aiko).
+        from cognition.memory.fact_identity import sanitize_fact_score_pairs
+        return sanitize_fact_score_pairs(
+            clean_pairs,
+            user_name=user_name,
+            assistant_name="Aiko",
+        )
 
     # ── write ─────────────────────────────────────────────────────────────────
 

--- a/cognition/memory/fact_identity.py
+++ b/cognition/memory/fact_identity.py
@@ -1,0 +1,206 @@
+"""
+memory/fact_identity.py
+
+Fix user vs assistant mis-attribution in extracted memory facts.
+
+- User display name (e.g. Oppa) vs assistant (Aiko)
+- "I" in user messages → user name
+- "I" in assistant messages → Aiko
+- Cheap post-filters for known bad patterns after LLM extract
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Iterable
+
+DEFAULT_ASSISTANT_NAME = "Aiko"
+DEFAULT_USER_NAME = "Oppa"
+
+# Patterns: (compiled regex, replacement callable or string template)
+def _user_re(name: str) -> str:
+    return re.escape(name.strip())
+
+
+def fix_fact_identity(
+    text: str,
+    *,
+    user_name: str | None = None,
+    assistant_name: str | None = None,
+) -> str:
+    """
+    Apply cheap repairs for common Oppa/Aiko swaps.
+    Does not invent new facts; returns text unchanged if no rule matches.
+    """
+    t = (text or "").strip()
+    if not t:
+        return t
+
+    u = (user_name or DEFAULT_USER_NAME).strip() or DEFAULT_USER_NAME
+    a = (assistant_name or DEFAULT_ASSISTANT_NAME).strip() or DEFAULT_ASSISTANT_NAME
+    if u.casefold() == a.casefold():
+        return t
+
+    ue, ae = _user_re(u), _user_re(a)
+
+    # 1) "{User} dislikes/hates being human-like" → Aiko (persona self-talk)
+    t2 = re.sub(
+        rf"^({ue})\s+(dislikes|doesn't like|does not like|hates|dislike)\s+"
+        rf"(to be |being )?(portrayed as )?human[- ]?like\b",
+        rf"{a} \2 being human-like",
+        t,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    if t2 != t:
+        t = t2
+
+    # 2) "{User} needs/must/should follow {User}'s rules" → Aiko follows user's rules
+    t2 = re.sub(
+        rf"^{ue}\s+(needs to|must|should|has to)\s+follow\s+{ue}'s\s+rules\b",
+        rf"{a} should follow {u}'s rules",
+        t,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    if t2 != t:
+        t = t2
+
+    # 3) "{User} must/should obey {User}'s instructions" (same idea)
+    t2 = re.sub(
+        rf"^{ue}\s+(needs to|must|should|has to)\s+(obey|follow)\s+{ue}'s\s+"
+        rf"(instructions|commands|orders)\b",
+        rf"{a} should follow {u}'s \3",
+        t,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    if t2 != t:
+        t = t2
+
+    # 4) "{User} is an AI / assistant / language model" → Aiko
+    t2 = re.sub(
+        rf"^{ue}\s+(is|as)\s+(an?\s+)?(AI|assistant|language model|LLM)\b",
+        rf"{a} is \2\3",
+        t,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    if t2 != t:
+        t = t2
+
+    # 5) "{User}'s persona / personality (assistant sense)" mild fix when clearly bot
+    t2 = re.sub(
+        rf"^{ue}\s+(has|uses)\s+(a\s+)?(persona|character settings)\b",
+        rf"{a} has \2\3",
+        t,
+        count=1,
+        flags=re.IGNORECASE,
+    )
+    if t2 != t:
+        t = t2
+
+    return t.strip()
+
+
+def should_skip_misattributed_fact(
+    text: str,
+    *,
+    user_name: str | None = None,
+    assistant_name: str | None = None,
+) -> bool:
+    """
+    True if fact still looks like assistant-persona pinned on the user
+    after fix_fact_identity — safer to skip than store wrong.
+    """
+    t = (text or "").strip()
+    if not t:
+        return True
+    u = (user_name or DEFAULT_USER_NAME).strip() or DEFAULT_USER_NAME
+    ue = _user_re(u)
+    # User-name subject + strong assistant-only cues
+    if re.match(
+        rf"^{ue}\s+.*\b(human[- ]?like|as an AI|language model|my persona)\b",
+        t,
+        re.IGNORECASE,
+    ):
+        return True
+    return False
+
+
+def sanitize_extracted_facts(
+    facts: Iterable[str],
+    *,
+    user_name: str | None = None,
+    assistant_name: str | None = None,
+) -> list[str]:
+    """Fix identity then drop remaining misattributed persona facts."""
+    out: list[str] = []
+    u = user_name or DEFAULT_USER_NAME
+    a = assistant_name or DEFAULT_ASSISTANT_NAME
+    for raw in facts:
+        if not isinstance(raw, str):
+            continue
+        fixed = fix_fact_identity(raw, user_name=u, assistant_name=a)
+        if should_skip_misattributed_fact(fixed, user_name=u, assistant_name=a):
+            continue
+        if fixed:
+            out.append(fixed)
+    return out
+
+
+def sanitize_fact_score_pairs(
+    pairs: Iterable[tuple[str, int | None]],
+    *,
+    user_name: str | None = None,
+    assistant_name: str | None = None,
+) -> list[tuple[str, int | None]]:
+    """Same as sanitize_extracted_facts for (text, valence_score) pairs."""
+    out: list[tuple[str, int | None]] = []
+    u = user_name or DEFAULT_USER_NAME
+    a = assistant_name or DEFAULT_ASSISTANT_NAME
+    for item in pairs:
+        if not item:
+            continue
+        raw, score = item[0], item[1] if len(item) > 1 else None
+        if not isinstance(raw, str):
+            continue
+        fixed = fix_fact_identity(raw, user_name=u, assistant_name=a)
+        if should_skip_misattributed_fact(fixed, user_name=u, assistant_name=a):
+            continue
+        if fixed:
+            out.append((fixed, score))
+    return out
+
+
+# --- Prompt fragment (paste into extract system prompt) ---
+
+IDENTITY_PROMPT_RULES = """
+IDENTITY (critical — never get this wrong):
+- The USER is named {user_name}. The ASSISTANT is {assistant_name}.
+- "I/me/my" in a USER message → fact subject is {user_name}.
+- "I/me/my" in an ASSISTANT message → fact subject is {assistant_name}.
+- Do NOT write {assistant_name}'s preferences, personality, or self-rules as {user_name}'s.
+- Do NOT write {user_name}'s preferences as {assistant_name}'s.
+- Assistant talking about being human-like, persona, or "my rules" → subject is {assistant_name}.
+- User commands/rules for the assistant → "{assistant_name} should follow {user_name}'s rules"
+  NOT "{user_name} needs to follow {user_name}'s rules".
+
+Examples:
+Good: "{assistant_name} dislikes being portrayed as human-like."
+Bad:  "{user_name} dislikes being portrayed as human-like." (when the assistant said it about herself)
+Good: "{assistant_name} should follow {user_name}'s rules."
+Bad:  "{user_name} needs to follow {user_name}'s rules."
+Good: "{user_name} prefers dark mode."
+Bad:  "{assistant_name} prefers dark mode." (when the user said it)
+""".strip()
+
+
+def format_identity_prompt_rules(
+    *,
+    user_name: str | None = None,
+    assistant_name: str | None = None,
+) -> str:
+    u = (user_name or DEFAULT_USER_NAME).strip() or DEFAULT_USER_NAME
+    a = (assistant_name or DEFAULT_ASSISTANT_NAME).strip() or DEFAULT_ASSISTANT_NAME
+    return IDENTITY_PROMPT_RULES.format(user_name=u, assistant_name=a)

--- a/cognition/memory/fact_identity.py
+++ b/cognition/memory/fact_identity.py
@@ -47,7 +47,7 @@ def fix_fact_identity(
     t2 = re.sub(
         rf"^({ue})\s+(dislikes|doesn't like|does not like|hates|dislike)\s+"
         rf"(to be |being )?(portrayed as )?human[- ]?like\b",
-        rf"{a} \2 being human-like",
+        lambda m: f"{a} {m.group(2)} being human-like",
         t,
         count=1,
         flags=re.IGNORECASE,
@@ -58,7 +58,7 @@ def fix_fact_identity(
     # 2) "{User} needs/must/should follow {User}'s rules" → Aiko follows user's rules
     t2 = re.sub(
         rf"^{ue}\s+(needs to|must|should|has to)\s+follow\s+{ue}'s\s+rules\b",
-        rf"{a} should follow {u}'s rules",
+        lambda m: f"{a} should follow {u}'s rules",
         t,
         count=1,
         flags=re.IGNORECASE,
@@ -70,7 +70,7 @@ def fix_fact_identity(
     t2 = re.sub(
         rf"^{ue}\s+(needs to|must|should|has to)\s+(obey|follow)\s+{ue}'s\s+"
         rf"(instructions|commands|orders)\b",
-        rf"{a} should follow {u}'s \3",
+        lambda m: f"{a} should follow {u}'s {m.group(3)}",
         t,
         count=1,
         flags=re.IGNORECASE,
@@ -81,18 +81,7 @@ def fix_fact_identity(
     # 4) "{User} is an AI / assistant / language model" → Aiko
     t2 = re.sub(
         rf"^{ue}\s+(is|as)\s+(an?\s+)?(AI|assistant|language model|LLM)\b",
-        rf"{a} is \2\3",
-        t,
-        count=1,
-        flags=re.IGNORECASE,
-    )
-    if t2 != t:
-        t = t2
-
-    # 5) "{User}'s persona / personality (assistant sense)" mild fix when clearly bot
-    t2 = re.sub(
-        rf"^{ue}\s+(has|uses)\s+(a\s+)?(persona|character settings)\b",
-        rf"{a} has \2\3",
+        lambda m: f"{a} is {m.group(2) or ''}{m.group(3)}",
         t,
         count=1,
         flags=re.IGNORECASE,


### PR DESCRIPTION
## Summary

Fix memory extract mis-attributing **Aiko** (assistant) facts to **Oppa** (user) and the reverse.

- Hard **IDENTITY** rules in the extract system prompt (role-locked names, “I” resolution)
- Post-filter `memory/fact_identity.py`: repair known bad patterns; skip remaining persona-on-user junk
- No full DB rebuild; forward path only

## Files

- `memory/fact_identity.py` (new)
- `memory/memorize.py` (prompt + sanitize on extract results)

## Test plan

- [ ] Assistant says she dislikes human-like portrayal → stored subject **Aiko**, not Oppa
- [ ] User: “follow my rules” → **Aiko should follow Oppa's rules** (or equivalent)
- [ ] User: “I prefer dark mode” → **Oppa prefers dark mode**
- [ ] Technical user fact unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory accuracy by distinguishing user preferences, assistant-owned facts, and assistant obligations.
  * Corrected common cases where memories were attributed to the wrong speaker.
  * Filtered out facts that cannot be reliably assigned to the correct identity.
* **Enhancements**
  * Added support for configurable user and assistant names when identifying and storing memories.
  * Expanded guidance and examples to improve attribution of newly extracted facts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->