### PR TITLE
feat(memory): Phase 17 session novelty — dynamic query anchor + rank boost

### DIFF
--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -2220,6 +2220,32 @@ class _MemoryBackend:
             except Exception:
                 return 0.0
 
+        # Phase 17: session dynamic anchor (mean of last-K query vectors)
+        _session_mean = None
+        _session_vecs: dict = {}
+        try:
+            from cognition.memory.session_anchor import (
+                MEMORY_SESSION_ANCHOR_ENABLED,
+                MEMORY_SESSION_ANCHOR_WEIGHT,
+                load_memory_vectors,
+                session_boost_for,
+                session_mean,
+            )
+            if MEMORY_SESSION_ANCHOR_ENABLED and MEMORY_SESSION_ANCHOR_WEIGHT > 0:
+                # user_id is on rows; pick any
+                _uid = None
+                for _mid in deduped_ids:
+                    _r = row_by_id.get(_mid)
+                    if _r is not None and _r["user_id"]:
+                        _uid = str(_r["user_id"])
+                        break
+                if _uid:
+                    _session_mean = session_mean(_uid)
+                    if _session_mean is not None:
+                        _session_vecs = load_memory_vectors(self._conn, list(deduped_ids))
+        except Exception as _sess_exc:
+            log.debug("session anchor prep skipped: %s", _sess_exc)
+
         def final_score(mem_id: str) -> float:
             knn = rank_knn.get(mem_id, 0)
             fts = rank_fts.get(mem_id, 0)
@@ -2248,6 +2274,13 @@ class _MemoryBackend:
                         )
                     except Exception as exc:
                         log.debug("entity importance boost skipped: %s", exc)
+
+                # Phase 17: align with this chat's query topic mean
+                if _session_mean is not None:
+                    try:
+                        score += session_boost_for(mem_id, _session_mean, _session_vecs)
+                    except Exception:
+                        pass
 
             return score
 
@@ -2325,6 +2358,12 @@ class _MemoryBackend:
         """
         if vector is None:
             vector = self._embed(query, query=True)
+        # Phase 17: record query embedding for session dynamic anchor
+        try:
+            from cognition.memory.session_anchor import push_query_vector
+            push_query_vector(user_id, vector)
+        except Exception:
+            pass
         fts_query = _sanitize_fts_query(query)
         query_entities = extract_entities(query, max_entities=5)
         active_only = not include_history

--- a/cognition/memory/session_anchor.py
+++ b/cognition/memory/session_anchor.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import math
 import os
+import struct
 import threading
 from collections import defaultdict, deque
 from typing import Deque
@@ -121,14 +122,25 @@ def load_memory_vectors(conn, ids: list[str]) -> dict[str, list[float]]:
             emb = row["embedding"] if hasattr(row, "keys") else row[1]
             if emb is None:
                 continue
-            if isinstance(emb, (bytes, bytearray)):
-                continue  # unexpected format
             try:
-                vec = list(emb) if not isinstance(emb, list) else emb
+                # Handle serialized float32 binary blobs (from sqlite_vec.serialize_float32)
+                if isinstance(emb, (bytes, bytearray)):
+                    # Validate length is divisible by 4 (float32 size)
+                    if len(emb) % 4 != 0:
+                        continue  # corrupted/invalid blob
+                    # Decode little-endian float32 array
+                    n = len(emb) // 4
+                    vec = list(struct.unpack(f"{n}f", emb))
+                else:
+                    # Handle list/array-like embeddings
+                    vec = list(emb) if not isinstance(emb, list) else emb
+
+                # Normalize the vector
                 normed = _normalize([float(x) for x in vec])
                 if normed:
                     out[str(mid)] = normed
             except Exception:
+                # Skip on any decode error (invalid format, struct error, etc.)
                 continue
     except Exception:
         return {}

--- a/cognition/memory/session_anchor.py
+++ b/cognition/memory/session_anchor.py
@@ -1,0 +1,145 @@
+"""
+Phase 17 — session-level dynamic anchor for personal memory recall.
+
+Maintains a per-user ring buffer of recent query embeddings for this process.
+Rank boosts memories similar to the session mean ("what's hot in this chat")
+without changing monthly consolidation novelty.
+"""
+from __future__ import annotations
+
+import math
+import os
+import threading
+from collections import defaultdict, deque
+from typing import Deque
+
+def _env_flag(name: str, default: str = "1") -> bool:
+    return str(os.getenv(name, default)).strip().lower() not in ("0", "false", "no", "off", "")
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+MEMORY_SESSION_ANCHOR_ENABLED = _env_flag("MEMORY_SESSION_ANCHOR_ENABLED", "1")
+MEMORY_SESSION_ANCHOR_K = max(1, _env_int("MEMORY_SESSION_ANCHOR_K", 8))
+# Mild boost; same order as MEMORY_RANK_RECENCY_WEIGHT (~0.004)
+MEMORY_SESSION_ANCHOR_WEIGHT = _env_float("MEMORY_SESSION_ANCHOR_WEIGHT", 0.006)
+
+_lock = threading.RLock()
+_buffers: dict[str, Deque[list[float]]] = defaultdict(
+    lambda: deque(maxlen=MEMORY_SESSION_ANCHOR_K)
+)
+
+
+def _normalize(vec: list[float]) -> list[float] | None:
+    if not vec:
+        return None
+    s = math.sqrt(sum(float(x) * float(x) for x in vec))
+    if s <= 1e-12:
+        return None
+    return [float(x) / s for x in vec]
+
+
+def push_query_vector(user_id: str, vector: list[float] | None) -> None:
+    """Record this turn's query embedding for the session mean."""
+    if not MEMORY_SESSION_ANCHOR_ENABLED or not user_id or not vector:
+        return
+    normed = _normalize(list(vector))
+    if normed is None:
+        return
+    with _lock:
+        buf = _buffers[user_id]
+        # Refresh maxlen if K changed at runtime (rare)
+        if buf.maxlen != MEMORY_SESSION_ANCHOR_K:
+            _buffers[user_id] = deque(buf, maxlen=MEMORY_SESSION_ANCHOR_K)
+            buf = _buffers[user_id]
+        buf.append(normed)
+
+
+def session_mean(user_id: str) -> list[float] | None:
+    """L2-normalized mean of the last K query vectors, or None if empty."""
+    if not MEMORY_SESSION_ANCHOR_ENABLED or not user_id:
+        return None
+    with _lock:
+        buf = _buffers.get(user_id)
+        if not buf:
+            return None
+        dim = len(buf[0])
+        acc = [0.0] * dim
+        n = 0
+        for v in buf:
+            if len(v) != dim:
+                continue
+            for i, x in enumerate(v):
+                acc[i] += x
+            n += 1
+        if n <= 0:
+            return None
+        acc = [x / n for x in acc]
+    return _normalize(acc)
+
+
+def cosine(a: list[float] | None, b: list[float] | None) -> float:
+    if not a or not b or len(a) != len(b):
+        return 0.0
+    return float(sum(x * y for x, y in zip(a, b)))
+
+
+def clear_session(user_id: str | None = None) -> None:
+    """Drop buffer(s) — tests or explicit session end."""
+    with _lock:
+        if user_id is None:
+            _buffers.clear()
+        else:
+            _buffers.pop(user_id, None)
+
+
+def load_memory_vectors(conn, ids: list[str]) -> dict[str, list[float]]:
+    """Fetch embeddings for candidate ids from memories_vec (best-effort)."""
+    out: dict[str, list[float]] = {}
+    if not ids:
+        return out
+    try:
+        placeholders = ",".join("?" * len(ids))
+        rows = conn.execute(
+            f"SELECT id, embedding FROM memories_vec WHERE id IN ({placeholders})",
+            list(ids),
+        ).fetchall()
+        for row in rows:
+            mid = row["id"] if hasattr(row, "keys") else row[0]
+            emb = row["embedding"] if hasattr(row, "keys") else row[1]
+            if emb is None:
+                continue
+            if isinstance(emb, (bytes, bytearray)):
+                continue  # unexpected format
+            try:
+                vec = list(emb) if not isinstance(emb, list) else emb
+                normed = _normalize([float(x) for x in vec])
+                if normed:
+                    out[str(mid)] = normed
+            except Exception:
+                continue
+    except Exception:
+        return {}
+    return out
+
+
+def session_boost_for(mid: str, mean: list[float] | None, vecs: dict[str, list[float]]) -> float:
+    if mean is None or MEMORY_SESSION_ANCHOR_WEIGHT <= 0:
+        return 0.0
+    v = vecs.get(str(mid))
+    if not v:
+        return 0.0
+    # Only reward alignment with current chat topic (not anti-topic)
+    return MEMORY_SESSION_ANCHOR_WEIGHT * max(0.0, cosine(v, mean))

