### PR TITLE
Enhance memory wiki pages with diagrams, charts, and link fixes

### DIFF
--- a/papers/Deferred after Phase 19.md
+++ b/papers/Deferred after Phase 19.md
@@ -8,30 +8,44 @@ Related: [[Memory-Architecture]] · [[Memory-Phases]] · [[Memory-Papers]]
 
 ## Not added (or partial)
 
-| Item | Status | Why not |
-|------|--------|---------|
-| Backfill `arousal_score` on legacy rows | Not done | NULL → rank bonus 0; full-text backfill deferred for Jetson migrate cost |
-| Dream / reflect / journal consume **arousal** | Explicit non-scope | P19 = write + rank + filter + lineage only; dream already uses valence/salience |
-| Monthly gate uses arousal | Not done | Paper I weights stay stable until design note revised |
-| Studio lineage **UI** (timeline) | API only | `GET …/lineage` enough for debug; full panel is front-end |
-| Hard filter on **all** recall entry points | Partial | End of `search`; some broad/recent helpers may skip |
-| LLM-based arousal | Not done | Keep zero extra tokens; mirror valence later behind a flag |
-| Arousal −2 lexicon | Not done | Rank uses `abs(a)`; −2 ≈ +2 for ordering; little value until sign is used |
-| Tune soft-avoid vs hard-filter weights | Defaults only | Needs live chat logs |
-| Experience spreading full parity | Partial | Knobs exist; not P19 scope |
-| Cross-user global entity graph | Out of scope | Multi-user is path-isolated |
-| Physical delete of superseded vectors | Not done | Breaks lineage / Studio; needs explicit purge policy |
-| Parametric in-weight memory | Out of scope | Aiko is explicit SQLite memory |
-| Filesystem-as-memory agent trees | Out of scope | Different research track |
+| Item | Status | Why not | Suggested owner area |
+|------|--------|---------|----------------------|
+| Backfill `arousal_score` on legacy rows | Not done | NULL → rank bonus 0; full-text backfill deferred for Jetson migrate cost | Offline migration / eval |
+| Dream / reflect / journal consume **arousal** | Explicit non-scope | P19 = write + rank + filter + lineage only; dream already uses valence/salience | Lifecycle |
+| Monthly gate uses arousal | Not done | Paper I weights stay stable until design note revised | Research + config |
+| Studio lineage **UI** (timeline) | API only | `GET …/lineage` enough for debug; full panel is front-end | Web UI |
+| Hard filter on **all** recall entry points | Partial | End of `search`; some broad/recent helpers may skip | Backend audit |
+| LLM-based arousal | Not done | Keep zero extra tokens; mirror valence later behind a flag | Extraction |
+| Arousal −2 lexicon | Not done | Rank uses `abs(a)`; −2 ≈ +2 for ordering; little value until sign is used | Heuristics |
+| Tune soft-avoid vs hard-filter weights | Defaults only | Needs live chat logs | Evaluation |
+| Experience spreading full parity | Partial | Knobs exist; not P19 scope | Experience store |
+| Cross-user global entity graph | Out of scope | Multi-user is path-isolated | Product/security |
+| Physical delete of superseded vectors | Not done | Breaks lineage / Studio; needs explicit purge policy | Data retention |
+| Parametric in-weight memory | Out of scope | Aiko is explicit SQLite memory | Research |
+| Filesystem-as-memory agent trees | Out of scope | Different research track | Research |
 
 ---
 
 ## Why P19 stayed small
 
-1. **Additive schema only** (`arousal_score`)  
-2. **Heuristic arousal** — no new LLM on write beyond extract  
-3. **Filter is recall-time** — does not delete negative memories  
-4. **Lineage is read-only**  
+```mermaid
+flowchart TD
+  A[P19 goal] --> B[Add arousal score]
+  A --> C[Filter unsolicited strong negative recall]
+  A --> D[Expose lineage]
+  B --> E{Requires new tokens?}
+  E -->|No, lexicon| F[Ship]
+  C --> G{Deletes memories?}
+  G -->|No, recall-time only| F
+  D --> H{Requires Studio UI?}
+  H -->|No, API first| F
+  F --> I[Flags off restores pre-P19 behavior]
+```
+
+1. **Additive schema only** (`arousal_score`).
+2. **Heuristic arousal** — no new LLM on write beyond extract.
+3. **Filter is recall-time** — does not delete negative memories.
+4. **Lineage is read-only** — audit first, UI later.
 
 Flags off → pre-P19 behavior.
 
@@ -39,13 +53,68 @@ Flags off → pre-P19 behavior.
 
 ## Suggested next slices
 
