### PR TITLE
feat(memory): Phase 18 knowledge/experience supersession + optional spreading

### DIFF
--- a/agentic/experience/backend.py
+++ b/agentic/experience/backend.py
@@ -260,12 +260,13 @@ def record_experience(owner, goal: str, steps: list[dict], final_answer: str, ve
                     limit=5,
                     threshold=EXPERIENCE_AUTO_RELATE_THRESHOLD,
                 )
+                best_sup = None  # (hid, sim)
                 for nb in neighbors:
                     hid = str(nb["id"])
                     if hid == row_id:
                         continue
                     dist = float(nb["dist"])
-                    sim = 1.0 - dist  # cosine similarity
+                    sim = 1.0 - dist
                     if sim < EXPERIENCE_AUTO_RELATE_THRESHOLD:
                         continue
                     old = conn.execute(
@@ -290,14 +291,20 @@ def record_experience(owner, goal: str, steps: list[dict], final_answer: str, ve
                         row_id, hid, rel, confidence=min(1.0, sim), user_id=uid
                     )
                     # Phase 18: very high similarity → mark older run superseded
-                    if (
+                    if (if (
                         EXPERIENCE_SUPERSEDE_ON_NEAR_DUP
                         and sim >= EXPERIENCE_SUPERSEDE_THRESHOLD
+                        and (best_sup is None or sim > best_sup[1])
                     ):
+                        best_sup = (hid, sim)
+
+                    if best_sup is not None:
+                        hid, sim = best_sup
                         try:
                             conn.execute(
                                 "UPDATE experiences SET status = 'superseded' "
-                                "WHERE id = ? AND user_id = ? AND (status = 'active' OR status IS NULL OR status = '')",
+                                "WHERE id = ? AND user_id = ? "
+                                "AND (status = 'active' OR status IS NULL OR status = '')",
                                 (hid, uid),
                             )
                             conn.execute(

--- a/agentic/experience/backend.py
+++ b/agentic/experience/backend.py
@@ -290,31 +290,31 @@ def record_experience(owner, goal: str, steps: list[dict], final_answer: str, ve
                     record_engram_relation(
                         row_id, hid, rel, confidence=min(1.0, sim), user_id=uid
                     )
-                    # Phase 18: very high similarity → mark older run superseded
-                    if (if (
+                    if (
                         EXPERIENCE_SUPERSEDE_ON_NEAR_DUP
                         and sim >= EXPERIENCE_SUPERSEDE_THRESHOLD
                         and (best_sup is None or sim > best_sup[1])
                     ):
                         best_sup = (hid, sim)
 
-                    if best_sup is not None:
-                        hid, sim = best_sup
-                        try:
-                            conn.execute(
-                                "UPDATE experiences SET status = 'superseded' "
-                                "WHERE id = ? AND user_id = ? "
-                                "AND (status = 'active' OR status IS NULL OR status = '')",
-                                (hid, uid),
-                            )
-                            conn.execute(
-                                "UPDATE experiences SET supersedes_id = ? WHERE id = ? AND user_id = ?",
-                                (hid, row_id, uid),
-                            )
-                            conn.commit()
-                            log.debug("experience supersede sim=%.3f old=%s", sim, hid[:8])
-                        except Exception as sup_exc:
-                            log.debug("experience supersede skipped: %s", sup_exc)
+                # after the for nb loop (same indent as `for nb`)
+                if best_sup is not None:
+                    hid, sim = best_sup
+                    try:
+                        conn.execute(
+                            "UPDATE experiences SET status = 'superseded' "
+                            "WHERE id = ? AND user_id = ? "
+                            "AND (status = 'active' OR status IS NULL OR status = '')",
+                            (hid, uid),
+                        )
+                        conn.execute(
+                            "UPDATE experiences SET supersedes_id = ? WHERE id = ? AND user_id = ?",
+                            (hid, row_id, uid),
+                        )
+                        conn.commit()
+                        log.debug("experience supersede sim=%.3f old=%s", sim, hid[:8])
+                    except Exception as sup_exc:
+                        log.debug("experience supersede skipped: %s", sup_exc)
             except Exception as rel_exc:
                 log.debug("auto engram relate skipped: %s", rel_exc)
 

--- a/agentic/experience/backend.py
+++ b/agentic/experience/backend.py
@@ -69,6 +69,11 @@ EXPERIENCE_MAX_ROWS = int(os.getenv("EXPERIENCE_MAX_ROWS", "5000"))
 EXPERIENCE_CONTEXT_CHARS = int(os.getenv("EXPERIENCE_CONTEXT_CHARS", "2500"))
 EXPERIENCE_ENTITY_BOOST = float(os.getenv("EXPERIENCE_ENTITY_BOOST", "0.003"))
 EXPERIENCE_AUTO_RELATE_THRESHOLD = float(os.getenv("EXPERIENCE_AUTO_RELATE_THRESHOLD", "0.90"))
+EXPERIENCE_SUPERSEDE_ON_NEAR_DUP = os.getenv("EXPERIENCE_SUPERSEDE_ON_NEAR_DUP", "1").strip().lower() in {"1", "true", "yes", "on"}
+EXPERIENCE_SUPERSEDE_THRESHOLD = float(os.getenv("EXPERIENCE_SUPERSEDE_THRESHOLD", "0.95"))
+EXPERIENCE_SPREADING_ENABLED = os.getenv("EXPERIENCE_SPREADING_ENABLED", "0").strip().lower() in {"1", "true", "yes", "on"}
+EXPERIENCE_SPREADING_MAX_EXTRA = max(0, int(os.getenv("EXPERIENCE_SPREADING_MAX_EXTRA", "2")))
+EXPERIENCE_SPREADING_SCORE_WEIGHT = float(os.getenv("EXPERIENCE_SPREADING_SCORE_WEIGHT", "0.003"))
 
 _SECRET_RE = re.compile(r"(?i)(api[_-]?key|token|secret|password)(\s*[:=]\s*)([^\s,;]+)")
 
@@ -86,7 +91,9 @@ CREATE TABLE IF NOT EXISTS experiences (
     score          REAL NOT NULL,
     answer_excerpt TEXT NOT NULL,
     entities       TEXT NOT NULL DEFAULT '[]',
-    created_at     TEXT NOT NULL
+    created_at     TEXT NOT NULL,
+    status         TEXT NOT NULL DEFAULT 'active',
+    supersedes_id  TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_experiences_user ON experiences(user_id);
@@ -142,6 +149,7 @@ def _connect(user_id: str | None = None) -> sqlite3.Connection:
     if "entities" not in cols:
         conn.execute("ALTER TABLE experiences ADD COLUMN entities TEXT NOT NULL DEFAULT '[]'")
         conn.commit()
+    _ensure_experience_schema(conn)
     return conn
 
 
@@ -164,6 +172,20 @@ class ExperienceStep:
     error_type: str | None = None
     arg_keys: list[str] = field(default_factory=list)
     args_preview: dict[str, str] = field(default_factory=dict)
+
+
+
+def _ensure_experience_schema(conn: sqlite3.Connection) -> None:
+    """Phase 18: status + supersedes_id on experiences."""
+    try:
+        cols = {row[1] for row in conn.execute("PRAGMA table_info(experiences)").fetchall()}
+        if "status" not in cols:
+            conn.execute("ALTER TABLE experiences ADD COLUMN status TEXT NOT NULL DEFAULT 'active'")
+        if "supersedes_id" not in cols:
+            conn.execute("ALTER TABLE experiences ADD COLUMN supersedes_id TEXT")
+        conn.commit()
+    except Exception as exc:
+        log.debug("experience schema migrate skipped: %s", exc)
 
 
 def record_experience(owner, goal: str, steps: list[dict], final_answer: str, verified_ok: bool, score: float, embedder=None) -> str | None:
@@ -197,7 +219,7 @@ def record_experience(owner, goal: str, steps: list[dict], final_answer: str, ve
     conn = _connect(uid)
     try:
         conn.execute(
-            "INSERT INTO experiences(id,user_id,goal,record_text,steps_json,outcome,score,answer_excerpt,entities,created_at) VALUES(?,?,?,?,?,?,?,?,?,?)",
+            "INSERT INTO experiences(id,user_id,goal,record_text,steps_json,outcome,score,answer_excerpt,entities,created_at,status,supersedes_id) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
             (
                 row_id,
                 uid,
@@ -209,6 +231,8 @@ def record_experience(owner, goal: str, steps: list[dict], final_answer: str, ve
                 _sanitize(final_answer, 500),
                 ents_json,
                 _now(),
+                "active",
+                None,
             ),
         )
         conn.commit()
@@ -265,6 +289,25 @@ def record_experience(owner, goal: str, steps: list[dict], final_answer: str, ve
                     record_engram_relation(
                         row_id, hid, rel, confidence=min(1.0, sim), user_id=uid
                     )
+                    # Phase 18: very high similarity → mark older run superseded
+                    if (
+                        EXPERIENCE_SUPERSEDE_ON_NEAR_DUP
+                        and sim >= EXPERIENCE_SUPERSEDE_THRESHOLD
+                    ):
+                        try:
+                            conn.execute(
+                                "UPDATE experiences SET status = 'superseded' "
+                                "WHERE id = ? AND user_id = ? AND (status = 'active' OR status IS NULL OR status = '')",
+                                (hid, uid),
+                            )
+                            conn.execute(
+                                "UPDATE experiences SET supersedes_id = ? WHERE id = ? AND user_id = ?",
+                                (hid, row_id, uid),
+                            )
+                            conn.commit()
+                            log.debug("experience supersede sim=%.3f old=%s", sim, hid[:8])
+                        except Exception as sup_exc:
+                            log.debug("experience supersede skipped: %s", sup_exc)
             except Exception as rel_exc:
                 log.debug("auto engram relate skipped: %s", rel_exc)
 
@@ -319,6 +362,51 @@ def _fts(conn: sqlite3.Connection, query: str, uid: str, limit: int) -> list[sql
     )
 
 
+
+def _experience_spread_extra(conn: sqlite3.Connection, uid: str, hits: list[dict], limit: int) -> list[dict]:
+    """Phase 18 optional: pull related engrams via engram_relations."""
+    if limit <= 0 or not hits:
+        return []
+    seen = {str(h.get("id") or "") for h in hits}
+    extra: list[dict] = []
+    try:
+        for h in hits:
+            hid = str(h.get("id") or "")
+            if not hid:
+                continue
+            rels = conn.execute(
+                "SELECT to_engram AS oid FROM engram_relations WHERE from_engram = ? "
+                "UNION SELECT from_engram AS oid FROM engram_relations WHERE to_engram = ?",
+                (hid, hid),
+            ).fetchall()
+            for rel in rels:
+                oid = str(rel["oid"] if hasattr(rel, "keys") else rel[0])
+                if not oid or oid in seen:
+                    continue
+                row = conn.execute(
+                    "SELECT * FROM experiences WHERE id = ? AND user_id = ?",
+                    (oid, uid),
+                ).fetchone()
+                if row is None:
+                    continue
+                try:
+                    st = (row["status"] if "status" in row.keys() else "active") or "active"
+                    if str(st).strip().lower() == "superseded":
+                        continue
+                except Exception:
+                    pass
+                d = dict(row)
+                d["recall_score"] = float(EXPERIENCE_SPREADING_SCORE_WEIGHT)
+                d["_from_spreading"] = True
+                extra.append(d)
+                seen.add(oid)
+                if len(extra) >= limit:
+                    return extra
+    except Exception as exc:
+        log.debug("experience spreading skipped: %s", exc)
+    return extra
+
+
 def search_experience(query: str, limit: int = 3, embedder=None, user_id: str | None = None) -> list[dict]:
     uid = user_id or current_user_id()
     conn = _connect(uid)
@@ -338,6 +426,12 @@ def search_experience(query: str, limit: int = 3, embedder=None, user_id: str | 
             if row is None:
                 continue
             try:
+                st = (row["status"] if "status" in row.keys() else "active") or "active"
+                if str(st).strip().lower() == "superseded":
+                    continue
+            except Exception:
+                pass
+            try:
                 ents = entities_from_json(row["entities"] if "entities" in row.keys() else "[]")
             except Exception:
                 ents = []
@@ -345,7 +439,10 @@ def search_experience(query: str, limit: int = 3, embedder=None, user_id: str | 
             if score >= EXPERIENCE_RECALL_SCORE_THRESHOLD:
                 scored.append((score, cid))
         scored.sort(key=lambda pair: (-pair[0], by_id[pair[1]]["created_at"]))
-        return [dict(by_id[eid]) | {"recall_score": score} for score, eid in scored[:limit]]
+        results = [dict(by_id[eid]) | {"recall_score": score} for score, eid in scored[:limit]]
+        if EXPERIENCE_SPREADING_ENABLED and EXPERIENCE_SPREADING_MAX_EXTRA > 0 and results:
+            results.extend(_experience_spread_extra(conn, uid, results, EXPERIENCE_SPREADING_MAX_EXTRA))
+        return results
     except Exception as exc:
         log.warning("Experience search failed: %s", exc)
         return []

--- a/cognition/knowledge/backend.py
+++ b/cognition/knowledge/backend.py
@@ -440,12 +440,26 @@ def ingest_text(
                         if sim >= KNOWLEDGE_WRITE_DEDUP_THRESHOLD:
                             old_id = str(neighbors[0]["id"])
                             if KNOWLEDGE_SUPERSEDE_ON_DEDUP and old_id:
-                                # Phase 18: replace near-dup with lineage instead of silent skip
+                                row = conn.execute(
+                                    "SELECT status FROM learned_chunks WHERE id = ? AND user_id = ?",
+                                    (old_id, uid),
+                                ).fetchone()
+                                st = "active"
+                                if row is not None:
+                                    try:
+                                        st = (row["status"] or "active")
+                                    except Exception:
+                                        st = "active"
+                                if str(st).strip().lower() == "superseded":
+                                    # Already replaced — skip insert (true dedup) or treat as no parent
+                                    log.debug("knowledge dedup skip already-superseded sim=%.3f", sim)
+                                    continue
                                 supersedes_id = old_id
                                 try:
                                     conn.execute(
                                         "UPDATE learned_chunks SET status = 'superseded' "
-                                        "WHERE id = ? AND user_id = ? AND (status = 'active' OR status IS NULL)",
+                                        "WHERE id = ? AND user_id = ? "
+                                        "AND (status = 'active' OR status IS NULL)",
                                         (old_id, uid),
                                     )
                                 except Exception as sup_exc:

--- a/cognition/knowledge/backend.py
+++ b/cognition/knowledge/backend.py
@@ -586,7 +586,7 @@ def _knowledge_spread_extra(conn: sqlite3.Connection, uid: str, hits: list[dict]
                 ents = {str(e).strip().lower() for e in entities_from_json(row["entities"] or "[]") if e}
             except Exception:
                 continue
-            if not (ents & entities):
+            if len(ents & entities) < 2:
                 continue
             d = dict(row)
             d["score"] = float(KNOWLEDGE_SPREADING_SCORE_WEIGHT)

--- a/cognition/knowledge/backend.py
+++ b/cognition/knowledge/backend.py
@@ -61,6 +61,11 @@ KNOWLEDGE_QUERY_INSTRUCT = os.getenv(
 KNOWLEDGE_WORKSPACE_DIR = os.getenv("KNOWLEDGE_WORKSPACE_DIR", "library").strip().strip("/") or "library"
 KNOWLEDGE_ENTITY_BOOST = float(os.getenv("KNOWLEDGE_ENTITY_BOOST", "0.003"))
 KNOWLEDGE_WRITE_DEDUP_THRESHOLD = float(os.getenv("KNOWLEDGE_WRITE_DEDUP_THRESHOLD", "0.95"))
+# Phase 18: near-dup → supersede old chunk instead of skip (when enabled).
+KNOWLEDGE_SUPERSEDE_ON_DEDUP = os.getenv("KNOWLEDGE_SUPERSEDE_ON_DEDUP", "1").strip().lower() in {"1", "true", "yes", "on"}
+KNOWLEDGE_SPREADING_ENABLED = os.getenv("KNOWLEDGE_SPREADING_ENABLED", "0").strip().lower() in {"1", "true", "yes", "on"}
+KNOWLEDGE_SPREADING_MAX_EXTRA = max(0, int(os.getenv("KNOWLEDGE_SPREADING_MAX_EXTRA", "2")))
+KNOWLEDGE_SPREADING_SCORE_WEIGHT = float(os.getenv("KNOWLEDGE_SPREADING_SCORE_WEIGHT", "0.003"))
 
 # ── search cache (mirrors memory/memorize.py's pattern) ─────────────────────
 
@@ -417,6 +422,7 @@ def ingest_text(
             ents_json = entities_to_json(extract_entities(chunk))
             vec = vectors[index] if index < len(vectors) else None
 
+            supersedes_id = None
             if KNOWLEDGE_WRITE_DEDUP_THRESHOLD > 0 and vec is not None:
                 try:
                     neighbors = user_scoped_vec_knn(
@@ -432,15 +438,29 @@ def ingest_text(
                         dist = float(neighbors[0]["dist"])
                         sim = 1.0 - dist
                         if sim >= KNOWLEDGE_WRITE_DEDUP_THRESHOLD:
-                            log.debug("knowledge dedup skip chunk sim=%.3f", sim)
-                            continue
+                            old_id = str(neighbors[0]["id"])
+                            if KNOWLEDGE_SUPERSEDE_ON_DEDUP and old_id:
+                                # Phase 18: replace near-dup with lineage instead of silent skip
+                                supersedes_id = old_id
+                                try:
+                                    conn.execute(
+                                        "UPDATE learned_chunks SET status = 'superseded' "
+                                        "WHERE id = ? AND user_id = ? AND (status = 'active' OR status IS NULL)",
+                                        (old_id, uid),
+                                    )
+                                except Exception as sup_exc:
+                                    log.debug("knowledge supersede mark failed: %s", sup_exc)
+                                log.debug("knowledge supersede chunk sim=%.3f old=%s", sim, old_id[:8])
+                            else:
+                                log.debug("knowledge dedup skip chunk sim=%.3f", sim)
+                                continue
                 except Exception as dedup_exc:
                     log.debug("knowledge dedup skipped: %s", dedup_exc)
 
             chunk_id = str(uuid.uuid4())
             conn.execute(
-                "INSERT INTO learned_chunks(id,doc_id,user_id,chunk_index,text,created_at,entities,status) VALUES(?,?,?,?,?,?,?,?)",
-                (chunk_id, doc_id, uid, index, chunk, created_at, ents_json, "active"),
+                "INSERT INTO learned_chunks(id,doc_id,user_id,chunk_index,text,created_at,entities,status,supersedes_id) VALUES(?,?,?,?,?,?,?,?,?)",
+                (chunk_id, doc_id, uid, index, chunk, created_at, ents_json, "active", supersedes_id),
             )
             if vec is not None:
                 insert_vector(conn, "learned_chunks_vec", chunk_id, vec)
@@ -521,6 +541,51 @@ def _fts(conn: sqlite3.Connection, query: str, uid: str, limit: int) -> list[sql
     )
 
 
+
+def _knowledge_spread_extra(conn: sqlite3.Connection, uid: str, hits: list[dict], limit: int) -> list[dict]:
+    """Phase 18 optional: pull active chunks sharing an entity with hits."""
+    if not KNOWLEDGE_SPREADING_ENABLED or limit <= 0 or not hits:
+        return []
+    seen = {str(h.get("id") or "") for h in hits}
+    entities: set[str] = set()
+    for h in hits:
+        try:
+            for e in entities_from_json(h.get("entities") or "[]"):
+                if e:
+                    entities.add(str(e).strip().lower())
+        except Exception:
+            continue
+    if not entities:
+        return []
+    extra: list[dict] = []
+    try:
+        rows = conn.execute(
+            "SELECT id, text, chunk_index, created_at, entities, status FROM learned_chunks "
+            "WHERE user_id = ? AND (status = 'active' OR status IS NULL) LIMIT 200",
+            (uid,),
+        ).fetchall()
+        for row in rows:
+            rid = str(row["id"])
+            if rid in seen:
+                continue
+            try:
+                ents = {str(e).strip().lower() for e in entities_from_json(row["entities"] or "[]") if e}
+            except Exception:
+                continue
+            if not (ents & entities):
+                continue
+            d = dict(row)
+            d["score"] = float(KNOWLEDGE_SPREADING_SCORE_WEIGHT)
+            d["_from_spreading"] = True
+            extra.append(d)
+            seen.add(rid)
+            if len(extra) >= limit:
+                break
+    except Exception as exc:
+        log.debug("knowledge spreading skipped: %s", exc)
+    return extra
+
+
 def search_knowledge(
     query: str,
     limit: int = 5,
@@ -560,7 +625,10 @@ def search_knowledge(
             if score >= KNOWLEDGE_RECALL_SCORE_THRESHOLD:
                 scored.append((score, cid))
         scored.sort(key=lambda pair: (-pair[0], by_id[pair[1]]["created_at"]))
-        return [dict(by_id[cid]) | {"score": score} for score, cid in scored[:limit]]
+        results = [dict(by_id[cid]) | {"score": score} for score, cid in scored[:limit]]
+        if KNOWLEDGE_SPREADING_ENABLED and KNOWLEDGE_SPREADING_MAX_EXTRA > 0:
+            results.extend(_knowledge_spread_extra(conn, uid, results, KNOWLEDGE_SPREADING_MAX_EXTRA))
+        return results
     except Exception as exc:
         log.warning("Knowledge search failed: %s", exc)
         return []

--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -256,3 +256,16 @@ MEMORY_SUPERSESSION_NARRATIVE_MAX: "2"   # max chains to narrate per turn
 MEMORY_SESSION_ANCHOR_ENABLED: "1"
 MEMORY_SESSION_ANCHOR_K: "8"           # Last K query vectors in this process/session
 MEMORY_SESSION_ANCHOR_WEIGHT: "0.006"  # Cosine-to-session-mean boost (same order as rank recency)
+
+# -- Phase 18: knowledge / experience store parity --
+# Near-dup writes can supersede older rows (status=superseded + supersedes_id).
+# Optional entity/engram spreading is OFF by default (enable if desired).
+KNOWLEDGE_SUPERSEDE_ON_DEDUP: "1"       # 1 = supersede near-dup instead of skip
+KNOWLEDGE_SPREADING_ENABLED: "0"
+KNOWLEDGE_SPREADING_MAX_EXTRA: "2"
+KNOWLEDGE_SPREADING_SCORE_WEIGHT: "0.003"
+EXPERIENCE_SUPERSEDE_ON_NEAR_DUP: "1"
+EXPERIENCE_SUPERSEDE_THRESHOLD: "0.95"  # cosine sim to mark older run superseded
+EXPERIENCE_SPREADING_ENABLED: "0"
+EXPERIENCE_SPREADING_MAX_EXTRA: "2"
+EXPERIENCE_SPREADING_SCORE_WEIGHT: "0.003"


### PR DESCRIPTION
## Summary

Phase 18 — **store parity** for knowledge and experience with personal memory lineage.

### Knowledge
- Near-duplicate chunks at ingest: **supersede** older row (`status=superseded`) and set `supersedes_id` on the new chunk (instead of only skipping)
- Toggle: `KNOWLEDGE_SUPERSEDE_ON_DEDUP` (default on); set `0` to restore skip-only dedup
- Optional **entity co-mention spreading** on search (`KNOWLEDGE_SPREADING_ENABLED`, default **off**)

### Experience
- Schema: `status`, `supersedes_id` (migrated on connect)
- Very high cosine similarity to a past run → mark older `superseded`, link `supersedes_id`
- Search **skips** superseded rows
- Optional **engram_relations spreading** (`EXPERIENCE_SPREADING_ENABLED`, default **off**)

## Files
- `cognition/knowledge/backend.py`
- `agentic/experience/backend.py`
- `config/memory.yaml`

## Out of scope
- Full personal-memory-style spreading depth on KB
- Studio UI for KB/exp supersedes edges (can follow)
- Changing personal memory gate / P17 session anchor

## Test plan
- [ ] Re-ingest near-identical knowledge → old chunk `status=superseded`, new has `supersedes_id`
- [ ] `KNOWLEDGE_SUPERSEDE_ON_DEDUP=0` → near-dup still skipped
- [ ] Record two very similar experiences → older may be superseded; search returns active tip
- [ ] Spreading flags `0` → no extra hits; `1` → at most MAX_EXTRA neighbors
