### PR TITLE
fix(memory): subject-aware fact extraction and SOUL memory boundaries

### DIFF
--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -515,6 +515,27 @@ _HEDGE_RE = re.compile(
 )
 
 
+def _force_subject_name(text: str, subject: str, user_name: str) -> str:
+    t = (text or "").strip()
+    if not t:
+        return t
+    name = "Aiko" if subject == "assistant" else user_name
+    low = t.casefold()
+    # strip a leading wrong/right name token once
+    for prefix in (user_name, "Aiko", "User", "Assistant"):
+        if prefix and low.startswith(prefix.casefold()):
+            parts = t.split(None, 1)
+            t = parts[1] if len(parts) > 1 else ""
+            low = t.casefold()
+            break
+    if not t:
+        return name
+    if not t.casefold().startswith(name.casefold()):
+        body = t[0].lower() + t[1:] if t else t
+        t = f"{name} {body}"
+    return t.strip()
+  
+
 def _valence_from_llm() -> bool:
     """Whether extract-provided valence_score overrides lexical inference.
 
@@ -566,25 +587,6 @@ Bad examples (do not produce these):
 Conversation:
 {conversation}"""
 
-def _force_subject_name(text: str, subject: str, user_name: str) -> str:
-    t = (text or "").strip()
-    if not t:
-        return t
-    name = "Aiko" if subject == "assistant" else user_name
-    low = t.casefold()
-    # strip a leading wrong/right name token once
-    for prefix in (user_name, "Aiko", "User", "Assistant"):
-        if prefix and low.startswith(prefix.casefold()):
-            parts = t.split(None, 1)
-            t = parts[1] if len(parts) > 1 else ""
-            low = t.casefold()
-            break
-    if not t:
-        return name
-    if not t.casefold().startswith(name.casefold()):
-        body = t[0].lower() + t[1:] if t else t
-        t = f"{name} {body}"
-    return t.strip()
 
 def _sanitize_fts_query(query: str) -> str | None:
     """
@@ -1491,7 +1493,12 @@ class _MemoryBackend:
                 log.debug(f"Dropped hedging fact: {fact!r}")
                 continue
             clean_pairs.append((fact, sc))
-
+          
+        subj = str(x.get("subject") or "").strip().lower()
+        if subj not in ("user", "assistant"):
+            subj = "assistant" if t.casefold().startswith("aiko") else "user"
+        t = _force_subject_name(t, subj, user_name)
+              
         # Repair common user/assistant subject swaps (Oppa vs Aiko).
         from cognition.memory.fact_identity import sanitize_fact_score_pairs
         return sanitize_fact_score_pairs(

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -562,7 +562,7 @@ Rules:
 
 Return ONLY a JSON array of objects. No markdown. No explanation.
 Each object:
-{"fact": "<third-person sentence>", "subject": "user"|"assistant", "valence_score": <int>}
+{{"fact": "<third-person sentence>", "subject": "user"|"assistant", "valence_score": <int>}}
 
 subject MUST match the speaker line:
 - "{user_name}: ..." → "user" → fact starts with "{user_name}"
@@ -1477,12 +1477,12 @@ class _MemoryBackend:
                 if not isinstance(raw_fact, str):
                     continue
                 t = raw_fact.strip()
-                sc = x.get("valence_score", x.get("valence"))
-                try:
-                    sc_i = max(-2, min(2, int(sc))) if sc is not None else None
-                except (TypeError, ValueError):
-                    sc_i = None
+                sc = ...
+                subj = str(x.get("subject") or "").strip().lower()
+                if subj not in ("user", "assistant"):
+                    subj = "assistant" if t.casefold().startswith("aiko") else "user"
                 if t:
+                    t = _force_subject_name(t, subj, user_name)
                     pairs.append((t, sc_i))
 
         # drop facts containing hedging/uncertain language (word-boundary
@@ -1493,11 +1493,6 @@ class _MemoryBackend:
                 log.debug(f"Dropped hedging fact: {fact!r}")
                 continue
             clean_pairs.append((fact, sc))
-          
-        subj = str(x.get("subject") or "").strip().lower()
-        if subj not in ("user", "assistant"):
-            subj = "assistant" if t.casefold().startswith("aiko") else "user"
-        t = _force_subject_name(t, subj, user_name)
               
         # Repair common user/assistant subject swaps (Oppa vs Aiko).
         from cognition.memory.fact_identity import sanitize_fact_score_pairs

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -540,7 +540,14 @@ Rules:
 - If nothing is worth remembering, return: []
 
 Return ONLY a JSON array of objects. No markdown. No explanation.
-Each object: {{"fact": "<one short self-contained sentence>", "valence_score": <int>}}
+Each object:
+{"fact": "<third-person sentence>", "subject": "user"|"assistant", "valence_score": <int>}
+
+subject MUST match the speaker line:
+- "{user_name}: ..." → "user" → fact starts with "{user_name}"
+- "Aiko: ..." → "assistant" → fact starts with "Aiko"
+- User giving the assistant rules ("follow my rules") → subject "assistant",
+  e.g. "Aiko should follow {user_name}'s rules"
 valence_score is -2..+2 (user feeling: -2 strong neg … 0 neutral/technical … +2 strong pos).
 Use 0 when there is no clear emotion.
 
@@ -559,6 +566,25 @@ Bad examples (do not produce these):
 Conversation:
 {conversation}"""
 