--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -247,3 +247,12 @@ MEMORY_NEG_RECALL_AVOID_WEIGHT: "0.015"   # subtract from rank when avoid applie
 MEMORY_NEG_RECALL_AVOID_EXCEPT: "1"      # skip avoid if query looks emotional/reflective
 MEMORY_SUPERSESSION_NARRATIVE: "1"
 MEMORY_SUPERSESSION_NARRATIVE_MAX: "2"   # max chains to narrate per turn
+
+# -- Phase 17: session novelty (turn-level dynamic anchor) --
+# Ring buffer of last-K query embeddings per user (in-process). Rank mildly
+# boosts memories similar to that mean ("hot in this chat"). Monthly dynamic
+# novelty is unchanged. Existing MEMORY_RANK_RECENCY_* still provides light
+# continuous recency in rank.
+MEMORY_SESSION_ANCHOR_ENABLED: "1"
+MEMORY_SESSION_ANCHOR_K: "8"           # Last K query vectors in this process/session
+MEMORY_SESSION_ANCHOR_WEIGHT: "0.006"  # Cosine-to-session-mean boost (same order as rank recency)


### PR DESCRIPTION
## Summary

Phase 17 — **session novelty** for personal memory recall (not monthly gate).

- In-process ring buffer of the last **K** query embeddings per user
- Mild rank boost when a memory vector aligns with the **session mean** (“hot in this chat”)
- Existing `MEMORY_RANK_RECENCY_*` remains the continuous **time** recency term
- Monthly consolidation dynamic novelty is **unchanged**

## Config

```yaml
MEMORY_SESSION_ANCHOR_ENABLED: "1"
MEMORY_SESSION_ANCHOR_K: "8"
MEMORY_SESSION_ANCHOR_WEIGHT: "0.006"
```

## Files

- `cognition/memory/session_anchor.py` (new)
- `cognition/memory/backend.py` — push on search; boost in `_rank_and_score`
- `config/memory.yaml` — knobs

## Out of scope

- Phase 18 KB/exp supersession / spreading
- Changing monthly R / dynamic archive novelty
- Redis / cross-process session store (in-process only)

## Test plan

- [ ] Two related queries in a row → topic-aligned memories can rank slightly higher
- [ ] `MEMORY_SESSION_ANCHOR_ENABLED=0` → no change vs pre-P17
- [ ] Cold process (empty buffer) → no crash; boost is no-op until first query embeds
- [ ] Recency rank still applies via existing weights

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved memory recall by prioritizing results aligned with the current session’s recent topics.
  * Added configurable session-based ranking enhancements for more relevant search results.
  * Added safeguards for missing or malformed memory data, with graceful fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->