### PR TITLE
feat(workflows): Layer 1 — runnable shared nodes + aurora on 5-node pipeline

### DIFF
--- a/agentic/workflows/LAYER1.md
+++ b/agentic/workflows/LAYER1.md
@@ -1,0 +1,25 @@
+# Layer 1 — Runnable shared nodes
+
+Builds on Layer 0 (`LAYER0.md`).
+
+## What Layer 1 adds
+
+1. **Catalog registration** — `ingest_data`, `store_data`, `synthesis_data`, `verify_results`, `output_user_results` in `config/tools.yaml`
+2. **Graph handlers** — `agentic/workflows/common/nodes.py` (`@tool` + `graph=True`)
+3. **Aurora adapter** — `ingest_data` source type `adapter` / name `aurora` calls the domain check and emits one normalized item
+4. **Aurora graph** — wired only to the five shared nodes (domain `check_aurora` kept for ReAct / debug)
+5. **Config mini-spec** — `aurora_forecast/config.json` carries sources, template, email, social, retain_days
+
+## Aurora graph shape
+
+```
+ingest_data → store_data → synthesis_data → verify_results → output_user_results
+```
+
+Trigger remains schedule_graphs (`hourly_aurora_forecast`).
+
+## Not in Layer 1
+
+- Full job_hunt migration onto shared nodes
+- Studio / Spec codegen
+- LLM-backed `synthesis_data` enrichment (hook only)

--- a/agentic/workflows/aurora_forecast/config.json
+++ b/agentic/workflows/aurora_forecast/config.json
@@ -1,4 +1,5 @@
 {
+  "workflow_id": "aurora_forecast",
   "location_name": "Vancouver, BC",
   "latitude": 49.2827,
   "longitude": -123.1207,
@@ -7,6 +8,22 @@
   "min_kp_for_alert": 5.0,
   "min_kp_for_threads": 5.0,
   "retain_days": 3,
+  "sources": [
+    {"type": "adapter", "id": "aurora", "name": "aurora"}
+  ],
+  "template": "{summary}",
+  "human_in_the_loop": false,
+  "email": {
+    "enabled": true,
+    "when": "interesting",
+    "subject": "Aurora watch — {location_name}"
+  },
+  "social": [
+    {
+      "platform": "threads",
+      "when": {"field": "kp_index", "op": ">=", "value": 5.0}
+    }
+  ],
   "email_on_check": true,
   "email_only_when_interesting": true
 }

--- a/agentic/workflows/aurora_forecast/graph.py
+++ b/agentic/workflows/aurora_forecast/graph.py
@@ -1,29 +1,34 @@
 """
 agentic/workflows/aurora_forecast/graph.py
 
-Lane: hourly aurora forecast for a configured location.
+Layer 1 lane: hourly aurora forecast on shared nodes.
 
-  check_aurora → store_forecast → notify_aurora
+  ingest_data → store_data → synthesis_data → verify_results → output_user_results
 
-Registered into agentic.workflows.common.graphs for schedule_graphs.json.
+Domain check remains available as adapter "aurora" and as tool check_aurora.
 """
 
 from __future__ import annotations
 
+import json
 import logging
+from pathlib import Path
 
 from agentic.graph_engine import PlanGraph, PlanNode
 from agentic.registry import TOOLS, tool
+from agentic.workflows.common.config import load_workflow_config
 from agentic.workflows.common.graphs import register_graph
+
+# Ensure shared Layer-1 nodes are registered.
+import agentic.workflows.common.nodes  # noqa: F401
 
 log = logging.getLogger(__name__)
 
+_WORKFLOW_DIR = Path(__file__).resolve().parent
+
 try:
-    from agentic.workflows.aurora_forecast.toolset import (
-        check_aurora as _check_aurora,
-        store_aurora_forecast as _store_aurora_forecast,
-        notify_aurora as _notify_aurora,
-    )
+    from agentic.workflows.aurora_forecast.toolset import check_aurora as _check_aurora
+
     _IMPORTS_OK = True
 except Exception as exc:
     log.warning("aurora_forecast toolkit import failed: %s", exc)