-1. Smoke test + merge PR #97  
-2. Optional offline arousal backfill  
-3. Hard filter on remaining recall helpers  
-4. Studio chain panel (consume lineage API)  
-5. Reflect / **daily journal 5×3** (cheer, grateful, remember, learned, experiences)  
-6. Paper I revision: optional \(W_{\mathrm{arousal}}\); dual-axis affect section  
-7. Eval for neg filter precision/recall on chat logs  
+```mermaid
+journey
+  title Next memory work slices
+  section Stabilize P19
+    Smoke test PR #97: 5: Maintainer
+    Audit recall helper coverage: 4: Backend
+  section Improve data quality
+    Optional arousal backfill: 3: Tools
+    Tune negative recall weights: 4: Eval
+  section Improve UX
+    Studio lineage timeline: 4: Frontend
+    Daily journal 5x3: 3: Product
+  section Research alignment
+    Paper I arousal revision: 4: Research
+```
+
+1. Smoke test + merge PR #97.
+2. Optional offline arousal backfill.
+3. Hard filter on remaining recall helpers.
+4. Studio chain panel consuming the lineage API.
+5. Reflect / **daily journal 5×3**: cheer, grateful, remember, learned, experiences.
+6. Paper I revision: optional `W_AROUSAL`; dual-axis affect section.
+7. Eval for negative-filter precision/recall on chat logs.
+
+---
+
+## Priority matrix
+
+```mermaid
+quadrantChart
+  title Deferred work priority
+  x-axis Low effort --> High effort
+  y-axis Low impact --> High impact
+  quadrant-1 Big bets
+  quadrant-2 Quick wins
+  quadrant-3 Park
+  quadrant-4 Schedule carefully
+  "Recall helper audit": [0.25, 0.80]
+  "Studio lineage UI": [0.55, 0.70]
+  "Arousal backfill": [0.40, 0.55]
+  "LLM arousal": [0.70, 0.45]
+  "Global entity graph": [0.90, 0.30]
+  "Parametric memory": [0.95, 0.20]
+```
+
+---
+
+## Decision flow for the next PR
+
+```mermaid
+flowchart TD
+  A[New memory proposal] --> B{Does it change recall safety?}
+  B -->|Yes| C[Add eval fixture + config flag]
+  B -->|No| D{Does it change schema?}
+  D -->|Yes| E[Prefer additive migration]
+  D -->|No| F[Keep patch scoped]
+  C --> G{Can Studio/API inspect it?}
+  E --> G
+  F --> G
+  G -->|No| H[Add debug surface or defer UI]
+  G -->|Yes| I[Update wiki + Paper checklist]
+```
 
 ---
 

--- a/papers/Home.md
+++ b/papers/Home.md
@@ -1,38 +1,106 @@
 # Aiko-chan Wiki
 