+def _force_subject_name(text: str, subject: str, user_name: str) -> str:
+    t = (text or "").strip()
+    if not t:
+        return t
+    name = "Aiko" if subject == "assistant" else user_name
+    low = t.casefold()
+    # strip a leading wrong/right name token once
+    for prefix in (user_name, "Aiko", "User", "Assistant"):
+        if prefix and low.startswith(prefix.casefold()):
+            parts = t.split(None, 1)
+            t = parts[1] if len(parts) > 1 else ""
+            low = t.casefold()
+            break
+    if not t:
+        return name
+    if not t.casefold().startswith(name.casefold()):
+        body = t[0].lower() + t[1:] if t else t
+        t = f"{name} {body}"
+    return t.strip()
 
 def _sanitize_fts_query(query: str) -> str | None:
     """
@@ -1380,9 +1406,10 @@ class _MemoryBackend:
                             "type": "object",
                             "properties": {
                                 "fact": {"type": "string"},
+                                "subject": {"type": "string", "enum": ["user", "assistant"]},
                                 "valence_score": {"type": "integer"},
                             },
-                            "required": ["fact"],
+                            "required": ["fact", "subject"],
                         },
                     },
                 },

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -579,10 +579,10 @@ Speaker attribution (critical):
 - '{user_name}: I prefer dark mode' → {{"fact": "{user_name} prefers dark mode"}}.
 
 Good examples:
-[{{"fact": "{user_name}'s birthday is June 3", "valence_score": 0}}, {{"fact": "{user_name} is building a robot called GRACE", "valence_score": 1}}, {{"fact": "{user_name} joined the Hugging Face Hackathon", "valence_score": 1}}, {{"fact": "{user_name} lost his wallet", "valence_score": -2}}, {{"fact": "{user_name} has a deadline on Friday", "valence_score": -1}}, {{"fact": "{user_name} dislikes mushrooms", "valence_score": -1}}, {{"fact": "Aiko is off limits to others", "valence_score": 0}}, {{"fact": "Aiko dislikes being treated as human-like", "valence_score": -1}}, {{"fact": "Aiko should follow {user_name}'s rules", "valence_score": 0}}]
+[{{"fact": "{user_name}'s birthday is June 3", "subject": "user", "valence_score": 0}}, {{"fact": "{user_name} is building a robot called GRACE", "subject": "user", "valence_score": 1}}, {{"fact": "{user_name} joined the Hugging Face Hackathon", "subject": "user", "valence_score": 1}}, {{"fact": "{user_name} lost his wallet", "subject": "user", "valence_score": -2}}, {{"fact": "{user_name} has a deadline on Friday", "subject": "user", "valence_score": -1}}, {{"fact": "{user_name} dislikes mushrooms", "subject": "user", "valence_score": -1}}, {{"fact": "Aiko is off limits to others", "subject": "assistant", "valence_score": 0}}, {{"fact": "Aiko dislikes being treated as human-like", "subject": "assistant", "valence_score": -1}}, {{"fact": "Aiko should follow {user_name}'s rules", "subject": "assistant", "valence_score": 0}}]
 
 Bad examples (do not produce these):
-[{{"fact": "{user_name} might like cats", "valence_score": 0}}, {{"fact": "It seems {user_name} is tired", "valence_score": 0}}, {{"fact": "Aiko should remember this", "valence_score": 0}}, {{"fact": "{user_name} says he is off limits to others", "valence_score": 0}}, {{"fact": "{user_name} dislikes being human-like", "valence_score": -1}}, {{"fact": "{user_name} needs to follow {user_name}'s rules", "valence_score": 0}}]
+[{{"fact": "{user_name} might like cats", "subject": "user", "valence_score": 0}}, {{"fact": "It seems {user_name} is tired", "subject": "user", "valence_score": 0}}, {{"fact": "Aiko should remember this", "subject": "assistant", "valence_score": 0}}, {{"fact": "{user_name} says he is off limits to others", "subject": "user", "valence_score": 0}}, {{"fact": "{user_name} dislikes being human-like", "subject": "user", "valence_score": -1}}, {{"fact": "{user_name} needs to follow {user_name}'s rules", "subject": "user", "valence_score": 0}}]
 
 Conversation:
 {conversation}"""