@@ -32,59 +37,102 @@ except Exception as exc:
     def _check_aurora(config_path: str = "", *, state=None) -> str:
         return '{"error": "aurora toolkit not available"}'
 
-    def _store_aurora_forecast(report_json: str = "", *, state=None) -> str:
-        return '{"error": "aurora toolkit not available"}'
 
-    def _notify_aurora(report_json: str = "", *, state=None) -> str:
-        return '{"error": "aurora toolkit not available"}'
-
-
-@tool(TOOLS["check_aurora"] if "check_aurora" in TOOLS else "check_aurora",
-      description="Fetch NOAA aurora + Kp + cloud cover and score viewability.",
-      graph=True, react=True, domain="weather")
+@tool(
+    TOOLS["check_aurora"] if "check_aurora" in TOOLS else "check_aurora",
+    description="Fetch NOAA aurora + Kp + cloud cover and score viewability.",
+    graph=True,
+    react=True,
+    domain="weather",
+)
 def check_aurora(config_path: str = "", *, state=None) -> str:
     return _check_aurora(config_path, state=state)
 
 
-@tool(TOOLS["store_aurora_forecast"] if "store_aurora_forecast" in TOOLS else "store_aurora_forecast",
-      description="Persist aurora report to the shared workflow store (TTL).",
-      graph=True, react=False, domain="weather")
-def store_aurora_forecast(report_json: str = "", *, state=None) -> str:
-    return _store_aurora_forecast(report_json, state=state)
-
-
-@tool(TOOLS["notify_aurora"] if "notify_aurora" in TOOLS else "notify_aurora",
-      description="Email aurora summary; post to Threads when Kp threshold met.",
-      graph=True, react=False, domain="weather")
-def notify_aurora(report_json: str = "", *, state=None) -> str:
-    return _notify_aurora(report_json, state=state)
+def _cfg_json() -> str:
+    cfg = load_workflow_config(_WORKFLOW_DIR)
+    return json.dumps(cfg, ensure_ascii=False)
 
 
 def build_aurora_forecast_graph(
     goal: str = "Check aurora visibility, store forecast, and notify when warranted",
 ) -> PlanGraph:
+    cfg = load_workflow_config(_WORKFLOW_DIR)
+    sources = cfg.get("sources") or [{"type": "adapter", "id": "aurora", "name": "aurora"}]
+    template = str(cfg.get("template") or "{summary}")
+    retain = str(cfg.get("retain_days") or 3)
+    email = cfg.get("email") if isinstance(cfg.get("email"), dict) else {
+        "enabled": True,
+        "when": "interesting",
+    }
+    social = cfg.get("social") if isinstance(cfg.get("social"), list) else [
+        {"platform": "threads", "when": {"field": "kp_index", "op": ">=", "value": 5.0}}
+    ]
+    config_json = json.dumps(cfg, ensure_ascii=False)
+
     nodes = [
         PlanNode(
-            id="check",
-            tool="check_aurora",
-            args={"config_path": ""},
+            id="ingest",
+            tool="ingest_data",
+            args={
+                "sources_json": json.dumps(sources),
+                "filters_json": "{}",
+                "parallel": "true",
+                "max_items": "5",
+                "config_json": config_json,
+            },
         ),
         PlanNode(
             id="store",
-            tool="store_aurora_forecast",
-            args={"report_json": "$result:check"},
-            depends_on=("check",),
+            tool="store_data",
+            args={
+                "workflow_id": "aurora_forecast",
+                "items_json": "$result:ingest",
+                "mode": "append",
+                "retain_days": retain,
+                "config_json": config_json,
+            },
+            depends_on=("ingest",),
         ),
         PlanNode(
-            id="notify",
-            tool="notify_aurora",
-            args={"report_json": "$result:check"},
+            id="synth",
+            tool="synthesis_data",
+            args={
+                "items_json": "$result:ingest",
+                "template": template,
+                "llm_enriched": "false",
+                "per_item": "true",
+                "config_json": config_json,
+            },
             depends_on=("store",),
+        ),
+        PlanNode(
+            id="verify",
+            tool="verify_results",
+            args={
+                "results_json": "$result:synth",
+                "human_in_the_loop": "false",
+                "llm_verify": "false",
+                "auto_pass_json": "{}",
+                "config_json": config_json,
+            },
+            depends_on=("synth",),
+        ),
+        PlanNode(
+            id="output",
+            tool="output_user_results",
+            args={
+                "results_json": "$result:verify",
+                "email_json": json.dumps(email),
+                "social_json": json.dumps(social),
+                "config_json": config_json,
+            },
+            depends_on=("verify",),
         ),
     ]
     return PlanGraph(
         id="aurora_forecast",
-        name="Aurora forecast (NOAA + clouds)",
+        name="Aurora forecast (shared nodes)",
         goal=goal,
         nodes=tuple(nodes),
     )