-Local-first AI companion — persistent memory, voice, VRM, agentic tools.  
-Repo [OppaAIAiko-chan](httpsgithub.comOppaAIAiko-chan)
+Local-first AI companion — persistent memory, voice, VRM, and agentic tools.
+Repo: [OppaAI/Aiko-chan](https://github.com/OppaAI/Aiko-chan)
 
 ---
 
-## Memory architecture
+## What this wiki covers
 
-Documentation for the explicit memory stack (feature phases P1–P19), separate from the product roadmap (Soul  Voice  Face  Presence).
+This wiki documents the **explicit memory stack**: how Aiko writes, recalls, filters, consolidates, and audits long-term memories. It is intentionally separate from the broader product roadmap (`Soul → Voice → Face → Presence`) so implementation notes stay focused and reviewable.
 
- Page  What it covers 
-----------------------
- [[Memory-Architecture]]  Design goals, data model, writerecall flows, mermaid diagrams, config 
- [[Memory-Phases]]  Full P1–P19 table with implementation detail 
- [[Memory-Deferred]]  What we did not ship after P19, and why 
- [[Memory-Papers]]  Paper I alignment and recommended paper updates 
+```mermaid
+mindmap
+  root((Aiko-chan Memory Wiki))
+    [[Memory-Architecture]]
+      Data model
+      Write path
+      Recall path
+      Lifecycle
+      Studio
+    [[Memory-Phases]]
+      P1 Core store
+      P8 Tiered recall
+      P12 Scenes
+      P19 Arousal + lineage
+    [[Memory-Deferred]]
+      Non-goals
+      Next slices
+      Risk register
+    [[Memory-Papers]]
+      Paper I mapping
+      Revision checklist
+      Paper II ideas
+```
 
-Status Phase 19 (arousal axis, neg hard filter, lineage API) — PR [#97](httpsgithub.comOppaAIAiko-chanpull97).
+---
+
+## Page map
+
+| Page | Best used for | Main diagrams |
+|------|---------------|---------------|
+| [[Memory-Architecture]] | Design goals, stores, write/recall flows, config, Studio surface | System overview, data model, sequence diagrams, lifecycle, lineage |
+| [[Memory-Phases]] | “What landed when?” across P1–P19 | Timeline, capability matrix, phase dependency graph |
+| [[Memory-Deferred]] | Scope control before the next memory PR | Deferred work funnel, priority matrix, decision flow |
+| [[Memory-Papers]] | Paper I alignment and recommended design-note updates | Concept-to-code map, research update flow, affect model |
+
+Status: **Phase 19** — arousal axis, negative hard filter, and lineage API. PR: [#97](https://github.com/OppaAI/Aiko-chan/pull/97).
+
+---
+
+## Architecture at a glance
+
+```mermaid
+flowchart LR
+  User((User)) --> Chat[Chat / agent loop]
+  Chat -->|enqueue facts| Write[Async write path]
+  Chat -->|query| Recall[Recall path]
+  Write --> Store[(SQLite memory DB<br/>sqlite-vec + FTS5)]
+  Recall --> Store
+  Store --> Studio[Memory Graph Studio]
+  Store --> Lifecycle[Nightly dream<br/>monthly consolidation]
+  Lifecycle --> Store
+  Recall --> Context[Injected context]
+  Context --> Chat
+```
+
+### Capability snapshot
+
+| Capability | Current state | Why it matters |
+|------------|---------------|----------------|
+| Local embeddings + FTS | Shipped | Runs on edge-class hardware without a separate vector service |
+| Belief revision | Shipped | Lets Aiko update facts without silently rewriting history |
+| Affect-aware ranking | Shipped | Supports more human-feeling recall while reducing unsolicited negative memories |
+| Cross-store context | Shipped | Adds knowledge and experience around personal memories |
+| Lineage API | Shipped | Enables auditability and future Studio timelines |
+| Paper I refresh | Recommended | Keeps public/design narrative aligned with implemented P19 behavior |
 
 ---
 
 ## Quick links (repo)
 
- [README](httpsgithub.comOppaAIAiko-chanblobdevREADME.md)
- [docsARCHITECTURE.md](httpsgithub.comOppaAIAiko-chanblobdevdocsARCHITECTURE.md)
- [docsROADMAP.md](httpsgithub.comOppaAIAiko-chanblobdevdocsROADMAP.md)
- [Memory Graph Studio](httpsgithub.comOppaAIAiko-chantreedevinterfacewebuistudiomemory)
- [AGi  AuRoRA](httpsgithub.comOppaAIAGi) — larger cognitive architecture
+* [README](https://github.com/OppaAI/Aiko-chan/blob/dev/README.md)
+* [docs/ARCHITECTURE.md](https://github.com/OppaAI/Aiko-chan/blob/dev/docs/ARCHITECTURE.md)
+* [docs/ROADMAP.md](https://github.com/OppaAI/Aiko-chan/blob/dev/docs/ROADMAP.md)
+* [Memory Graph Studio](https://github.com/OppaAI/Aiko-chan/tree/dev/interface/webui/studio/memory)
+* [AGi / AuRoRA](https://github.com/OppaAI/AGi) — larger cognitive architecture
 
 ---
 
-## How to use this wiki
+## Recommended reading order
+
+```mermaid
+flowchart TD
+  A[Start here: Home] --> B[Memory-Architecture]
+  B --> C{What do you need next?}
+  C -->|Implementation history| D[Memory-Phases]
+  C -->|Planning next PR| E[Memory-Deferred]
+  C -->|Paper / design note edits| F[Memory-Papers]
+  D --> E
+  F --> E
+```
 
 1. Start at [[Memory-Architecture]] for the system picture.
 2. Use [[Memory-Phases]] when you need “what landed in which phase.”
 3. Check [[Memory-Deferred]] before proposing the next memory PR.
-4. Use [[Memory-Papers]] when revising design notes (Paper I).
+4. Use [[Memory-Papers]] when revising design notes or Paper I.

--- a/papers/Memory architecture.md
+++ b/papers/Memory architecture.md
@@ -1,6 +1,6 @@
 # Memory architecture
 
-> Explicit, local-first long-term memory for Aiko-chan.  
+> Explicit, local-first long-term memory for Aiko-chan.
 > Edge-friendly (Jetson / 8GB class). Precursor patterns for **Grace / AuRoRA**.
 
 Related: [[Memory-Phases]] · [[Memory-Deferred]] · [[Memory-Papers]]
@@ -9,15 +9,15 @@ Related: [[Memory-Phases]] · [[Memory-Deferred]] · [[Memory-Papers]]
 
 ## Design goals
 
-| Goal | Approach |
-|------|----------|
-| **Edge-first** | In-process **sqlite-vec** + FTS5; Harrier GGUF/ONNX embeddings; no Qdrant/mem0 server |
-| **Explicit memory** | Rows with clear write/read semantics (not only weights / KV cache) |
-| **Belief revision** | `supersedes_id` + `status` — update without silent overwrite |
-| **Affect-aware** | **Valence** (pleasant↔unpleasant) and **arousal** (calm↔activated) |
-| **Human-feel recall** | Soft neg avoid + hard filter; session topic anchor; state tags |
-| **Lifecycle** | Access tracking, decay, nightly dream, monthly retention gate |
-| **Inspectable** | Memory Graph Studio + lineage API |
+| Goal | Approach | Reviewer check |
+|------|----------|----------------|
+| **Edge-first** | In-process **sqlite-vec** + FTS5; Harrier GGUF/ONNX embeddings; no Qdrant/mem0 server | Can boot locally without external memory service |
+| **Explicit memory** | Rows with clear write/read semantics, not only weights or KV cache | Inspectable DB rows and deterministic migrations |
+| **Belief revision** | `supersedes_id` + `status` — update without silent overwrite | Old facts remain auditable through lineage |
+| **Affect-aware** | **Valence** (pleasant↔unpleasant) and **arousal** (calm↔activated) | Recall can distinguish “happy calm” from “urgent scary” |
+| **Human-feel recall** | Soft neg avoid + hard filter; session topic anchor; state tags | Avoids unsolicited bad memories while allowing direct queries |
+| **Lifecycle** | Access tracking, decay, nightly dream, monthly retention gate | Important memories survive without unbounded growth |
+| **Inspectable** | Memory Graph Studio + lineage API | Debuggable by humans before changing ranking weights |
 
 Design weights for monthly consolidation are cited in-repo as **Paper I** §5.2 (see [[Memory-Papers]]).
 
@@ -73,6 +73,45 @@ flowchart TB
   MC --> M
 ```
 
+### Store responsibilities
+
+```mermaid
+erDiagram
+  memories ||--o{ memories : supersedes
+  memories ||--o{ memories_vec : embeds
+  memories ||--o{ entity_relations : mentions
+  memories ||--o{ knowledge : enriches
+  memories ||--o{ experience : contextualizes
+
+  memories {
+    integer id PK
+    text user_id
+    text memory
+    text status
+    integer supersedes_id FK
+    integer scene_id
+    integer valence_score
+    integer arousal_score
+    text state_json
+  }
+  entity_relations {
+    text user_id
+    text entity_a
+    text entity_b
+    real strength
+  }
+  knowledge {
+    integer id PK
+    text text
+    text entities
+  }
+  experience {
+    integer id PK
+    text trace
+    text entities
+  }
+```
+
 ### Primary code
 
 | Role | Path |
@@ -88,20 +127,20 @@ flowchart TB
 
 ## Data model (core columns)
 
-| Column | Role |
-|--------|------|
-| `id`, `user_id`, `memory`, `created_at` | Identity + text |
-| `access_count`, `last_accessed_at`, `access_day_count` | Practice / spacing |
-| `pinned` | Immune to ordinary decay / prune |
-| `status`, `supersedes_id` | Active vs superseded; belief chain |
-| `kind`, `source`, `entities` | Fact/scene/…; origin; entity JSON |
-| `scene_id` | L2 episode membership |
-| `valence_tag`, `valence_score` | Polarity (−2…+2) |
-| `salience_hit` | Cheap importance flag |
-| `arousal_score` | Activation (−2…+2 schema; see note below) |
-| `state_json` | Encode-time context (e.g. `local_hour`) |
+| Column | Role | Notes |
+|--------|------|-------|
+| `id`, `user_id`, `memory`, `created_at` | Identity + text | User-scoped, local-first memory rows |
+| `access_count`, `last_accessed_at`, `access_day_count` | Practice / spacing | Used by rank and monthly retention |
+| `pinned` | Keep signal | Immune to ordinary decay / prune |
+| `status`, `supersedes_id` | Active vs superseded; belief chain | Enables explicit revision history |
+| `kind`, `source`, `entities` | Fact/scene/…; origin; entity JSON | Drives graph and Studio grouping |
+| `scene_id` | L2 episode membership | Lets scene recall expand related facts |
+| `valence_tag`, `valence_score` | Polarity (−2…+2) | Negative filters and emotion-modified decay |
+| `salience_hit` | Cheap importance flag | Monthly consolidation feature |
+| `arousal_score` | Activation (−2…+2 schema) | P19 rank bonus uses magnitude |
+| `state_json` | Encode-time context | Example: local hour or other state tags |
 
-Vectors: `memories_vec`. Co-mentions: `entity_relations`.
+Vectors live in `memories_vec`. Co-mentions live in `entity_relations`.
 
 **Arousal note:** Schema and docs target a 5-point scale (−2…+2). The P19 lexicon currently emits **{−1, 0, +1, +2}** only (`−2` reserved). Rank uses `|arousal|`, so sign does not change ordering yet.
 
@@ -111,6 +150,7 @@ Vectors: `memories_vec`. Co-mentions: `entity_relations`.
 
 ```mermaid
 sequenceDiagram
+  autonumber
   participant User
   participant Think as think.py
   participant Queue as Write queue
@@ -132,9 +172,22 @@ sequenceDiagram
   end
 ```
 
-* Extraction: LLM. Entities / kind: heuristics.  
-* Valence: extract when `MEMORY_VALENCE_FROM_LLM=1`, else lexicon.  
-* Arousal (P19): lexicon only when `MEMORY_AROUSAL_ENABLED=1`.  
+```mermaid
+flowchart TD
+  A[Candidate fact] --> B{Near duplicate?}
+  B -->|No| C[Insert active row]
+  B -->|Yes, same meaning| D[No-op or touch existing]
+  B -->|Yes, changed fact| E[Mark old row superseded]
+  E --> F[Insert new active row<br/>supersedes_id = old id]
+  C --> G[Embed + FTS index]
+  D --> G
+  F --> G
+  G --> H[Update entity graph]
+```
+
+* Extraction: LLM. Entities / kind: heuristics.
+* Valence: extract when `MEMORY_VALENCE_FROM_LLM=1`, else lexicon.
+* Arousal (P19): lexicon only when `MEMORY_AROUSAL_ENABLED=1`.
 * Writes are async so chat is not blocked by extract+embed.
 
 ---
@@ -143,6 +196,7 @@ sequenceDiagram
 
 ```mermaid
 sequenceDiagram
+  autonumber
   participant User
   participant Think as think.py
   participant Mem as AikoMemorize
@@ -161,9 +215,23 @@ sequenceDiagram
   Mem->>Think: memories → format_for_context
 ```
 
-Rank combines RRF (KNN + FTS + graph) with recency, access, pinned, entity importance, **arousal magnitude**, session boost, spreading, etc.
+```mermaid
+flowchart LR
+  Q[Query] --> K[KNN candidates]
+  Q --> F[FTS candidates]
+  Q --> G[Graph expansion]
+  K --> R[RRF merge]
+  F --> R
+  G --> R
+  R --> B[Rank bonuses<br/>recency + access + pinned + arousal + session]
+  B --> N[Negative policy<br/>soft avoid then hard filter]
+  N --> X[Cross-store attach<br/>knowledge + experience]
+  X --> C[Context window]
+```
 
-**Hard filter (P19):** drops strong-neg rows unless the query engages them (token overlap or emotion-seeking). Soft avoid only lowers score.
+Rank combines RRF (KNN + FTS + graph) with recency, access, pinned, entity importance, **arousal magnitude**, session boost, spreading, and related context.
+
+**Hard filter (P19):** drops strong-negative rows unless the query engages them through token overlap or explicit emotion-seeking. Soft avoid only lowers score.
 
 ---
 
@@ -180,21 +248,50 @@ flowchart LR
   M -->|drop| X[Delete day-pins if coverage OK]
 ```
 
-| Pass | Behavior |
-|------|----------|
-| Touch | Search bumps access counts / day count |
-| Dream | Boost salient, merge near-dupes, prune decayed |
-| Forget | Half-life can stretch with valence intensity |
-| Monthly | Paper I weights + valence; provenance before delete |
+```mermaid
+gantt
+  title Memory maintenance cadence
+  dateFormat  YYYY-MM-DD
+  axisFormat  %d
+  section Online
+  User turns and recall touches :active, 2026-08-01, 30d
+  section Nightly
+  Dream / cleanup windows :crit, 2026-08-01, 1d
+  Repeated nightly passes :crit, 2026-08-02, 29d
+  section Monthly
+  Consolidation gate :milestone, 2026-08-31, 0d
+```
+
+| Pass | Behavior | Output |
+|------|----------|--------|
+| Touch | Search bumps access counts / day count | More reliable spacing features |
+| Dream | Boost salient, merge near-dupes, prune decayed | Cleaner active set |
+| Forget | Half-life can stretch with valence intensity | Less accidental loss of meaningful affective memories |
+| Monthly | Paper I weights + valence; provenance before delete | Smaller, auditable long-term archive |
 
 ---
 
 ## Affect axes
 
+```mermaid
+quadrantChart
+  title Valence × arousal examples
+  x-axis Negative valence --> Positive valence
+  y-axis Calm / low arousal --> Activated / high arousal
+  quadrant-1 Excited / joyful
+  quadrant-2 Alarmed / upset
+  quadrant-3 Sad / quiet
+  quadrant-4 Peaceful / grateful
+  "Surprise party": [0.85, 0.85]
+  "Cozy routine": [0.75, 0.25]
+  "Emergency": [0.10, 0.90]
+  "Melancholy memory": [0.20, 0.20]
+```
+
 | Axis | Range | Role |
 |------|-------|------|
-| **Valence** | −2…+2 | Polarity; forget intensity; neg soft/hard policy |
-| **Arousal** | −2…+2 | Activation; small rank bonus \(w \cdot \|a\|/2\) |
+| **Valence** | −2…+2 | Polarity; forget intensity; negative soft/hard policy |
+| **Arousal** | −2…+2 | Activation; small rank bonus `w * abs(a) / 2` |
 
 Orthogonal by design: calm positive ≠ excited positive. Mid-arousal lexicon drops bare tech noise (`bug` / `glitch` / `crash`).
 
@@ -204,13 +301,15 @@ Orthogonal by design: calm positive ≠ excited positive. Mid-arousal lexicon dr
 
 ```mermaid
 flowchart LR
-  O[Oldest] -->|supersedes_id| M[Middle]
-  M --> T[Active tip]
+  O[Oldest fact] -->|superseded by| M[Intermediate fact]
+  M -->|superseded by| T[Active tip]
+  T --> API[GET /api/memory/{id}/lineage]
+  API --> Studio[Studio timeline panel<br/>future UI]
 ```
 
-* `walk_supersession_lineage` — back via `supersedes_id`, forward via `find_by_supersedes`  
-* `AikoMemorize.get_lineage` → Studio `GET /api/memory/{id}/lineage`  
-* Depth: `MEMORY_LINEAGE_MAX_DEPTH` (default 32)
+* `walk_supersession_lineage` — back via `supersedes_id`, forward via `find_by_supersedes`.
+* `AikoMemorize.get_lineage` → Studio `GET /api/memory/{id}/lineage`.
+* Depth: `MEMORY_LINEAGE_MAX_DEPTH` (default 32).
 
 ---
 
@@ -242,20 +341,29 @@ uv run python -m interface.webui.studio.memory.backend.api
 # → http://127.0.0.1:8001
 ```
 
-Graph: memories, entities, knowledge, experience.  
-P19: lineage endpoint for ordered supersession chains.
+Graph: memories, entities, knowledge, experience. P19 adds a lineage endpoint for ordered supersession chains.
+
+```mermaid
+flowchart TD
+  DB[(Memory DB)] --> API[Studio backend API]
+  API --> Galaxy[Galaxy graph]
+  API --> Filters[Filters<br/>status / valence / retain / entity]
+  API --> Export[Node and edge export]
+  API --> Lineage[Lineage JSON]
+  Lineage -. future .-> Timeline[Timeline UI]
+```
 
 ---
 
 ## Relation to AuRoRA
 
-| Aiko | AGi analogue |
-|------|----------------|
-| sqlite-vec + rank | MSB |
-| search + context assembly | MCC |
-| facts / scenes | EMC-like |
-| experience store | PMC traces |
-| entity graph | SMC connectivity |
+| Aiko | AGi analogue | Notes |
+|------|--------------|-------|
+| sqlite-vec + rank | MSB | Local explicit memory substrate |
+| search + context assembly | MCC | Retrieves just-in-time working context |
+| facts / scenes | EMC-like | Episodic and semantic traces |
+| experience store | PMC traces | Agent-run traces and learned procedures |
+| entity graph | SMC connectivity | Associations and spreading activation |
 
 ---
 

--- a/papers/Memory phases (P1–P19).md
+++ b/papers/Memory phases (P1–P19).md
@@ -6,29 +6,108 @@ See also: [[Memory-Architecture]] · [[Memory-Deferred]]
 
 ---
 
+## Phase timeline
+
+```mermaid
+timeline
+  title Aiko memory stack evolution
+  P1 : Core SQLite + vector + FTS store
+  P2-P4 : Spacing, entity importance, valence and salience
+  P5-P7 : Emotion decay, dynamic novelty, journal promote
+  P8-P10 : Tiered recall, spreading activation, Graph Studio
+  P11-P13 : Provenance, scenes, cross-store context
+  P14-P16 : Experience polish, LLM valence, human-feel recall
+  P17-P19 : Session anchor, experience ops, arousal + lineage
+```
+
+---
+
 ## Table
 
-| Phase | Theme | Implementation details |
-|-------|--------|------------------------|
-| **P1** | Core store | sqlite-vec + FTS5; Harrier embed; LLM fact extract; user-scoped DB; chat inject; replace mem0/Qdrant |
-| **P2** | Spacing | `access_day_count` — distinct local days recalled (spaced-repetition signal for monthly gate) |
-| **P3** | Entity importance | Rank term from entity importance map (`MEMORY_RANK_ENTITY_IMPORTANCE_WEIGHT`) |
-| **P4** | Valence / salience | `valence_tag`, `valence_score`, `salience_hit`; monthly `W_VALENCE` blended with Paper I weights |
-| **P5** | Emotion imprint | `FORGET_EMOTION_GAMMA`; intensity by tag; dream prefers stored tags |
-| **P6** | Dynamic novelty anchors | Static archive anchors + dynamic mean of recent active vectors for monthly novelty |
-| **P7** | Journal promote | Optional promote of journal fragments before retention gate; safer day-pin delete coverage |
-| **P8** | Rank / tiered recall | RRF KNN+FTS+graph; quick→wide; recency-among-relevant; score thresholds |
-| **P9** | Spreading activation | Walk `entity_relations`; depth/decay/min strength; extra neighbor memories + score weight |
-| **P10** | Memory Graph Studio | Galaxy UI; nodes/edges export; filters (status, valence, retain, entity) |
-| **P11** | Hard provenance | Monthly delete requires LLM `source_ids` coverage of kept day-pins |
-| **P12** | Scenes + 5-point valence | L2 `scene_id` / `kind=scene`; expand on recall; `valence_score` −2…+2 |
-| **P13** | Cross-store | Attach related knowledge + experience after personal recall; Studio node types |
-| **P14** | Experience store polish | Experience DB RAG for agent runs; auto-relate threshold; entity boost |
-| **P15** | LLM valence on extract | `MEMORY_VALENCE_FROM_LLM`; extract can supply `valence_score`; Studio contrast |
-| **P16** | Human-feel recall | `state_json`; soft `MEMORY_NEG_RECALL_AVOID`; supersession narrative; Studio dims superseded |
-| **P17** | Session dynamic anchor | Rolling mean of last-K **query** embeddings; rank boost toward current chat topic |
-| **P18** | Experience / spreading ops | Config + wiring for experience supersede / spreading knobs |
-| **P19** | Arousal + hard filter + lineage | `arousal_score` write + rank bonus; sticky-neg hard filter; `lineage.py` + Studio route |
+| Phase | Theme | Implementation details | Primary user-visible effect |
+|-------|-------|------------------------|-----------------------------|
+| **P1** | Core store | sqlite-vec + FTS5; Harrier embed; LLM fact extract; user-scoped DB; chat inject; replace mem0/Qdrant | Aiko can remember explicit facts locally |
+| **P2** | Spacing | `access_day_count` — distinct local days recalled (spaced-repetition signal for monthly gate) | Recalled-on-many-days facts become stickier |
+| **P3** | Entity importance | Rank term from entity importance map (`MEMORY_RANK_ENTITY_IMPORTANCE_WEIGHT`) | Important people/topics rank higher |
+| **P4** | Valence / salience | `valence_tag`, `valence_score`, `salience_hit`; monthly `W_VALENCE` blended with Paper I weights | Emotional and salient memories get better treatment |
+| **P5** | Emotion imprint | `FORGET_EMOTION_GAMMA`; intensity by tag; dream prefers stored tags | Emotional memories decay more carefully |
+| **P6** | Dynamic novelty anchors | Static archive anchors + dynamic mean of recent active vectors for monthly novelty | Novel but relevant memories survive better |
+| **P7** | Journal promote | Optional promote of journal fragments before retention gate; safer day-pin delete coverage | Daily notes can become durable memories |
+| **P8** | Rank / tiered recall | RRF KNN+FTS+graph; quick→wide; recency-among-relevant; score thresholds | Recall gets faster, broader, and less noisy |
+| **P9** | Spreading activation | Walk `entity_relations`; depth/decay/min strength; extra neighbor memories + score weight | Related memories can surface through connected entities |
+| **P10** | Memory Graph Studio | Galaxy UI; nodes/edges export; filters (status, valence, retain, entity) | Memory becomes inspectable and debuggable |
+| **P11** | Hard provenance | Monthly delete requires LLM `source_ids` coverage of kept day-pins | Safer consolidation before deleting day-pins |
+| **P12** | Scenes + 5-point valence | L2 `scene_id` / `kind=scene`; expand on recall; `valence_score` −2…+2 | Episodes recall with richer context |
+| **P13** | Cross-store | Attach related knowledge + experience after personal recall; Studio node types | Personal memory gains factual and experiential context |
+| **P14** | Experience store polish | Experience DB RAG for agent runs; auto-relate threshold; entity boost | Agent traces become reusable context |
+| **P15** | LLM valence on extract | `MEMORY_VALENCE_FROM_LLM`; extract can supply `valence_score`; Studio contrast | Better affect labels when enabled |
+| **P16** | Human-feel recall | `state_json`; soft `MEMORY_NEG_RECALL_AVOID`; supersession narrative; Studio dims superseded | Less jarring recall and clearer updated facts |
+| **P17** | Session dynamic anchor | Rolling mean of last-K **query** embeddings; rank boost toward current chat topic | Current conversation theme influences recall |
+| **P18** | Experience / spreading ops | Config + wiring for experience supersede / spreading knobs | More controllable experience graph behavior |
+| **P19** | Arousal + hard filter + lineage | `arousal_score` write + rank bonus; sticky-neg hard filter; `lineage.py` + Studio route | Safer affect-aware recall and auditable belief chains |
+
+---
+
+## Capability matrix
+
+| Capability area | Early phases | Middle phases | Late phases |
+|-----------------|--------------|---------------|-------------|
+| Storage | P1 local DB and vectors | P12 scenes | P13+ cross-store graph |
+| Ranking | P2 spacing, P3 entities | P8 RRF, P9 spreading | P17 session anchor, P19 arousal |
+| Affect | P4 valence/salience | P5 emotion decay, P12 5-point valence | P15 LLM valence, P19 arousal/filter |
+| Safety / audit | P1 explicit rows | P11 provenance | P16 supersession narrative, P19 lineage |
+| UX / tooling | Chat injection | P10 Studio | P19 lineage API for future timeline |
+
+---
+
+## Dependency graph
+
+```mermaid
+flowchart TD
+  P1[P1 Core store] --> P2[P2 Spacing]
+  P1 --> P3[P3 Entity importance]
+  P1 --> P4[P4 Valence / salience]
+  P4 --> P5[P5 Emotion imprint]
+  P2 --> P6[P6 Dynamic novelty]
+  P4 --> P6
+  P6 --> P7[P7 Journal promote]
+  P1 --> P8[P8 Tiered recall]
+  P3 --> P9[P9 Spreading activation]
+  P8 --> P9
+  P9 --> P10[P10 Graph Studio]
+  P7 --> P11[P11 Hard provenance]
+  P4 --> P12[P12 Scenes + 5-point valence]
+  P10 --> P13[P13 Cross-store]
+  P13 --> P14[P14 Experience polish]
+  P12 --> P15[P15 LLM valence]
+  P15 --> P16[P16 Human-feel recall]
+  P8 --> P17[P17 Session anchor]
+  P14 --> P18[P18 Experience ops]
+  P16 --> P19[P19 Arousal + lineage]
+  P17 --> P19
+```
+
+---
+
+## Review checklist by phase family
+
+```mermaid
+flowchart LR
+  A[Schema changes] --> B[Config flags]
+  B --> C[Ranking behavior]
+  C --> D[Studio/debug visibility]
+  D --> E[Retention and delete safety]
+  E --> F[Paper/wiki update]
+```
+
+| Before merging a new memory phase | Ask |
+|----------------------------------|-----|
+| Schema | Is the migration additive and safe for existing DBs? |
+| Config | Can flags restore prior behavior? |
+| Recall | Does ranking change only intended entry points? |
+| Safety | Are negative/sensitive memories filtered at recall, not destroyed unexpectedly? |
+| Studio | Can a developer inspect the new state? |
+| Docs | Does [[Memory-Papers]] need an update? |
 
 ---
 

--- a/papers/Papers and design notes.md
+++ b/papers/Papers and design notes.md
@@ -23,35 +23,54 @@ MONTHLY_CONSOLIDATION_W_VALENCE: "0.10"
 
 Also implemented in the spirit of that note:
 
-* **Dynamic anchors (P6)** — novelty vs static `[YYYY-MM]` archives + dynamic mean of recent active vectors  
-* **Emotion-modified decay (P5)** — effective half-life stretched by valence intensity  
-* **Soft monthly threshold** — retention gate (~0.44)
+* **Dynamic anchors (P6)** — novelty vs static `[YYYY-MM]` archives + dynamic mean of recent active vectors.
+* **Emotion-modified decay (P5)** — effective half-life stretched by valence intensity.
+* **Soft monthly threshold** — retention gate (~0.44).
 
 ---
 
 ## Concept → code map
 
+```mermaid
+flowchart LR
+  Paper[Paper I §5.2] --> Salience[Salience]
+  Paper --> Novelty[Novelty]
+  Paper --> Spacing[Spacing]
+  Paper --> Connectivity[Connectivity]
+  Paper --> Valence[Valence intensity]
+  Salience --> Code1[`salience_hit`]
+  Novelty --> Code2[Static + dynamic anchors]
+  Spacing --> Code3[`access_day_count`]
+  Connectivity --> Code4[`entity_relations`]
+  Valence --> Code5[`valence_score` + decay]
+  Code1 --> Gate[Monthly consolidation]
+  Code2 --> Gate
+  Code3 --> Gate
+  Code4 --> Gate
+  Code5 --> Gate
+```
+
 | Paper I concept (as used in config) | Code | Phase |
 |-------------------------------------|------|-------|
-| Salience | `salience_hit`; monthly \(W_S\) | P4+ |
+| Salience | `salience_hit`; monthly `W_S` | P4+ |
 | Novelty (static + dynamic) | Monthly novelty | P6 |
 | Spacing | `access_day_count` | P2, P6 |
 | Connectivity | Entity graph / importance | P3, P9 |
-| Valence intensity | `valence_score` / tag; forget + \(W_V\) | P4–P15 |
+| Valence intensity | `valence_score` / tag; forget + `W_V` | P4–P15 |
 | Consolidation / archive | Monthly facts; day-pin policy | P7, P11 |
 | Explicit external store | sqlite-vec | P1 |
 
 ### In code but not yet in Paper I (as cited)
 
-| Concept | Phase |
-|---------|-------|
-| Arousal axis + rank bonus | **P19** |
-| Hard neg filter (unsolicited suppress) | **P19** |
-| Soft neg avoid | P16 |
-| Session query-mean anchor | P17 |
-| Supersession lineage API | P19 |
-| Cross-store knowledge / experience | P13+ |
-| Spreading activation | P9 |
+| Concept | Phase | Paper impact |
+|---------|-------|--------------|
+| Arousal axis + rank bonus | **P19** | Add dual-axis affect model and clarify `abs(arousal)` ranking |
+| Hard neg filter (unsolicited suppress) | **P19** | Describe as recall policy, not retention/deletion |
+| Soft neg avoid | P16 | Explain score lowering before hard filtering |
+| Session query-mean anchor | P17 | Separate online chat-topic anchoring from monthly novelty |
+| Supersession lineage API | P19 | Add belief-revision audit trail |
+| Cross-store knowledge / experience | P13+ | Explain multi-store context without over-claiming one unified brain |
+| Spreading activation | P9 | Connect entity graph to candidate expansion |
 
 ---
 
@@ -59,20 +78,79 @@ Also implemented in the spirit of that note:
 
 **Yes**, if Paper I is the system-of-record description. The live system is ahead on dual-axis affect and recall safety policy.
 
+```mermaid
+flowchart TD
+  A[Live implementation] --> B{Paper describes behavior?}
+  B -->|Yes| C[Keep citations stable]
+  B -->|No| D[Add revision note]
+  D --> E{Changes retention math?}
+  E -->|Yes| F[Update §5.2 weights / equations]
+  E -->|No| G[Add implementation subsection]
+  F --> H[Update wiki + config comments]
+  G --> H
+```
+
 ### Suggested Paper I edits
 
-1. **Affect** — Valence vs arousal; rank uses `|a|`; monthly still valence-primary until \(W_A\) is proposed.  
-2. **§5.2** — Document five-term blend; optional future \(W_A\) defaulting to 0; hard filter is **recall policy**, not a gate input.  
-3. **Belief revision** — `supersedes_id` chains; lineage for audit/Studio.  
-4. **Human-feel recall** — Soft avoid vs hard filter; session anchor ≠ monthly dynamic novelty anchor.  
-5. **Edge constraints** — Explicit SQLite vs parametric long-term memory research.  
+1. **Affect** — Valence vs arousal; rank uses `|a|`; monthly still valence-primary until `W_AROUSAL` is proposed.
+2. **§5.2** — Document five-term blend; optional future `W_AROUSAL` defaulting to 0; hard filter is **recall policy**, not a gate input.
+3. **Belief revision** — `supersedes_id` chains; lineage for audit/Studio.
+4. **Human-feel recall** — Soft avoid vs hard filter; session anchor ≠ monthly dynamic novelty anchor.
+5. **Edge constraints** — Explicit SQLite vs parametric long-term memory research.
 6. **Version table** — Point at [[Memory-Phases]] (P1–P19).
 
-### Optional “Paper II” sketch
+---
 
-* Dual-axis affect at encode and rank  
-* Companion inject safety filters  
-* Multi-store (memory / knowledge / experience) without over-claiming one brain model  
+## Proposed affect-model wording
+
+```mermaid
+quadrantChart
+  title Dual-axis affect for memory
+  x-axis Unpleasant valence --> Pleasant valence
+  y-axis Low activation --> High activation
+  quadrant-1 Joy / excitement
+  quadrant-2 Fear / anger / urgency
+  quadrant-3 Sadness / low mood
+  quadrant-4 Calm / comfort
+  "rank bonus uses |arousal|": [0.50, 0.82]
+  "negative policy uses valence": [0.18, 0.60]
+  "emotion decay uses intensity": [0.32, 0.35]
+  "gratitude memory": [0.82, 0.30]
+```
+
+Suggested concise paragraph:
+
+> The memory store represents affect with two orthogonal axes. Valence estimates pleasantness or unpleasantness and participates in emotion-modified decay and negative-recall policy. Arousal estimates activation or urgency and may provide a bounded ranking bonus by magnitude. Retention remains governed by the Paper I salience/novelty/spacing/connectivity blend plus valence until an explicit arousal retention weight is introduced.
+
+---
+
+## Optional “Paper II” sketch
+
+```mermaid
+mindmap
+  root((Paper II: companion memory))
+    Dual-axis affect
+      Valence
+      Arousal
+      Recall safety
+    Multi-store context
+      Personal memory
+      Knowledge
+      Experience traces
+    Auditability
+      Supersession
+      Lineage API
+      Studio visualization
+    Edge constraints
+      SQLite
+      Quantized embeddings
+      No always-on vector service
+```
+
+* Dual-axis affect at encode and rank.
+* Companion inject safety filters.
+* Multi-store memory / knowledge / experience without over-claiming one brain model.
+* Auditable belief revision through supersession lineage.
 
 ---
 
@@ -83,6 +161,7 @@ Also implemented in the spirit of that note:
 | Is code ahead of Paper I? | **Yes** |
 | Block engineering merge on paper rewrite? | **No** |
 | Minimal paper fix | Dual-axis affect + recall policy ≠ retention gate + P19 footnote |
+| Best next doc task | Add a P19 subsection and a small version table |
 
 ---
 


### PR DESCRIPTION
### Motivation

- Improve the professionalism and readability of the in-repo memory documentation for Aiko-chan by expanding the draft wiki pages with clearer structure, visuals, and reviewer-focused notes.
- Capture P1–P19 implementation status and P19 (arousal/lineage/negative-filter) design decisions more explicitly so docs match the live codebase. 
- Make the pages easier to use for code reviewers and designers by adding diagrams, checklists, and a page map.

### Description

- Expanded the five markdown pages under `papers/` (`Home.md`, `Memory architecture.md`, `Memory phases (P1–P19).md`, `Deferred after Phase 19.md`, `Papers and design notes.md`) with additional prose, reviewer check items, and a page map. 
- Added multiple Mermaid diagrams (mindmap, flowcharts, sequence diagrams, ER diagram, Gantt, timeline, journey, quadrantChart) across the pages to illustrate system overview, write/recall flows, lifecycle cadence, affect axes, phase dependency graph, and decision flows. 
- Improved traceability and guidance: added a clearer concept→code map, phase capability matrix, suggested Paper I edits, and decision/checklist flows for future memory PRs. 
- Minor doc hygiene: fixed malformed GitHub link markers, trimmed trailing whitespace, and ensured balanced Markdown code fences across the updated files.

### Testing

- Ran a Markdown sanity script that verifies balanced fenced blocks and fixes malformed GitHub link markers using `python` (fence/link sanity checks): passed. 
- Ran `git diff --check` to validate whitespace and other diff issues: no problems reported. 
- Verified the updated files render as plain Markdown locally (no automated HTML preview); no additional linters were run in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7531c3e74483298cb3e9ff271595c5)