### PR TITLE
Phase 19: arousal axis, neg sticky hard filter, memory lineage API

### DIFF
--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -638,6 +638,7 @@ _PHASE_A_COLUMNS: tuple[tuple[str, str], ...] = (
   # Phase 4: turn-level emotion / salience tags (cheap, no LLM).
     ("valence_tag", "TEXT NOT NULL DEFAULT 'neutral'"),
     ("valence_score", "INTEGER"),  # -2..+2; NULL = legacy/unknown
+    ("arousal_score", "INTEGER"),  # Phase 19: −2..+2 intensity; NULL = legacy
     ("salience_hit", "INTEGER NOT NULL DEFAULT 0"),
     ("state_json", "TEXT"),  # Phase 16: optional {"local_hour": 0-23}
 )
@@ -778,6 +779,147 @@ def infer_valence_score(text: str) -> int:
         return -1
     return 0
 
+# ── config ────────────────────────────────────────────────────────────────────
+
+def _env_bool(name: str, default: str = "1") -> bool:
+    return os.getenv(name, default).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _arousal_enabled() -> bool:
+    return _env_bool("MEMORY_AROUSAL_ENABLED", "1")
+
+
+def _arousal_rank_weight() -> float:
+    try:
+        return float(os.getenv("MEMORY_AROUSAL_RANK_WEIGHT", "0.08"))
+    except ValueError:
+        return 0.08
+
+
+def _neg_hard_filter_enabled() -> bool:
+    return _env_bool("MEMORY_NEG_HARD_FILTER", "1")
+
+
+def _neg_hard_threshold() -> int:
+    try:
+        return int(os.getenv("MEMORY_NEG_HARD_THRESHOLD", "-1"))
+    except ValueError:
+        return -1
+
+
+# ── arousal inference (heuristic, no LLM) ─────────────────────────────────────
+
+_AROUSAL_HIGH_RE = re.compile(
+    r"\b(?:panic|panick(?:ed|ing)?|terrified|furious|ecstatic|urgent|emergency|"
+    r"scream(?:ed|ing)?|shock(?:ed|ing)?|adrenaline|frantic|hyper|"
+    r"can't sleep|cant sleep|all-nighter|meltdown|breakdown)\b|!{2,}",
+    re.IGNORECASE,
+)
+_AROUSAL_MID_RE = re.compile(
+    r"\b(?:excited|anxious|nervous|stressed|worried|angry|upset|thrilled|"
+    r"glitch|bug|crash(?:ed|ing)?|deadline|interview|hackathon|fight|"
+    r"argument|crying|tears)\b",
+    re.IGNORECASE,
+)
+_AROUSAL_LOW_RE = re.compile(
+    r"\b(?:calm|peaceful|quiet|tired|sleepy|bored|meh|whatever|"
+    r"routine|ordinary|mundane)\b",
+    re.IGNORECASE,
+)
+
+
+def infer_arousal_score(text: str) -> int:
+    """Return −2…+2 activation intensity from lexicon (no LLM).
+
+    Convention (parallel to valence magnitude, signed only for extreme calm):
+      +2 strong high arousal, +1 moderate high, 0 neutral/unknown,
+      −1 low activation (calm/flat), −2 very flat/withdrawn if clearly marked.
+    Ranking uses abs(score); sign is for analytics/Studio.
+    """
+    t = text or ""
+    if _AROUSAL_HIGH_RE.search(t):
+        return 2
+    if _AROUSAL_MID_RE.search(t):
+        return 1
+    if _AROUSAL_LOW_RE.search(t):
+        return -1
+    return 0
+
+
+def arousal_rank_bonus(arousal_score: int | None) -> float:
+    """Additive score term; 0 when disabled or missing."""
+    if not _arousal_enabled() or arousal_score is None:
+        return 0.0
+    try:
+        a = int(arousal_score)
+    except (TypeError, ValueError):
+        return 0.0
+    return _arousal_rank_weight() * (abs(a) / 2.0)
+
+
+# ── neg hard filter ───────────────────────────────────────────────────────────
+
+_EMOTION_QUERY_RE = re.compile(
+    r"\b(?:feel(?:ing)?|emotion|upset|sad|angry|anxious|stress(?:ed)?|"
+    r"embarrass(?:ed|ing)?|ashamed|guilt|hate|conflict|fight|problem with|"
+    r"what's wrong|what is wrong|are you ok|worried about)\b",
+    re.IGNORECASE,
+)
+
+
+def _is_sticky_neg(mem: dict[str, Any]) -> bool:
+    thr = _neg_hard_threshold()
+    vs = mem.get("valence_score")
+    if vs is not None:
+        try:
+            if int(vs) <= thr:
+                return True
+        except (TypeError, ValueError):
+            pass
+    tag = (mem.get("valence_tag") or "").strip().lower()
+    return tag in ("neg", "negative") and thr >= -1
+
+
+def _query_engages_memory(query: str, mem: dict[str, Any]) -> bool:
+    q = (query or "").casefold()
+    if not q:
+        return False
+    if _EMOTION_QUERY_RE.search(query or ""):
+        return True
+    text = (mem.get("memory") or mem.get("text") or "").casefold()
+    if text and any(tok in text for tok in q.split() if len(tok) >= 4):
+        # light token overlap; prefer entity overlap when present
+        return True
+    ents = mem.get("entities") or []
+    if isinstance(ents, str):
+        try:
+            import json
+            ents = json.loads(ents)
+        except Exception:
+            ents = []
+    for e in ents:
+        if e and str(e).casefold() in q:
+            return True
+    return False
+
+
+def apply_neg_hard_filter(
+    memories: list[dict[str, Any]],
+    query: str,
+) -> list[dict[str, Any]]:
+    """Drop sticky-neg rows unless the user query engages them.
+
+    Unsolicited = no engagement signal. Explicit reference or emotion-seeking
+    query keeps the memory.
+    """
+    if not _neg_hard_filter_enabled():
+        return memories
+    out: list[dict[str, Any]] = []
+    for m in memories:
+        if _is_sticky_neg(m) and not _query_engages_memory(query, m):
+            continue
+        out.append(m)
+    return out
 
 def tag_from_score(score: int) -> str:
     try:

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -1702,6 +1702,7 @@ class _MemoryBackend:
         base_vals: list[Any] = [mem_id, user_id, text, now, 0, "never", pinned]
         ext_cols: list[str] = []
         ext_vals = []