@@ -92,4 +140,4 @@ def build_aurora_forecast_graph(
 
 register_graph(build_aurora_forecast_graph())
 
-__all__ = ["build_aurora_forecast_graph", "check_aurora", "store_aurora_forecast", "notify_aurora"]
+__all__ = ["build_aurora_forecast_graph", "check_aurora"]

--- a/agentic/workflows/common/__init__.py
+++ b/agentic/workflows/common/__init__.py
@@ -1,9 +1,9 @@
 """Shared primitives for agentic workflows (job_hunt, aurora_forecast, …).
 
-Layer 0 stack:
-  Spec → Graph → Nodes (execution.py) → Toolsets (registry/MCP)
+Stack:
+  Spec → Graph → Nodes (execution + nodes.py registration) → Toolsets
 
-Helpers: config, store, notify, graph registry.
+Layer 1 registers the five shared nodes as graph tools.
 """
 
 from agentic.workflows.common.config import load_workflow_config, resolve_config_value

--- a/agentic/workflows/common/execution.py
+++ b/agentic/workflows/common/execution.py
@@ -448,10 +448,21 @@ def output_user_results(
             for r in deliverable
         )
         if when == "always" or interesting:
+            # Render email subject template with values from first deliverable result
+            subject_tmpl = str(email_cfg.get("subject") or cfg.get("email_subject") or "Aiko workflow")
+            subject = subject_tmpl
+            if deliverable and "{" in subject_tmpl:
+                first_result = deliverable[0]
+                item = first_result.get("item") if isinstance(first_result.get("item"), dict) else {}
+                # Merge result and item fields for template rendering
+                all_fields = {**item, **first_result}
+                for key, val in all_fields.items():
+                    if isinstance(val, (str, int, float, bool)):
+                        subject = subject.replace("{" + key + "}", str(val))
             actions.append({
                 "channel": "email",
                 "result": notify_email(
-                    subject=str(email_cfg.get("subject") or cfg.get("email_subject") or "Aiko workflow"),
+                    subject=subject,
                     body=body,
                     to=email_cfg.get("to"),
                 ),

--- a/agentic/workflows/common/graphs.py
+++ b/agentic/workflows/common/graphs.py
@@ -36,8 +36,9 @@ def list_graphs() -> list[str]:
 
 
 def _ensure_workflow_graphs_loaded() -> None:
-    """Import workflow graph modules so they self-register."""
+    """Import shared nodes + workflow graph modules so they self-register."""
     modules = (
+        "agentic.workflows.common.nodes",
         "agentic.workflows.job_hunt.graph",
         "agentic.workflows.aurora_forecast.graph",
     )

--- a/agentic/workflows/common/nodes.py
+++ b/agentic/workflows/common/nodes.py
@@ -75,7 +75,7 @@ def _expand_aurora_sources(sources_json: str, state=None) -> tuple[str, list[dic
     return json.dumps(remaining, ensure_ascii=False), pre_items
 
 
-def _merge_pre_items(result_json: str, pre_items: list[dict[str, Any]], state=None) -> str:
+def _merge_pre_items(result_json: str, pre_items: list[dict[str, Any]], state=None, max_items: int = 50) -> str:
     if not pre_items:
         return result_json
     data = _loads(result_json, {})
@@ -83,6 +83,8 @@ def _merge_pre_items(result_json: str, pre_items: list[dict[str, Any]], state=No
         data = {"ok": True, "items": [], "meta": {}}
     items = list(data.get("items") or [])
     items = pre_items + items
+    # Enforce max_items limit after prepending
+    items = items[:max_items]
     data["items"] = items
     data["ok"] = True if items else data.get("ok", True)
     meta = data.get("meta") if isinstance(data.get("meta"), dict) else {}
@@ -153,7 +155,11 @@ def ingest_data(
         config_json=config_json,
         state=state,
     )
-    return _merge_pre_items(result, pre_items, state=state)
+    try:
+        limit = max(1, int(max_items or 50))
+    except (TypeError, ValueError):
+        limit = 50
+    return _merge_pre_items(result, pre_items, state=state, max_items=limit)
 
 
 @tool(

--- a/agentic/workflows/common/nodes.py
+++ b/agentic/workflows/common/nodes.py
@@ -1,0 +1,157 @@
+"""Register Layer-1 shared workflow nodes as graph tools.
+
+Importing this module binds handlers from execution.py into the registry
+using catalog metadata from config/tools.yaml (with string fallback).
+"""
+
+from __future__ import annotations
+
+from agentic.registry import TOOLS, tool
+from agentic.workflows.common import execution as _ex
+
+
+def _spec(name: str, description: str):
+    if name in TOOLS:
+        return TOOLS[name]
+    return name
+
+
+@tool(
+    _spec("ingest_data", "Layer-1 shared node: ingest sources into items[]"),
+    description="Layer-1 shared node: ingest sources into items[].",
+    graph=True,
+    react=False,
+    domain="workflow",
+)
+def ingest_data(
+    sources_json: str = "[]",
+    filters_json: str = "{}",
+    parallel: str = "true",
+    max_items: str = "50",
+    config_json: str = "{}",
+    *,
+    state=None,
+) -> str:
+    return _ex.ingest_data(
+        sources_json=sources_json,
+        filters_json=filters_json,
+        parallel=parallel,
+        max_items=max_items,
+        config_json=config_json,
+        state=state,
+    )
+
+
+@tool(
+    _spec("store_data", "Layer-1 shared node: persist items to TTL store"),
+    description="Layer-1 shared node: persist items to TTL store.",
+    graph=True,
+    react=False,
+    domain="workflow",
+)
+def store_data(
+    workflow_id: str = "",
+    items_json: str = "",
+    mode: str = "append",
+    retain_days: str = "3",
+    config_json: str = "{}",
+    *,
+    state=None,
+) -> str:
+    return _ex.store_data(
+        workflow_id=workflow_id,
+        items_json=items_json,
+        mode=mode,
+        retain_days=retain_days,
+        config_json=config_json,
+        state=state,
+    )
+
+
+@tool(
+    _spec("synthesis_data", "Layer-1 shared node: template fill from items"),
+    description="Layer-1 shared node: template fill from items.",
+    graph=True,
+    react=False,
+    domain="workflow",
+)
+def synthesis_data(
+    items_json: str = "",
+    template: str = "",
+    llm_enriched: str = "false",
+    per_item: str = "true",
+    config_json: str = "{}",
+    *,
+    client=None,
+    model: str | None = None,
+    state=None,
+) -> str:
+    return _ex.synthesis_data(
+        items_json=items_json,
+        template=template,
+        llm_enriched=llm_enriched,
+        per_item=per_item,
+        config_json=config_json,
+        client=client,
+        model=model,
+        state=state,
+    )
+
+
+@tool(
+    _spec("verify_results", "Layer-1 shared node: HITL or auto-pass verify"),
+    description="Layer-1 shared node: HITL or auto-pass verify.",
+    graph=True,
+    react=False,
+    domain="workflow",
+)
+def verify_results(
+    results_json: str = "",
+    human_in_the_loop: str = "false",
+    llm_verify: str = "false",
+    auto_pass_json: str = "{}",
+    config_json: str = "{}",
+    *,
+    state=None,
+) -> str:
+    return _ex.verify_results(
+        results_json=results_json,
+        human_in_the_loop=human_in_the_loop,
+        llm_verify=llm_verify,
+        auto_pass_json=auto_pass_json,
+        config_json=config_json,
+        state=state,
+    )
+
+
+@tool(
+    _spec("output_user_results", "Layer-1 shared node: email / social output"),
+    description="Layer-1 shared node: email / social output.",
+    graph=True,
+    react=False,
+    domain="workflow",
+)
+def output_user_results(
+    results_json: str = "",
+    email_json: str = "{}",
+    social_json: str = "[]",
+    config_json: str = "{}",
+    *,
+    state=None,
+) -> str:
+    return _ex.output_user_results(
+        results_json=results_json,
+        email_json=email_json,
+        social_json=social_json,
+        config_json=config_json,
+        state=state,
+    )
+
+
+__all__ = [
+    "ingest_data",
+    "store_data",
+    "synthesis_data",
+    "verify_results",
+    "output_user_results",
+]

--- a/agentic/workflows/common/nodes.py
+++ b/agentic/workflows/common/nodes.py
@@ -1,10 +1,16 @@
 """Register Layer-1 shared workflow nodes as graph tools.
 
-Importing this module binds handlers from execution.py into the registry
-using catalog metadata from config/tools.yaml (with string fallback).
+Importing this module binds handlers into the registry using catalog
+metadata from config/tools.yaml (with string fallback).
+
+Also hosts small Layer-1 adapters (e.g. aurora) so domain checks can run
+through ingest_data without bloating execution.py.
 """
 
 from __future__ import annotations
+
+import json
+from typing import Any
 
 from agentic.registry import TOOLS, tool
 from agentic.workflows.common import execution as _ex
@@ -14,6 +20,112 @@ def _spec(name: str, description: str):
     if name in TOOLS:
         return TOOLS[name]
     return name
+
+
+def _loads(raw: str | dict | list | None, default: Any = None) -> Any:
+    if raw is None or raw == "":
+        return default if default is not None else {}
+    if isinstance(raw, (dict, list)):
+        return raw
+    try:
+        return json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return default if default is not None else {}
+
+
+def _expand_aurora_sources(sources_json: str, state=None) -> tuple[str, list[dict[str, Any]]]:
+    """Resolve adapter:aurora sources into concrete items; leave other sources."""
+    sources = _loads(sources_json, [])
+    if isinstance(sources, dict):
+        sources = sources.get("sources") or []
+    if not isinstance(sources, list):
+        sources = []
+
+    remaining: list[dict[str, Any]] = []
+    pre_items: list[dict[str, Any]] = []
+
+    for src in sources:
+        if not isinstance(src, dict):
+            continue
+        stype = str(src.get("type") or "").strip().lower()
+        name = str(src.get("name") or src.get("adapter") or src.get("id") or "").strip().lower()
+        if stype == "adapter" and name in {"aurora", "aurora_forecast"}:
+            try:
+                from agentic.workflows.aurora_forecast.toolset import check_aurora
+
+                raw = check_aurora(str(src.get("config_path") or ""), state=state)
+                payload = json.loads(raw) if isinstance(raw, str) else raw
+                if isinstance(payload, dict) and not (
+                    payload.get("error") and "location_name" not in payload
+                ):
+                    item = dict(payload)
+                    sid = str(src.get("id") or "aurora")
+                    item.setdefault("id", sid)
+                    item.setdefault("source", sid)
+                    item.setdefault("type", "adapter")
+                    item.setdefault("text", str(payload.get("summary") or ""))
+                    pre_items.append(item)
+                else:
+                    remaining.append(src)
+            except Exception:
+                remaining.append(src)
+        else:
+            remaining.append(src)
+
+    return json.dumps(remaining, ensure_ascii=False), pre_items
+
+
+def _merge_pre_items(result_json: str, pre_items: list[dict[str, Any]], state=None) -> str:
+    if not pre_items:
+        return result_json
+    data = _loads(result_json, {})
+    if not isinstance(data, dict):
+        data = {"ok": True, "items": [], "meta": {}}
+    items = list(data.get("items") or [])
+    items = pre_items + items
+    data["items"] = items
+    data["ok"] = True if items else data.get("ok", True)
+    meta = data.get("meta") if isinstance(data.get("meta"), dict) else {}
+    meta["pre_expanded"] = ["aurora"]
+    data["meta"] = meta
+    if state is not None and hasattr(state, "data") and isinstance(state.data, dict):
+        state.data["ingest_items"] = items
+    return json.dumps(data, ensure_ascii=False)
+
+
+def _promote_synth_fields(result_json: str, state=None) -> str:
+    """Copy level/kp/viewable onto each result for verify/output rules."""
+    data = _loads(result_json, {})
+    if not isinstance(data, dict):
+        return result_json
+    results = data.get("results")
+    if not isinstance(results, list):
+        return result_json
+    keys = (
+        "level",
+        "kp_index",
+        "viewable",
+        "summary",
+        "location_name",
+        "aurora_probability_pct",
+        "cloud_cover_pct",
+        "is_night",
+    )
+    out = []
+    for r in results:
+        if not isinstance(r, dict):
+            out.append(r)
+            continue
+        row = dict(r)
+        item = row.get("item") if isinstance(row.get("item"), dict) else {}
+        for k in keys:
+            if k not in row and k in item:
+                row[k] = item[k]
+        out.append(row)
+    data["results"] = out
+    if state is not None and hasattr(state, "data") and isinstance(state.data, dict):
+        state.data["synth_results"] = out
+    return json.dumps(data, ensure_ascii=False)
 
 
 @tool(
@@ -32,14 +144,16 @@ def ingest_data(
     *,
     state=None,
 ) -> str:
-    return _ex.ingest_data(
-        sources_json=sources_json,
+    remaining_json, pre_items = _expand_aurora_sources(sources_json, state=state)
+    result = _ex.ingest_data(
+        sources_json=remaining_json,
         filters_json=filters_json,
         parallel=parallel,
         max_items=max_items,
         config_json=config_json,
         state=state,
     )
+    return _merge_pre_items(result, pre_items, state=state)
 
 
 @tool(
@@ -86,7 +200,7 @@ def synthesis_data(
     model: str | None = None,
     state=None,
 ) -> str:
-    return _ex.synthesis_data(
+    result = _ex.synthesis_data(
         items_json=items_json,
         template=template,
         llm_enriched=llm_enriched,
@@ -96,6 +210,7 @@ def synthesis_data(
         model=model,
         state=state,
     )
+    return _promote_synth_fields(result, state=state)
 
 
 @tool(

--- a/config/tools.yaml
+++ b/config/tools.yaml
@@ -1046,6 +1046,109 @@
       "graph": true,
       "wiki": true,
       "skill": false
+    },
+{
+      "handler": "agentic.workflows.common.nodes:ingest_data",
+      "name": "ingest_data",
+      "description": "Layer-1 shared node: ingest from sources (http_json, adapter:aurora, …) into normalized items[].",
+      "props": {
+        "sources_json": {"type": "string", "description": "JSON list of source objects {type, id, ...}."},
+        "filters_json": {"type": "string", "description": "Optional filter tree JSON."},
+        "parallel": {"type": "string", "description": "true|false"},
+        "max_items": {"type": "string"},
+        "config_json": {"type": "string", "description": "Optional config overlay JSON."}
+      },
+      "required": [],
+      "domain": "workflow",
+      "react": false,
+      "graph": true,
+      "wiki": false,
+      "skill": false
+    },
+    {
+      "handler": "agentic.workflows.common.nodes:store_data",
+      "name": "store_data",
+      "description": "Layer-1 shared node: persist items to TTL JSONL store and prune by retain_days.",
+      "props": {
+        "workflow_id": {"type": "string"},
+        "items_json": {"type": "string"},
+        "mode": {"type": "string"},
+        "retain_days": {"type": "string"},
+        "config_json": {"type": "string"}
+      },
+      "required": [],
+      "domain": "workflow",
+      "react": false,
+      "graph": true,
+      "wiki": false,
+      "skill": false
+    },
+    {
+      "handler": "agentic.workflows.common.nodes:synthesis_data",
+      "name": "synthesis_data",
+      "description": "Layer-1 shared node: fill template from items (optional LLM enrichment later).",
+      "props": {
+        "items_json": {"type": "string"},
+        "template": {"type": "string"},
+        "llm_enriched": {"type": "string"},
+        "per_item": {"type": "string"},
+        "config_json": {"type": "string"}
+      },
+      "required": [],
+      "domain": "workflow",
+      "react": false,
+      "graph": true,
+      "wiki": false,
+      "skill": false
+    },
+    {
+      "handler": "agentic.workflows.common.nodes:verify_results",
+      "name": "verify_results",
+      "description": "Layer-1 shared node: HITL gate or auto-pass rules on synthesized results.",
+      "props": {
+        "results_json": {"type": "string"},
+        "human_in_the_loop": {"type": "string"},
+        "llm_verify": {"type": "string"},
+        "auto_pass_json": {"type": "string"},
+        "config_json": {"type": "string"}
+      },
+      "required": [],
+      "domain": "workflow",
+      "react": false,
+      "graph": true,
+      "wiki": false,
+      "skill": false
+    },
+    {
+      "handler": "agentic.workflows.common.nodes:output_user_results",
+      "name": "output_user_results",
+      "description": "Layer-1 shared node: deliver verified results via email and/or social tools.",
+      "props": {
+        "results_json": {"type": "string"},
+        "email_json": {"type": "string"},
+        "social_json": {"type": "string"},
+        "config_json": {"type": "string"}
+      },
+      "required": [],
+      "domain": "workflow",
+      "react": false,
+      "graph": true,
+      "wiki": false,
+      "skill": false
+    },
+    {
+      "handler": "agentic.workflows.aurora_forecast.graph:check_aurora",
+      "name": "check_aurora",
+      "description": "Fetch NOAA aurora + Kp + cloud cover and score viewability (domain adapter).",
+      "props": {
+        "config_path": {"type": "string"}
+      },
+      "required": [],
+      "domain": "weather",
+      "react": true,
+      "graph": true,
+      "wiki": false,
+      "skill": false
     }
   ]
 }


### PR DESCRIPTION
## Layer 1 — Runnable shared nodes

Builds on merged Layer 0 (`#103`).

### What’s in this PR

| Piece | Change |
|-------|--------|
| `common/nodes.py` | Registers **ingest / store / synthesis / verify / output** as `graph=True` tools; **aurora adapter** expands `adapter:aurora` before generic ingest; promotes `kp_index` / `level` / `viewable` for output rules |
| `aurora_forecast/graph.py` | Rewired to **5 shared nodes** only |
| `aurora_forecast/config.json` | Mini-spec: `sources`, `template`, `email`, `social`, thresholds |
| `common/graphs.py` | Loads `common.nodes` before workflow graphs |
| `LAYER1.md` | Design notes |

### Aurora pipeline

```
ingest_data (adapter:aurora)
  → store_data
  → synthesis_data
  → verify_results
  → output_user_results  (email when interesting; Threads if kp≥5)
```

Domain `check_aurora` remains for ReAct / debug.

### Optional follow-up (not blocking)

Add the 5 node names (+ `check_aurora`) to `config/tools.yaml` so the catalog matches runtime. String-fallback `@tool(...)` still registers handlers without the catalog entries. After merge you can also run:

```bash
python util/export_tools_catalog.py
```

if that utility is how you normalize the catalog.

### Test plan

- [ ] Import: `from agentic.workflows.common.nodes import ingest_data`
- [ ] `from agentic.workflows.common.graphs import get_graph; g = get_graph("aurora_forecast"); assert g and len(g.nodes)==5`
- [ ] Node tools: `ingest_data`, `store_data`, … present in `registry.get_graph_tool_map()`
- [ ] Dry-run / scheduled hourly aurora once network is available

### Out of scope

- job_hunt migration onto shared nodes (Layer 2)
- Studio / Spec codegen


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
- Added a standardized workflow pipeline for ingesting, storing, synthesizing, verifying, and presenting results.
- Added the Aurora forecast workflow with configurable data sources, summaries, retention, email alerts, and social notifications for notable events.
- Added documentation describing workflow configuration, execution order, triggers, and supported capabilities.

## Improvements
- Aurora forecasts now use the shared workflow pipeline for more consistent processing and output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->