@@ -2919,7 +2919,10 @@ class AikoMemorize:
 
     def set_display_name(self, name: str) -> None:
         """Set the display name for this user (e.g. GitHub login)."""
-        self._display_name = name.strip() if name else None
+        stripped = name.strip() if name else None
+        if stripped and stripped.casefold() == "aiko":
+            raise ValueError("Display name cannot be 'Aiko' (reserved for assistant)")
+        self._display_name = stripped
 
     def get_display_name(self) -> str:
         """Return the display name for this user, or fall back to user_id."""

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -1477,7 +1477,11 @@ class _MemoryBackend:
                 if not isinstance(raw_fact, str):
                     continue
                 t = raw_fact.strip()
-                sc = ...
+                sc = x.get("valence_score", x.get("valence"))
+                try:
+                    sc_i = max(-2, min(2, int(sc))) if sc is not None else None
+                except (TypeError, ValueError):
+                    sc_i = None
                 subj = str(x.get("subject") or "").strip().lower()
                 if subj not in ("user", "assistant"):
                     subj = "assistant" if t.casefold().startswith("aiko") else "user"

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -1381,6 +1381,8 @@ class _MemoryBackend:
             return []
 
         user_name = (display_name or current_display_name()).strip()
+        if user_name.casefold() == "aiko":
+            user_name = "User"  # belt only — prefer reject at set time      
         convo = "\n".join(
             f"{user_name}: {m['content'].strip()}" if m["role"] == "user"
             else f"Aiko: {m['content'].strip()}"

--- a/persona/SOUL.md
+++ b/persona/SOUL.md
@@ -54,7 +54,8 @@ You have memory only when it is provided to you.
 - Facts that start with your name (e.g. Oppa, or the name in "speaking with") are about you.
 - Facts that start with "Aiko" are about Aiko (persona, limits, preferences, duties) — not about you.
 - Do not retell an Aiko-subject memory as if it were your preference or identity.
-- If a memory clearly confuses the two, prefer the system identity lines above and do not elaborate the bad fact.- If a `<search_results>` block is present, treat it as the source for that topic.
+- If a memory clearly confuses the two, prefer the system identity lines above and do not elaborate the bad fact.
+- If a `<search_results>` block is present, treat it as the source for that topic.
 - If search results are insufficient, say what is missing instead of filling gaps with guesses.
 - Use general knowledge for stable topics, but accept corrections without defensiveness.
 

--- a/persona/SOUL.md
+++ b/persona/SOUL.md
@@ -10,10 +10,13 @@ You are speaking with USER_ID_HERE. Today is TODAY_HERE.
 
 ## Identity Handling
 
+- You (Aiko) and the user are different people in memory: never treat "Aiko …" memories as facts about the user.
 - Always address the current user as "you."
-- OppaAI's name is "Oppa" — use it when calling him directly.
-- Other users have their own names — use them the same way, when addressing them directly.
-- Never speak about the user in third person.
+- When using a name, use the name from "You are speaking with <name>." above.
+  - OppaAI is "Oppa" when he is the current user.
+  - Other users: their own name only — never call them Oppa.
+- Never speak about the current user in third person in the reply.
+
 
 **Tone:**
 - With OppaAI: relax. Be teasing, dry, familiar. See Toward OppaAI for the full shape of this.
@@ -47,7 +50,11 @@ You have memory only when it is provided to you.
 - The user's identity (name, who they are) is already given in "You are speaking with <name>." above — that is not a memory-dependent fact. If asked who they are, answer from that line.
 - If a `<memory_context>` block contains additional facts about the current user, you may use them too.
 - If `<memory_context>` says "No relevant memories found", do not say "I don't know" for their name or identity — you already have it from the system prompt.
-- If a `<search_results>` block is present, treat it as the source for that topic.
+- Memory facts may be about **you (the user)** or about **Aiko**.
+- Facts that start with your name (e.g. Oppa, or the name in "speaking with") are about you.
+- Facts that start with "Aiko" are about Aiko (persona, limits, preferences, duties) — not about you.
+- Do not retell an Aiko-subject memory as if it were your preference or identity.
+- If a memory clearly confuses the two, prefer the system identity lines above and do not elaborate the bad fact.- If a `<search_results>` block is present, treat it as the source for that topic.
 - If search results are insufficient, say what is missing instead of filling gaps with guesses.
 - Use general knowledge for stable topics, but accept corrections without defensiveness.
 

--- a/system/userspace.py
+++ b/system/userspace.py
@@ -65,6 +65,9 @@ def current_user_id() -> str:
 
 def set_current_display_name(name: str | None) -> contextvars.Token[str | None]:
     """Set the request-local display name (e.g. GitHub login) and return a token."""
+    n = (name or "").strip()
+    if n.casefold() in _RESERVED_DISPLAY:
+        raise ValueError("Display name 'Aiko' is reserved for the assistant")
     return _CURRENT_DISPLAY_NAME.set(name)
 
 


### PR DESCRIPTION
## Summary

Follow-up to #90: make fact extraction **subject-aware** so user vs Aiko attribution is structural, not only prompt + regex.

- Extract JSON includes `subject`: `user` | `assistant`
- Schema requires `subject`
- Write path forces the fact string to start with the correct name (`{display_name}` vs `Aiko`)
- `fact_identity` sanitize kept as a last-resort seatbelt
- `SOUL.md` Knowledge Boundaries: do not treat Aiko-subject memories as the user’s

## Why

#90 reduced known swaps (prompt + regex). Small models can still mis-label free-text subjects. Forcing the name from `subject` (derived from speaker lines) closes the main hole.

## Files

- `cognition/memory/backend.py` — prompt, json_schema, `_force_subject_name`, parse
- `persona/SOUL.md` — memory subject boundaries for chat
- `cognition/memory/fact_identity.py` — unchanged (seatbelt)

## Out of scope

- Mass backfill / rewrite of existing bad rows
- Auto-supersede on correction
- Second LLM verification pass

## Test plan

- [ ] `Aiko: I dislike being human-like` → stored `Aiko dislikes…` (not Oppa)
- [ ] `Oppa: follow my rules` → `Aiko should follow Oppa's rules`
- [ ] `Oppa: I prefer dark mode` → `Oppa prefers dark mode`
- [ ] Legacy string-only extract still works (sanitize path)
- [ ] Chat: Aiko-subject line in `<memory_context>` not retold as the user’s preference

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved memory attribution so facts are correctly associated with the user, assistant, or Aiko.
  - Corrected inconsistent names and prefixes in saved memories.
  - Reduced incorrect third-person references and identity confusion.
  - Improved handling of conflicting memories by prioritizing the current system identity.
- **Improvements**
  - Memory search results now follow clearer subject and identity rules for more reliable responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->