+        a_score = infer_arousal_score(text) if _arousal_enabled() else None
         if "status" in cols:
             ext_cols += ["status", "supersedes_id", "kind", "source", "entities"]
             ext_vals  += [STATUS_ACTIVE, supersedes_id, kind_val, source, ents_json]
@@ -1727,6 +1728,9 @@ class _MemoryBackend:
                 ext_vals.append(state_json)
             except Exception:
                 pass
+        if "arousal_score" in cols and a_score is not None:
+            ext_cols.append("arousal_score")
+            ext_vals.append(int(a_score))
         all_cols = base_cols + ext_cols
         placeholders = ", ".join("?" * len(all_cols))
         self._conn.execute(

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -817,7 +817,7 @@ _AROUSAL_HIGH_RE = re.compile(
 )
 _AROUSAL_MID_RE = re.compile(
     r"\b(?:excited|anxious|nervous|stressed|worried|angry|upset|thrilled|"
-    r"glitch|bug|crash(?:ed|ing)?|deadline|interview|hackathon|fight|"
+    r"deadline|interview|hackathon|fight|"
     r"argument|crying|tears)\b",
     re.IGNORECASE,
 )

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -2621,10 +2621,10 @@ class _MemoryBackend:
                         key = "_recall_score"  # or "score" — match your pipeline
                         r[key] = float(r.get(key) or 0.0) - w
                 results.sort(key=lambda x: float(x.get("_recall_score") or x.get("score") or 0.0), reverse=True)
-
+  
         # Phase 19: sticky-neg not volunteered unless query engages them
         results = apply_neg_hard_filter(results, query)
-        return results
+        return results[:limit]
 
     def _expand_supersession_chains(self, query: str, user_id: str, results: list[dict], limit: int = 5) -> list[dict]:
         """
@@ -2764,13 +2764,7 @@ class _MemoryBackend:
                 (mem_id, user_id, user_id),
             ).fetchall()
         return [dict(r) for r in rows]
-      
-    def get_lineage(self, mem_id: str, user_id: str | None = None) -> dict:
-        from cognition.memory.lineage import walk_supersession_lineage
-        uid = user_id or self.get_user_id()
-        store = self._mem  # or self, depending on how AikoMemorize wraps backend
-        return walk_supersession_lineage(store, mem_id, user_id=uid)
-      
+
     # ── delete ────────────────────────────────────────────────────────────────
 
     def delete(self, memory_id: str) -> None:
@@ -4298,7 +4292,13 @@ class AikoMemorize:
         """Return memories created in [start, end), oldest first."""
         user_id = self._resolve_user_id(user_id)
         return self._mem.get_between(start, end, user_id=user_id)
-
+      
+    def get_lineage(self, mem_id: str, user_id: str | None = None) -> dict:
+        from cognition.memory.lineage import walk_supersession_lineage
+        uid = user_id or self.get_user_id()
+        store = self._mem  # or self, depending on how AikoMemorize wraps backend
+        return walk_supersession_lineage(store, mem_id, user_id=uid)
+      
     def delete(self, memory_id: str) -> None:
         """Delete one memory from the store and clear search cache."""
         self._mem.delete(memory_id)

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -893,9 +893,8 @@ def _query_engages_memory(query: str, mem: dict[str, Any]) -> bool:
     ents = mem.get("entities") or []
     if isinstance(ents, str):
         try:
-            import json
             ents = json.loads(ents)
-        except Exception:
+        except (ValueError, TypeError):
             ents = []
     for e in ents:
         if e and str(e).casefold() in q:

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -2413,7 +2413,7 @@ class _MemoryBackend:
 
                 # Phase 19: arousal intensity (small tiebreaker)
                 try:
-                    score += arousal_rank_bonus(row["arousal_score"] if "arousal_score" in row.keys() else row.get("arousal_score"))
+                    score += arousal_rank_bonus(row["arousal_score"] if row.get("arousal_score") is not None else None)
                 except Exception:
                     pass
 

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -2411,6 +2411,12 @@ class _MemoryBackend:
                 if int(row["pinned"] or 0):
                     score += MEMORY_RANK_PINNED_WEIGHT
 
+                # Phase 19: arousal intensity (small tiebreaker)
+                try:
+                    score += arousal_rank_bonus(row["arousal_score"] if "arousal_score" in row.keys() else row.get("arousal_score"))
+                except Exception:
+                    pass
+
                 # Phase 3: entity importance boost
                 if MEMORY_RANK_ENTITY_IMPORTANCE_WEIGHT > 0 and entity_importance_map:
                     try:
@@ -2616,7 +2622,9 @@ class _MemoryBackend:
                         r[key] = float(r.get(key) or 0.0) - w
                 results.sort(key=lambda x: float(x.get("_recall_score") or x.get("score") or 0.0), reverse=True)
 
-        return results[:limit]
+        # Phase 19: sticky-neg not volunteered unless query engages them
+        results = apply_neg_hard_filter(results, query)
+        return results
 
     def _expand_supersession_chains(self, query: str, user_id: str, results: list[dict], limit: int = 5) -> list[dict]:
         """
@@ -2727,7 +2735,42 @@ class _MemoryBackend:
         with self._db_lock:
             rows = self._conn.execute(sql, params).fetchall()
         return [dict(r) for r in rows]
+      
+    def get_by_id(self, mem_id: str, user_id: str | None = None) -> dict | None:
+        uid = user_id  # require user_id from caller for safety
+        with self._db_lock:
+            row = self._conn.execute(
+                """
+                SELECT id, memory, created_at, status, supersedes_id, pinned,
+                       kind, source, valence_score, arousal_score, entities, access_count
+                FROM memories
+                WHERE id = ? AND (? IS NULL OR user_id = ?)
+                """,
+                (mem_id, uid, uid),
+            ).fetchone()
+        return dict(row) if row else None
 
+    def find_by_supersedes(self, mem_id: str, user_id: str | None = None) -> list[dict]:
+        with self._db_lock:
+            rows = self._conn.execute(
+                """
+                SELECT id, memory, created_at, status, supersedes_id, pinned,
+                       kind, source, valence_score, arousal_score, entities, access_count
+                FROM memories
+                WHERE supersedes_id = ? AND (? IS NULL OR user_id = ?)
+                ORDER BY created_at ASC
+                LIMIT 16
+                """,
+                (mem_id, user_id, user_id),
+            ).fetchall()
+        return [dict(r) for r in rows]
+      
+    def get_lineage(self, mem_id: str, user_id: str | None = None) -> dict:
+        from cognition.memory.lineage import walk_supersession_lineage
+        uid = user_id or self.get_user_id()
+        store = self._mem  # or self, depending on how AikoMemorize wraps backend
+        return walk_supersession_lineage(store, mem_id, user_id=uid)
+      
     # ── delete ────────────────────────────────────────────────────────────────
 
     def delete(self, memory_id: str) -> None:

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -833,7 +833,8 @@ def infer_arousal_score(text: str) -> int:
 
     Convention (parallel to valence magnitude, signed only for calm):
       +2 strong high arousal, +1 moderate high, 0 neutral/unknown,
-      −1 low activation (calm/flat).
+      -1 low activation (calm/flat). -2 is reserved and not yet produced
+      by this heuristic.
     Ranking uses abs(score); sign is for analytics/Studio.
     """
     t = text or ""

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -887,9 +887,12 @@ def _query_engages_memory(query: str, mem: dict[str, Any]) -> bool:
     if _EMOTION_QUERY_RE.search(query or ""):
         return True
     text = (mem.get("memory") or mem.get("text") or "").casefold()
-    if text and any(tok in text for tok in q.split() if len(tok) >= 4):
-        # light token overlap; prefer entity overlap when present
-        return True
+    if text:
+        mem_tokens = set(re.findall(r"\w+", text))
+        q_tokens = {t for t in re.findall(r"\w+", q) if len(t) >= 4}
+        if mem_tokens & q_tokens:
+            # light token overlap; prefer entity overlap when present
+            return True
     ents = mem.get("entities") or []
     if isinstance(ents, str):
         try:

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -4296,7 +4296,7 @@ class AikoMemorize:
     def get_lineage(self, mem_id: str, user_id: str | None = None) -> dict:
         from cognition.memory.lineage import walk_supersession_lineage
         uid = user_id or self.get_user_id()
-        store = self._mem  # or self, depending on how AikoMemorize wraps backend
+        store = self._mem
         return walk_supersession_lineage(store, mem_id, user_id=uid)
       
     def delete(self, memory_id: str) -> None:

--- a/cognition/memory/backend.py
+++ b/cognition/memory/backend.py
@@ -791,9 +791,9 @@ def _arousal_enabled() -> bool:
 
 def _arousal_rank_weight() -> float:
     try:
-        return float(os.getenv("MEMORY_AROUSAL_RANK_WEIGHT", "0.08"))
+        return float(os.getenv("MEMORY_AROUSAL_RANK_WEIGHT", "0.01"))
     except ValueError:
-        return 0.08
+        return 0.01
 
 
 def _neg_hard_filter_enabled() -> bool:
@@ -829,11 +829,11 @@ _AROUSAL_LOW_RE = re.compile(
 
 
 def infer_arousal_score(text: str) -> int:
-    """Return −2…+2 activation intensity from lexicon (no LLM).
+    """Return −1…+2 activation intensity from lexicon (no LLM).
 
-    Convention (parallel to valence magnitude, signed only for extreme calm):
+    Convention (parallel to valence magnitude, signed only for calm):
       +2 strong high arousal, +1 moderate high, 0 neutral/unknown,
-      −1 low activation (calm/flat), −2 very flat/withdrawn if clearly marked.
+      −1 low activation (calm/flat).
     Ranking uses abs(score); sign is for analytics/Studio.
     """
     t = text or ""
@@ -854,7 +854,7 @@ def arousal_rank_bonus(arousal_score: int | None) -> float:
         a = int(arousal_score)
     except (TypeError, ValueError):
         return 0.0
-    return _arousal_rank_weight() * (abs(a) / 2.0)
+    return _arousal_rank_weight() * (min(abs(a), 2) / 2.0)
 
 
 # ── neg hard filter ───────────────────────────────────────────────────────────
@@ -872,8 +872,7 @@ def _is_sticky_neg(mem: dict[str, Any]) -> bool:
     vs = mem.get("valence_score")
     if vs is not None:
         try:
-            if int(vs) <= thr:
-                return True
+            return int(vs) <= thr
         except (TypeError, ValueError):
             pass
     tag = (mem.get("valence_tag") or "").strip().lower()

--- a/cognition/memory/lineage.py
+++ b/cognition/memory/lineage.py
@@ -1,0 +1,133 @@
+"""Phase 19 — supersession lineage walk for Studio / GET /api/memory/{id}/lineage."""
+from __future__ import annotations
+
+import os
+from typing import Any, Protocol
+
+
+def _max_depth() -> int:
+    try:
+        return max(1, int(os.getenv("MEMORY_LINEAGE_MAX_DEPTH", "32")))
+    except ValueError:
+        return 32
+
+
+class _Store(Protocol):
+    def get_by_id(self, mem_id: str, user_id: str | None = None) -> dict | None: ...
+    # Optional: implement with raw SQL if get_by_id does not exist yet.
+
+
+def _row_public(row: dict[str, Any]) -> dict[str, Any]:
+    keys = (
+        "id", "memory", "created_at", "status", "supersedes_id",
+        "pinned", "kind", "source", "valence_score", "arousal_score",
+        "entities", "access_count",
+    )
+    return {k: row.get(k) for k in keys if k in row or row.get(k) is not None}
+
+
+def walk_supersession_lineage(
+    store: Any,
+    mem_id: str,
+    *,
+    user_id: str | None = None,
+    max_depth: int | None = None,
+) -> dict[str, Any]:
+    """Return ordered supersession chain around ``mem_id``.
+
+    - ``chain``: oldest → newest (root predecessor … current … successors)
+    - ``center_id``: requested id
+    - Walks ``supersedes_id`` backward (this → older) then forward (who points here)
+
+    Requires the store to support loading a row by id for ``user_id``.
+    If ``get_by_id`` is missing, implement via:
+
+        SELECT * FROM memories WHERE id=? AND user_id=?
+    """
+    depth = max_depth if max_depth is not None else _max_depth()
+    uid = user_id
+
+    def load(mid: str) -> dict | None:
+        if hasattr(store, "get_by_id"):
+            return store.get_by_id(mid, user_id=uid)
+        # Fallback: AikoMemorize-style connection helper expected on backend
+        get = getattr(store, "_get_memory_row", None)
+        if callable(get):
+            return get(mid, user_id=uid)
+        raise AttributeError("store must provide get_by_id or _get_memory_row")
+
+    center = load(mem_id)
+    if not center:
+        return {"center_id": mem_id, "chain": [], "error": "not_found"}
+
+    # Backward: follow supersedes_id toward older roots
+    backward: list[dict] = []
+    cur = center
+    seen: set[str] = {str(center.get("id") or mem_id)}
+    for _ in range(depth):
+        sid = cur.get("supersedes_id")
+        if not sid or sid in seen:
+            break
+        prev = load(str(sid))
+        if not prev:
+            break
+        backward.append(prev)
+        seen.add(str(prev.get("id")))
+        cur = prev
+    backward.reverse()  # oldest first
+
+    # Forward: memories that supersede the current node (one hop fan-in at a time)
+    # Prefer a store method if present; else single-step SQL via store helper.
+    forward: list[dict] = []
+    frontier = [str(center.get("id") or mem_id)]
+    for _ in range(depth):
+        if not frontier:
+            break
+        nxt_ids: list[str] = []
+        for fid in frontier:
+            children = _find_superseding(store, fid, user_id=uid)
+            for ch in children:
+                cid = str(ch.get("id") or "")
+                if not cid or cid in seen:
+                    continue
+                seen.add(cid)
+                forward.append(ch)
+                nxt_ids.append(cid)
+                if len(backward) + 1 + len(forward) >= depth:
+                    break
+            if len(backward) + 1 + len(forward) >= depth:
+                break
+        frontier = nxt_ids
+
+    chain = [_row_public(r) for r in backward] + [_row_public(center)] + [_row_public(r) for r in forward]
+    return {
+        "center_id": str(center.get("id") or mem_id),
+        "chain": chain[:depth],
+        "depth": len(chain[:depth]),
+    }
+
+
+def _find_superseding(store: Any, mem_id: str, user_id: str | None) -> list[dict]:
+    """Return rows whose supersedes_id == mem_id."""
+    if hasattr(store, "find_by_supersedes"):
+        return list(store.find_by_supersedes(mem_id, user_id=user_id) or [])
+    # Raw SQL fallback on backend connection
+    conn = getattr(store, "_conn", None)
+    lock = getattr(store, "_db_lock", None)
+    if conn is None:
+        return []
+    sql = """
+        SELECT id, memory, created_at, status, supersedes_id, pinned,
+               kind, source, valence_score, arousal_score, entities, access_count
+        FROM memories
+        WHERE supersedes_id = ? AND (? IS NULL OR user_id = ?)
+        ORDER BY created_at ASC
+        LIMIT 16
+    """
+    args = (mem_id, user_id, user_id)
+    if lock is not None:
+        with lock:
+            rows = conn.execute(sql, args).fetchall()
+    else:
+        rows = conn.execute(sql, args).fetchall()
+    return [dict(r) for r in rows]

--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -269,3 +269,10 @@ EXPERIENCE_SUPERSEDE_THRESHOLD: "0.95"  # cosine sim to mark older run supersede
 EXPERIENCE_SPREADING_ENABLED: "0"
 EXPERIENCE_SPREADING_MAX_EXTRA: "2"
 EXPERIENCE_SPREADING_SCORE_WEIGHT: "0.003"
+
+# -- Phase 19: arousal + neg hard filter + lineage --
+MEMORY_AROUSAL_ENABLED: "1"           # Write/rank arousal_score (−2..+2).
+MEMORY_AROUSAL_RANK_WEIGHT: "0.08"    # Small additive rank term: weight * |arousal|/2.
+MEMORY_NEG_HARD_FILTER: "1"           # Exclude strong-neg from unsolicited context inject.
+MEMORY_NEG_HARD_THRESHOLD: "-1"       # valence_score <= this counts as sticky-neg.
+MEMORY_LINEAGE_MAX_DEPTH: "32"        # Max supersession chain nodes returned by lineage API.

--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -272,7 +272,7 @@ EXPERIENCE_SPREADING_SCORE_WEIGHT: "0.003"
 
 # -- Phase 19: arousal + neg hard filter + lineage --
 MEMORY_AROUSAL_ENABLED: "1"           # Write/rank arousal_score (−2..+2).
-MEMORY_AROUSAL_RANK_WEIGHT: "0.08"    # Small additive rank term: weight * |arousal|/2.
+MEMORY_AROUSAL_RANK_WEIGHT: "0.01"    # Small additive rank term: weight * |arousal|/2.
 MEMORY_NEG_HARD_FILTER: "1"           # Exclude strong-neg from unsolicited context inject.
 MEMORY_NEG_HARD_THRESHOLD: "-1"       # valence_score <= this counts as sticky-neg.
 MEMORY_LINEAGE_MAX_DEPTH: "32"        # Max supersession chain nodes returned by lineage API.

--- a/interface/webui/studio/memory/backend/api.py
+++ b/interface/webui/studio/memory/backend/api.py
@@ -109,7 +109,7 @@ async def memory_lineage(
 
     uid = (user_id or "").strip() or current_user_id()
     memorize = AikoMemorize(silent=True)
-    return memorize.get_lineage(mem_id, user_id=uid)  # or walk_...(store, mem_id, user_id=uid)
+    return memorize.get_lineage(mem_id, user_id=uid)
 
 
 @app.get("/")

--- a/interface/webui/studio/memory/backend/api.py
+++ b/interface/webui/studio/memory/backend/api.py
@@ -105,7 +105,6 @@ async def memory_lineage(
 ):
     from cognition.memory.memorize import AikoMemorize
     from system.userspace import current_user_id
-    # walk_supersession_lineage from backend or cognition/memory/lineage.py
 
     uid = (user_id or "").strip() or current_user_id()
     memorize = AikoMemorize(silent=True)

--- a/interface/webui/studio/memory/backend/api.py
+++ b/interface/webui/studio/memory/backend/api.py
@@ -98,6 +98,20 @@ async def search(
     }
 
 
+@app.get("/api/memory/{mem_id}/lineage")
+async def memory_lineage(
+    mem_id: str,
+    user_id: str | None = Query(None, description="User id (default: current_user_id)"),
+):
+    from cognition.memory.memorize import AikoMemorize
+    from system.userspace import current_user_id
+    # walk_supersession_lineage from backend or cognition/memory/lineage.py
+
+    uid = (user_id or "").strip() or current_user_id()
+    memorize = AikoMemorize(silent=True)
+    return memorize.get_lineage(mem_id, user_id=uid)  # or walk_...(store, mem_id, user_id=uid)
+
+
 @app.get("/")
 async def serve_studio():
     return FileResponse(FRONTEND_DIR / "index.html")

--- a/tests/unit/test_arousal.py
+++ b/tests/unit/test_arousal.py
@@ -1,0 +1,69 @@
+"""Phase 19 unit tests — copy into repo tests/ and adapt imports if needed."""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+# Allow importing patches when run from artifacts tree
+_PATCHES = Path(__file__).resolve().parents[1] / "patches"
+if str(_PATCHES) not in sys.path:
+    sys.path.insert(0, str(_PATCHES))
+
+from arousal_and_filter import (  # noqa: E402
+    apply_neg_hard_filter,
+    arousal_rank_bonus,
+    infer_arousal_score,
+)
+
+
+def test_infer_arousal_high():
+    assert infer_arousal_score("He panicked about the emergency glitch!!") == 2
+
+
+def test_infer_arousal_mid():
+    assert infer_arousal_score("Oppa is anxious about the deadline") == 1
+
+
+def test_infer_arousal_low():
+    assert infer_arousal_score("A calm quiet evening, routine work") == -1
+
+
+def test_infer_arousal_neutral():
+    assert infer_arousal_score("Oppa prefers dark mode") == 0
+
+
+def test_arousal_rank_bonus_respects_flag(monkeypatch):
+    monkeypatch.setenv("MEMORY_AROUSAL_ENABLED", "0")
+    assert arousal_rank_bonus(2) == 0.0
+    monkeypatch.setenv("MEMORY_AROUSAL_ENABLED", "1")
+    monkeypatch.setenv("MEMORY_AROUSAL_RANK_WEIGHT", "0.08")
+    assert abs(arousal_rank_bonus(2) - 0.08) < 1e-9
+
+
+def test_neg_hard_filter_drops_unsolicited(monkeypatch):
+    monkeypatch.setenv("MEMORY_NEG_HARD_FILTER", "1")
+    monkeypatch.setenv("MEMORY_NEG_HARD_THRESHOLD", "-1")
+    mems = [
+        {"id": "1", "memory": "Oppa lost his wallet", "valence_score": -2, "entities": []},
+        {"id": "2", "memory": "Oppa prefers dark mode", "valence_score": 0, "entities": []},
+    ]
+    out = apply_neg_hard_filter(mems, query="what do you know about my settings")
+    ids = [m["id"] for m in out]
+    assert "1" not in ids
+    assert "2" in ids
+
+
+def test_neg_hard_filter_keeps_on_overlap(monkeypatch):
+    monkeypatch.setenv("MEMORY_NEG_HARD_FILTER", "1")
+    mems = [
+        {"id": "1", "memory": "Oppa lost his wallet last week", "valence_score": -2, "entities": ["wallet"]},
+    ]
+    out = apply_neg_hard_filter(mems, query="did I lose my wallet")
+    assert len(out) == 1
+
+
+def test_neg_hard_filter_disabled(monkeypatch):
+    monkeypatch.setenv("MEMORY_NEG_HARD_FILTER", "0")
+    mems = [{"id": "1", "memory": "bad day", "valence_score": -2, "entities": []}]
+    assert len(apply_neg_hard_filter(mems, query="hello")) == 1


### PR DESCRIPTION
## Summary
Phase 19 adds three small, independent memory improvements:

1. **Arousal axis** — write-time intensity score (−2…+2) parallel to valence, plus a small rank bonus so high-activation memories rank differently from calm high-valence ones.
2. **Neg hard filter** — strongly negative memories are not injected into unsolicited chat context; they still surface when the query overlaps the memory or asks about conflict/feelings.
3. **Lineage API** — read-only supersession chain walk for Studio/debug (`supersedes_id` forward + back).

## Scope
- Additive schema only (`arousal_score`)
- Heuristic arousal on write; small flagged rank weight
- Neg filter flagged with query-overlap escape
- No monthly R / dream / reflect / journal changes

## Config
- `MEMORY_AROUSAL_ENABLED` (default `1`)
- `MEMORY_AROUSAL_RANK_WEIGHT` (default `0.08`)
- `MEMORY_NEG_HARD_FILTER` (default `1`)
- `MEMORY_NEG_HARD_THRESHOLD` (default `-1`)
- `MEMORY_LINEAGE_MAX_DEPTH` (default `32`)

## Test plan
- [ ] `arousal_score` column migrates
- [ ] New facts get arousal when enabled
- [ ] Rank bonus applies with weight > 0
- [ ] Strong-neg excluded unsolicited; kept on overlap
- [ ] Lineage endpoint returns ordered chain
- [ ] Flags off → pre-P19 behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved memory retrieval with arousal-aware ranking across high, moderate, low, and neutral activation levels.
  - Added safeguards to filter strongly negative memories unless the query provides relevant emotional or contextual signals.
  - Added memory supersession lineage access through the web interface.
  - Added configurable limits for lineage traversal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->