### PR TITLE
feat(workflows): Layer 3 — Spec JSON → shared PlanGraph

### DIFF
--- a/agentic/workflows/LAYER3.md
+++ b/agentic/workflows/LAYER3.md
@@ -1,0 +1,53 @@
+# Layer 3 — Spec JSON → PlanGraph
+
+Builds on Layer 2 (`LAYER2.md`).
+
+## What Layer 3 adds
+
+1. **`common/spec.py`** — versioned Spec schema (`spec_version: "1"`), validate, load, and **coerce** legacy `config.json` into a Spec
+2. **`common/spec_graph.py`** — `build_plan_graph(spec)` compiles Spec → shared 5-node `PlanGraph`
+3. **Aurora + job_hunt** — `graph.py` builders load Spec (or coerce config) then call `build_plan_graph` (no duplicated node lists)
+4. Optional **`spec.json`** per workflow — if present, preferred over coerced config
+
+## Spec shape (v1)
+
+```json
+{
+  "spec_version": "1",
+  "id": "gen_job_post",
+  "name": "Job hunt (shared nodes)",
+  "goal": "Fetch job listings, draft posts, save for human review",
+  "pipeline": "shared_5",
+  "workflow_id": "job_hunt",
+  "sources": [{"type": "adapter", "id": "job_hunt", "name": "job_hunt"}],
+  "filters": {},
+  "max_items": 30,
+  "retain_days": 3,
+  "parallel": true,
+  "template": "",
+  "llm_enriched": true,
+  "per_item": true,
+  "human_in_the_loop": true,
+  "auto_pass_if": null,
+  "email": {"enabled": false},
+  "social": [],
+  "config": { }
+}
+```
+
+`config` holds domain fields (RSS feeds, `post_fields`, lat/lon, …). Shared fields may also appear at the top level; coercion lifts them from legacy configs automatically.
+
+## Pipeline
+
+Only `shared_5` in Layer 3:
+
+```text
+ingest_data → store_data → synthesis_data → verify_results → output_user_results
+```
+
+## Not in Layer 3
+
+- Studio UI (Layer 4)
+- Arbitrary custom node DAGs in Spec (only `shared_5`)
+- Auto-codegen of Python modules
+- Removing domain toolsets / adapters

--- a/agentic/workflows/LAYER3.md
+++ b/agentic/workflows/LAYER3.md
@@ -37,6 +37,12 @@ Builds on Layer 2 (`LAYER2.md`).
 
 `config` holds domain fields (RSS feeds, `post_fields`, lat/lon, …). Shared fields may also appear at the top level; coercion lifts them from legacy configs automatically.
 
+### Field notes
+
+- **`max_items` / `retain_days`**: clamped to a minimum of **1** at validate time.
+- **`template`**: omitted → default `"{summary}"`. Explicit `""` stays empty (no default fill-in).
+- **`llm_verify`**: not on Spec v1; verify always uses `"false"` in Layer 3 (HITL / rules only).
+
 ## Pipeline
 
 Only `shared_5` in Layer 3:
@@ -51,3 +57,4 @@ ingest_data → store_data → synthesis_data → verify_results → output_user
 - Arbitrary custom node DAGs in Spec (only `shared_5`)
 - Auto-codegen of Python modules
 - Removing domain toolsets / adapters
+- Spec-driven `llm_verify` (always off in shared_5 compile)

--- a/agentic/workflows/aurora_forecast/graph.py
+++ b/agentic/workflows/aurora_forecast/graph.py
@@ -18,6 +18,8 @@ from agentic.graph_engine import PlanGraph, PlanNode
 from agentic.registry import TOOLS, tool
 from agentic.workflows.common.config import load_workflow_config
 from agentic.workflows.common.graphs import register_graph
+from agentic.workflows.common.spec import load_spec_for_workflow
+from agentic.workflows.common.spec_graph import build_plan_graph
 
 # Ensure shared Layer-1 nodes are registered.
 import agentic.workflows.common.nodes  # noqa: F401
@@ -49,93 +51,38 @@ def check_aurora(config_path: str = "", *, state=None) -> str:
     return _check_aurora(config_path, state=state)
 
 
-def _cfg_json() -> str:
-    cfg = load_workflow_config(_WORKFLOW_DIR)
-    return json.dumps(cfg, ensure_ascii=False)
-
-
 def build_aurora_forecast_graph(
     goal: str = "Check aurora visibility, store forecast, and notify when warranted",
 ) -> PlanGraph:
+    """Layer 3: Spec (or coerced config.json) → shared 5-node PlanGraph."""
     cfg = load_workflow_config(_WORKFLOW_DIR)
-    sources = cfg.get("sources") or [{"type": "adapter", "id": "aurora", "name": "aurora"}]
-    template = str(cfg.get("template") or "{summary}")
-    retain = str(cfg.get("retain_days") or 3)
-    email = cfg.get("email") if isinstance(cfg.get("email"), dict) else {
-        "enabled": True,
-        "when": "interesting",
-    }
-    social = cfg.get("social") if isinstance(cfg.get("social"), list) else [
-        {"platform": "threads", "when": {"field": "kp_index", "op": ">=", "value": 5.0}}
-    ]
-    config_json = json.dumps(cfg, ensure_ascii=False)
+    # Preserve prior default when config omits max_items
+    if "max_items" not in cfg and "max_results" not in cfg:
+        cfg = {**cfg, "max_items": 5}
+    if "email" not in cfg:
+        cfg = {
+            **cfg,
+            "email": {"enabled": True, "when": "interesting"},
+        }
+    if "social" not in cfg:
+        cfg = {
+            **cfg,
+            "social": [
+                {"platform": "threads", "when": {"field": "kp_index", "op": ">=", "value": 5.0}}
+            ],
+        }
+    # Write temp defaults via coerce path: load_spec_for_workflow reads disk config,
+    # so apply overrides through coerce_config_to_spec directly.
+    from agentic.workflows.common.spec import coerce_config_to_spec
 
-    nodes = [
-        PlanNode(
-            id="ingest",
-            tool="ingest_data",
-            args={
-                "sources_json": json.dumps(sources),
-                "filters_json": "{}",
-                "parallel": "true",
-                "max_items": "5",
-                "config_json": config_json,
-            },
-        ),
-        PlanNode(
-            id="store",
-            tool="store_data",
-            args={
-                "workflow_id": "aurora_forecast",
-                "items_json": "$result:ingest",
-                "mode": "append",
-                "retain_days": retain,
-                "config_json": config_json,
-            },
-            depends_on=("ingest",),
-        ),
-        PlanNode(
-            id="synth",
-            tool="synthesis_data",
-            args={
-                "items_json": "$result:ingest",
-                "template": template,
-                "llm_enriched": "false",
-                "per_item": "true",
-                "config_json": config_json,
-            },
-            depends_on=("store",),
-        ),
-        PlanNode(
-            id="verify",
-            tool="verify_results",
-            args={
-                "results_json": "$result:synth",
-                "human_in_the_loop": "false",
-                "llm_verify": "false",
-                "auto_pass_json": "{}",
-                "config_json": config_json,
-            },
-            depends_on=("synth",),
-        ),
-        PlanNode(
-            id="output",
-            tool="output_user_results",
-            args={
-                "results_json": "$result:verify",
-                "email_json": json.dumps(email),
-                "social_json": json.dumps(social),
-                "config_json": config_json,
-            },
-            depends_on=("verify",),
-        ),
-    ]
-    return PlanGraph(
-        id="aurora_forecast",
+    spec = coerce_config_to_spec(
+        graph_id="aurora_forecast",
         name="Aurora forecast (shared nodes)",
         goal=goal,
-        nodes=tuple(nodes),
+        config=cfg,
+        workflow_id="aurora_forecast",
     )
+    return build_plan_graph(spec, goal=goal)
 
 
 register_graph(build_aurora_forecast_graph())

--- a/agentic/workflows/aurora_forecast/graph.py
+++ b/agentic/workflows/aurora_forecast/graph.py
@@ -69,6 +69,11 @@ def build_aurora_forecast_graph(
 
     cfg = load_workflow_config(_WORKFLOW_DIR)
     # Defaults only when coercing legacy config.json
+    if "sources" not in cfg or not isinstance(cfg.get("sources"), list) or not cfg.get("sources"):
+        cfg = {
+            **cfg,
+            "sources": [{"type": "adapter", "id": "aurora", "name": "aurora"}],
+        }
     if "max_items" not in cfg and "max_results" not in cfg:
         cfg = {**cfg, "max_items": 5}
     if "email" not in cfg:

--- a/agentic/workflows/aurora_forecast/graph.py
+++ b/agentic/workflows/aurora_forecast/graph.py
@@ -18,7 +18,6 @@ from agentic.graph_engine import PlanGraph, PlanNode
 from agentic.registry import TOOLS, tool
 from agentic.workflows.common.config import load_workflow_config
 from agentic.workflows.common.graphs import register_graph
-from agentic.workflows.common.spec import load_spec_for_workflow
 from agentic.workflows.common.spec_graph import build_plan_graph
 
 # Ensure shared Layer-1 nodes are registered.
@@ -54,9 +53,22 @@ def check_aurora(config_path: str = "", *, state=None) -> str:
 def build_aurora_forecast_graph(
     goal: str = "Check aurora visibility, store forecast, and notify when warranted",
 ) -> PlanGraph:
-    """Layer 3: Spec (or coerced config.json) → shared 5-node PlanGraph."""
+    """Layer 3: Spec (or coerced config.json) → shared 5-node PlanGraph.
+
+    Prefer ``spec.json`` when present so Layer-3 Specs are honored. Defaults
+    below apply only on the config.json fallback path.
+    """
+    from agentic.workflows.common.spec import WorkflowSpec, coerce_config_to_spec, load_spec
+
+    spec_path = _WORKFLOW_DIR / "spec.json"
+    if spec_path.is_file():
+        spec = load_spec(spec_path)
+        if goal and goal != spec.goal:
+            spec = WorkflowSpec(**{**spec.to_dict(), "goal": goal})
+        return build_plan_graph(spec, goal=goal)
+
     cfg = load_workflow_config(_WORKFLOW_DIR)
-    # Preserve prior default when config omits max_items
+    # Defaults only when coercing legacy config.json
     if "max_items" not in cfg and "max_results" not in cfg:
         cfg = {**cfg, "max_items": 5}
     if "email" not in cfg:
@@ -71,10 +83,6 @@ def build_aurora_forecast_graph(
                 {"platform": "threads", "when": {"field": "kp_index", "op": ">=", "value": 5.0}}
             ],
         }
-    # Write temp defaults via coerce path: load_spec_for_workflow reads disk config,
-    # so apply overrides through coerce_config_to_spec directly.
-    from agentic.workflows.common.spec import coerce_config_to_spec
-
     spec = coerce_config_to_spec(
         graph_id="aurora_forecast",
         name="Aurora forecast (shared nodes)",

--- a/agentic/workflows/common/__init__.py
+++ b/agentic/workflows/common/__init__.py
@@ -17,6 +17,8 @@ from agentic.workflows.common.execution import (
 )
 from agentic.workflows.common.graphs import get_graph, list_graphs, register_graph
 from agentic.workflows.common.spec import (
+    SPEC_VERSION,
+    SpecError,
     WorkflowSpec,
     coerce_config_to_spec,
     load_spec,
@@ -37,6 +39,8 @@ __all__ = [
     "resolve_config_value",
     "register_graph",
     "get_graph",
+    "SPEC_VERSION",
+    "SpecError",
     "WorkflowSpec",
     "validate_spec",
     "load_spec",

--- a/agentic/workflows/common/__init__.py
+++ b/agentic/workflows/common/__init__.py
@@ -4,6 +4,7 @@ Stack:
   Spec → Graph → Nodes (execution + nodes.py registration) → Toolsets
 
 Layer 1 registers the five shared nodes as graph tools.
+Layer 3 compiles WorkflowSpec → PlanGraph (shared_5 pipeline).
 """
 
 from agentic.workflows.common.config import load_workflow_config, resolve_config_value
@@ -15,6 +16,14 @@ from agentic.workflows.common.execution import (
     verify_results,
 )
 from agentic.workflows.common.graphs import get_graph, list_graphs, register_graph
+from agentic.workflows.common.spec import (
+    WorkflowSpec,
+    coerce_config_to_spec,
+    load_spec,
+    load_spec_for_workflow,
+    validate_spec,
+)
+from agentic.workflows.common.spec_graph import build_plan_graph
 from agentic.workflows.common.notify import maybe_post_threads, notify_email
 from agentic.workflows.common.store import (
     append_record,
@@ -28,16 +37,22 @@ __all__ = [
     "resolve_config_value",
     "register_graph",
     "get_graph",
+    "WorkflowSpec",
+    "validate_spec",
+    "load_spec",
+    "coerce_config_to_spec",
+    "load_spec_for_workflow",
+    "build_plan_graph",
     "list_graphs",
+    "ingest_data",
+    "store_data",
+    "synthesis_data",
+    "verify_results",
+    "output_user_results",
     "append_record",
     "load_records",
     "prune_records",
     "workflow_data_dir",
     "notify_email",
     "maybe_post_threads",
-    "ingest_data",
-    "store_data",
-    "synthesis_data",
-    "verify_results",
-    "output_user_results",
 ]

--- a/agentic/workflows/common/spec.py
+++ b/agentic/workflows/common/spec.py
@@ -84,6 +84,8 @@ def validate_spec(raw: dict[str, Any]) -> WorkflowSpec:
     if not isinstance(sources, list):
         raise SpecError("sources must be a list")
 
+    if "filters" in raw and raw["filters"] is not None and not isinstance(raw["filters"], dict):
+        raise SpecError("filters must be an object")
     filters = raw.get("filters") if isinstance(raw.get("filters"), dict) else {}
 
     def _int(key: str, default: int) -> int:
@@ -125,7 +127,11 @@ def validate_spec(raw: dict[str, Any]) -> WorkflowSpec:
     if auto_pass is not None and not isinstance(auto_pass, dict):
         raise SpecError("auto_pass_if must be an object or null")
 
+    if "email" in raw and raw["email"] is not None and not isinstance(raw["email"], dict):
+        raise SpecError("email must be an object")
     email = raw.get("email") if isinstance(raw.get("email"), dict) else {}
+    if "social" in raw and raw["social"] is not None and not isinstance(raw["social"], list):
+        raise SpecError("social must be a list")
     social = raw.get("social") if isinstance(raw.get("social"), list) else []
 
     config = raw.get("config")
@@ -167,16 +173,6 @@ def load_spec(path: str | Path) -> WorkflowSpec:
     return validate_spec(data if isinstance(data, dict) else {})
 
 
-# Keys lifted from legacy config.json onto Spec fields (not only left in config bag).
-_SPEC_LIFT_KEYS = frozenset({
-    "sources", "filters", "max_items", "retain_days", "parallel",
-    "template", "llm_enriched", "per_item", "human_in_the_loop",
-    "auto_pass_if", "email", "social", "workflow_id",
-    "max_results",  # job_hunt alias for max_items
-    "dedup_days",   # job_hunt alias for retain_days
-})
-
-
 def coerce_config_to_spec(
     *,
     graph_id: str,
@@ -196,14 +192,10 @@ def coerce_config_to_spec(
     retain = cfg.get("retain_days", cfg.get("dedup_days", 3))
 
     sources = cfg.get("sources")
-    if not isinstance(sources, list) or not sources:
-        # Sensible defaults when config has no explicit sources list
-        if wid in {"job_hunt", "gen_job_post"} or graph_id == "gen_job_post":
-            sources = [{"type": "adapter", "id": "job_hunt", "name": "job_hunt"}]
-        elif wid in {"aurora_forecast", "aurora"} or "aurora" in graph_id:
-            sources = [{"type": "adapter", "id": "aurora", "name": "aurora"}]
-        else:
-            sources = []
+    if not isinstance(sources, list):
+        sources = []
+    # Domain builders (job_hunt / aurora graph.py) inject sources defaults
+    # before calling coerce; shared Layer 3 stays workflow-agnostic.
 
     raw: dict[str, Any] = {
         "spec_version": SPEC_VERSION,
@@ -249,7 +241,7 @@ def load_spec_for_workflow(
                 spec = WorkflowSpec(**{**spec.to_dict(), "goal": goal})
             return spec
         except SpecError as exc:
-            log.warning("invalid spec.json in %s (%s); falling back to config.json", workflow_dir, exc)
+            log.warning("invalid spec.json in %s (%s); falling back to config.json", workflow_dir, exp)
 
     cfg = load_workflow_config(workflow_dir)
     return coerce_config_to_spec(

--- a/agentic/workflows/common/spec.py
+++ b/agentic/workflows/common/spec.py
@@ -264,10 +264,10 @@ def load_spec_for_workflow(
 __all__ = [
     "SPEC_VERSION",
     "SUPPORTED_PIPELINES",
-    "WorkflowSpec",
     "SpecError",
-    "validate_spec",
-    "load_spec",
+    "WorkflowSpec",
     "coerce_config_to_spec",
+    "load_spec",
     "load_spec_for_workflow",
+    "validate_spec",
 ]

--- a/agentic/workflows/common/spec.py
+++ b/agentic/workflows/common/spec.py
@@ -1,0 +1,273 @@
+"""Layer 3 — Workflow Spec schema, load/validate, and coerce from config.json.
+
+A Spec is a versioned JSON document that fully describes a shared-pipeline
+workflow. The engine builds a PlanGraph from it (see ``build_plan_graph``).
+
+Existing ``config.json`` files remain valid: ``coerce_config_to_spec`` lifts
+known keys into Spec fields and keeps the rest under ``config`` for domain
+adapters (post_fields, latitude, RSS feeds, …).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+SPEC_VERSION = "1"
+SUPPORTED_PIPELINES = frozenset({"shared_5"})
+
+
+@dataclass
+class WorkflowSpec:
+    """Version-1 workflow Spec (Layer 3)."""
+
+    spec_version: str = SPEC_VERSION
+    id: str = ""
+    name: str = ""
+    goal: str = ""
+    pipeline: str = "shared_5"
+    workflow_id: str = ""
+    sources: list[Any] = field(default_factory=list)
+    filters: dict[str, Any] = field(default_factory=dict)
+    max_items: int = 50
+    retain_days: int = 3
+    parallel: bool = True
+    template: str = "{summary}"
+    llm_enriched: bool = False
+    per_item: bool = True
+    human_in_the_loop: bool = False
+    auto_pass_if: dict[str, Any] | None = None
+    email: dict[str, Any] = field(default_factory=dict)
+    social: list[Any] = field(default_factory=list)
+    # Full domain bag (RSS feeds, post_fields, lat/lon, …) passed as config_json
+    config: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class SpecError(ValueError):
+    """Invalid or unsupported Spec."""
+
+
+def validate_spec(raw: dict[str, Any]) -> WorkflowSpec:
+    """Validate a Spec dict and return a WorkflowSpec. Raises SpecError."""
+    if not isinstance(raw, dict):
+        raise SpecError("spec must be a JSON object")
+
+    version = str(raw.get("spec_version") or SPEC_VERSION).strip() or SPEC_VERSION
+    if version != SPEC_VERSION:
+        raise SpecError(f"unsupported spec_version {version!r}; want {SPEC_VERSION!r}")
+
+    pipeline = str(raw.get("pipeline") or "shared_5").strip() or "shared_5"
+    if pipeline not in SUPPORTED_PIPELINES:
+        raise SpecError(
+            f"unsupported pipeline {pipeline!r}; supported: {sorted(SUPPORTED_PIPELINES)}"
+        )
+
+    sid = str(raw.get("id") or raw.get("workflow_id") or "").strip()
+    if not sid:
+        raise SpecError("spec requires id (or workflow_id)")
+
+    workflow_id = str(raw.get("workflow_id") or sid).strip()
+    name = str(raw.get("name") or sid).strip()
+    goal = str(raw.get("goal") or name).strip()
+
+    sources = raw.get("sources")
+    if sources is None:
+        sources = []
+    if not isinstance(sources, list):
+        raise SpecError("sources must be a list")
+
+    filters = raw.get("filters") if isinstance(raw.get("filters"), dict) else {}
+
+    def _int(key: str, default: int) -> int:
+        try:
+            return max(1, int(raw.get(key, default)))
+        except (TypeError, ValueError):
+            return default
+
+    max_items = _int("max_items", 50)
+    retain_days = _int("retain_days", 3)
+
+    parallel = raw.get("parallel", True)
+    if isinstance(parallel, str):
+        parallel = parallel.strip().lower() in {"1", "true", "yes", "on"}
+    else:
+        parallel = bool(parallel)
+
+    template = str(raw.get("template") if raw.get("template") is not None else "{summary}")
+
+    llm = raw.get("llm_enriched", False)
+    if isinstance(llm, str):
+        llm = llm.strip().lower() in {"1", "true", "yes", "on"}
+    else:
+        llm = bool(llm)
+
+    per_item = raw.get("per_item", True)
+    if isinstance(per_item, str):
+        per_item = per_item.strip().lower() in {"1", "true", "yes", "on"}
+    else:
+        per_item = bool(per_item)
+
+    hitl = raw.get("human_in_the_loop", False)
+    if isinstance(hitl, str):
+        hitl = hitl.strip().lower() in {"1", "true", "yes", "on"}
+    else:
+        hitl = bool(hitl)
+
+    auto_pass = raw.get("auto_pass_if")
+    if auto_pass is not None and not isinstance(auto_pass, dict):
+        raise SpecError("auto_pass_if must be an object or null")
+
+    email = raw.get("email") if isinstance(raw.get("email"), dict) else {}
+    social = raw.get("social") if isinstance(raw.get("social"), list) else []
+
+    config = raw.get("config")
+    if config is None:
+        config = {}
+    if not isinstance(config, dict):
+        raise SpecError("config must be an object")
+
+    return WorkflowSpec(
+        spec_version=version,
+        id=sid,
+        name=name,
+        goal=goal,
+        pipeline=pipeline,
+        workflow_id=workflow_id,
+        sources=list(sources),
+        filters=dict(filters),
+        max_items=max_items,
+        retain_days=retain_days,
+        parallel=bool(parallel),
+        template=template,
+        llm_enriched=bool(llm),
+        per_item=bool(per_item),
+        human_in_the_loop=bool(hitl),
+        auto_pass_if=dict(auto_pass) if isinstance(auto_pass, dict) else None,
+        email=dict(email),
+        social=list(social),
+        config=dict(config),
+    )
+
+
+def load_spec(path: str | Path) -> WorkflowSpec:
+    """Load and validate a Spec JSON file."""
+    p = Path(path)
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SpecError(f"failed to load spec from {p}: {exc}") from exc
+    return validate_spec(data if isinstance(data, dict) else {})
+
+
+# Keys lifted from legacy config.json onto Spec fields (not only left in config bag).
+_SPEC_LIFT_KEYS = frozenset({
+    "sources", "filters", "max_items", "retain_days", "parallel",
+    "template", "llm_enriched", "per_item", "human_in_the_loop",
+    "auto_pass_if", "email", "social", "workflow_id",
+    "max_results",  # job_hunt alias for max_items
+    "dedup_days",   # job_hunt alias for retain_days
+})
+
+
+def coerce_config_to_spec(
+    *,
+    graph_id: str,
+    name: str,
+    goal: str,
+    config: dict[str, Any],
+    workflow_id: str | None = None,
+) -> WorkflowSpec:
+    """Build a Spec from a legacy workflow config.json (+ graph metadata).
+
+    Domain-only keys stay under ``config`` so adapters keep working unchanged.
+    """
+    cfg = dict(config or {})
+    wid = workflow_id or str(cfg.get("workflow_id") or graph_id)
+
+    max_items = cfg.get("max_items", cfg.get("max_results", 50))
+    retain = cfg.get("retain_days", cfg.get("dedup_days", 3))
+
+    sources = cfg.get("sources")
+    if not isinstance(sources, list) or not sources:
+        # Sensible defaults when config has no explicit sources list
+        if wid in {"job_hunt", "gen_job_post"} or graph_id == "gen_job_post":
+            sources = [{"type": "adapter", "id": "job_hunt", "name": "job_hunt"}]
+        elif wid in {"aurora_forecast", "aurora"} or "aurora" in graph_id:
+            sources = [{"type": "adapter", "id": "aurora", "name": "aurora"}]
+        else:
+            sources = []
+
+    raw: dict[str, Any] = {
+        "spec_version": SPEC_VERSION,
+        "id": graph_id,
+        "name": name,
+        "goal": goal,
+        "pipeline": "shared_5",
+        "workflow_id": wid,
+        "sources": sources,
+        "filters": cfg.get("filters") if isinstance(cfg.get("filters"), dict) else {},
+        "max_items": max_items,
+        "retain_days": retain,
+        "parallel": cfg.get("parallel", True),
+        "template": cfg.get("template", "{summary}"),
+        "llm_enriched": cfg.get("llm_enriched", False),
+        "per_item": cfg.get("per_item", True),
+        "human_in_the_loop": cfg.get("human_in_the_loop", False),
+        "auto_pass_if": cfg.get("auto_pass_if"),
+        "email": cfg.get("email") if isinstance(cfg.get("email"), dict) else {},
+        "social": cfg.get("social") if isinstance(cfg.get("social"), list) else [],
+        "config": cfg,  # full original config for domain adapters
+    }
+    return validate_spec(raw)
+
+
+def load_spec_for_workflow(
+    workflow_dir: Path,
+    *,
+    graph_id: str,
+    name: str,
+    goal: str,
+    workflow_id: str | None = None,
+) -> WorkflowSpec:
+    """Load Spec from ``spec.json`` if present, else coerce ``config.json``."""
+    from agentic.workflows.common.config import load_workflow_config
+
+    spec_path = workflow_dir / "spec.json"
+    if spec_path.is_file():
+        try:
+            spec = load_spec(spec_path)
+            # Allow goal override from caller (runtime prompt)
+            if goal and goal != spec.goal:
+                spec = WorkflowSpec(**{**spec.to_dict(), "goal": goal})
+            return spec
+        except SpecError as exc:
+            log.warning("invalid spec.json in %s (%s); falling back to config.json", workflow_dir, exc)
+
+    cfg = load_workflow_config(workflow_dir)
+    return coerce_config_to_spec(
+        graph_id=graph_id,
+        name=name,
+        goal=goal,
+        config=cfg,
+        workflow_id=workflow_id,
+    )
+
+
+__all__ = [
+    "SPEC_VERSION",
+    "SUPPORTED_PIPELINES",
+    "WorkflowSpec",
+    "SpecError",
+    "validate_spec",
+    "load_spec",
+    "coerce_config_to_spec",
+    "load_spec_for_workflow",
+]

--- a/agentic/workflows/common/spec_graph.py
+++ b/agentic/workflows/common/spec_graph.py
@@ -37,16 +37,16 @@ def build_plan_graph(spec: WorkflowSpec, *, goal: str | None = None) -> PlanGrap
     domain.setdefault("template", spec.template)
     domain.setdefault("llm_enriched", spec.llm_enriched)
     domain.setdefault("human_in_the_loop", spec.human_in_the_loop)
-    # Overwrite with validated spec values (not setdefault) for lifted fields
-    domain["per_item"] = spec.per_item
-    domain["parallel"] = spec.parallel
-    domain["auto_pass_if"] = spec.auto_pass_if
-    domain["email"] = spec.email
-    domain["social"] = spec.social
+    if spec.auto_pass_if is not None:
+        domain.setdefault("auto_pass_if", spec.auto_pass_if)
+    if spec.email:
+        domain.setdefault("email", spec.email)
+    if spec.social:
+        domain.setdefault("social", spec.social)
 
     config_json = json.dumps(domain, ensure_ascii=False)
-    sources = spec.sources or domain.get("sources") or []
-    filters = spec.filters or {}
+    sources = list(spec.sources)
+    filters = dict(spec.filters)
     retain = str(spec.retain_days)
     max_items = str(spec.max_items)
     parallel = "true" if spec.parallel else "false"
@@ -55,8 +55,8 @@ def build_plan_graph(spec: WorkflowSpec, *, goal: str | None = None) -> PlanGrap
     per_item = "true" if spec.per_item else "false"
     hitl = "true" if spec.human_in_the_loop else "false"
     auto_pass = json.dumps(spec.auto_pass_if or {}, ensure_ascii=False)
-    email = spec.email or domain.get("email") or {}
-    social = spec.social if spec.social else (domain.get("social") or [])
+    email = dict(spec.email)
+    social = list(spec.social)
     workflow_id = spec.workflow_id or spec.id
 
     nodes = [

--- a/agentic/workflows/common/spec_graph.py
+++ b/agentic/workflows/common/spec_graph.py
@@ -37,12 +37,12 @@ def build_plan_graph(spec: WorkflowSpec, *, goal: str | None = None) -> PlanGrap
     domain.setdefault("template", spec.template)
     domain.setdefault("llm_enriched", spec.llm_enriched)
     domain.setdefault("human_in_the_loop", spec.human_in_the_loop)
-    if spec.auto_pass_if is not None:
-        domain.setdefault("auto_pass_if", spec.auto_pass_if)
-    if spec.email:
-        domain.setdefault("email", spec.email)
-    if spec.social:
-        domain.setdefault("social", spec.social)
+    # Overwrite with validated spec values (not setdefault) for lifted fields
+    domain["per_item"] = spec.per_item
+    domain["parallel"] = spec.parallel
+    domain["auto_pass_if"] = spec.auto_pass_if
+    domain["email"] = spec.email
+    domain["social"] = spec.social
 
     config_json = json.dumps(domain, ensure_ascii=False)
     sources = spec.sources or domain.get("sources") or []

--- a/agentic/workflows/common/spec_graph.py
+++ b/agentic/workflows/common/spec_graph.py
@@ -1,0 +1,132 @@
+"""Layer 3 — build a PlanGraph from a WorkflowSpec.
+
+Currently supports pipeline ``shared_5``:
+
+  ingest_data → store_data → synthesis_data → verify_results → output_user_results
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+from agentic.graph_engine import PlanGraph, PlanNode
+from agentic.workflows.common.spec import SpecError, WorkflowSpec
+
+log = logging.getLogger(__name__)
+
+
+def build_plan_graph(spec: WorkflowSpec, *, goal: str | None = None) -> PlanGraph:
+    """Compile a WorkflowSpec into a PlanGraph.
+
+    ``goal`` overrides ``spec.goal`` when provided (runtime user prompt).
+    """
+    if spec.pipeline != "shared_5":
+        raise SpecError(f"cannot build pipeline {spec.pipeline!r}")
+
+    run_goal = (goal or spec.goal or spec.name or spec.id).strip()
+    # Merge lifted fields back into the domain config bag so node handlers
+    # that only read config_json still see sources / HITL / email / etc.
+    domain: dict[str, Any] = dict(spec.config or {})
+    domain.setdefault("workflow_id", spec.workflow_id or spec.id)
+    domain.setdefault("sources", spec.sources)
+    domain.setdefault("filters", spec.filters)
+    domain.setdefault("retain_days", spec.retain_days)
+    domain.setdefault("max_items", spec.max_items)
+    domain.setdefault("template", spec.template)
+    domain.setdefault("llm_enriched", spec.llm_enriched)
+    domain.setdefault("human_in_the_loop", spec.human_in_the_loop)
+    if spec.auto_pass_if is not None:
+        domain.setdefault("auto_pass_if", spec.auto_pass_if)
+    if spec.email:
+        domain.setdefault("email", spec.email)
+    if spec.social:
+        domain.setdefault("social", spec.social)
+
+    config_json = json.dumps(domain, ensure_ascii=False)
+    sources = spec.sources or domain.get("sources") or []
+    filters = spec.filters or {}
+    retain = str(spec.retain_days)
+    max_items = str(spec.max_items)
+    parallel = "true" if spec.parallel else "false"
+    template = spec.template or ""
+    llm = "true" if spec.llm_enriched else "false"
+    per_item = "true" if spec.per_item else "false"
+    hitl = "true" if spec.human_in_the_loop else "false"
+    auto_pass = json.dumps(spec.auto_pass_if or {}, ensure_ascii=False)
+    email = spec.email or domain.get("email") or {}
+    social = spec.social if spec.social else (domain.get("social") or [])
+    workflow_id = spec.workflow_id or spec.id
+
+    nodes = [
+        PlanNode(
+            id="ingest",
+            tool="ingest_data",
+            args={
+                "sources_json": json.dumps(sources, ensure_ascii=False),
+                "filters_json": json.dumps(filters, ensure_ascii=False),
+                "parallel": parallel,
+                "max_items": max_items,
+                "config_json": config_json,
+            },
+        ),
+        PlanNode(
+            id="store",
+            tool="store_data",
+            args={
+                "workflow_id": workflow_id,
+                "items_json": "$result:ingest",
+                "mode": "append",
+                "retain_days": retain,
+                "config_json": config_json,
+            },
+            depends_on=("ingest",),
+        ),
+        PlanNode(
+            id="synth",
+            tool="synthesis_data",
+            args={
+                "items_json": "$result:ingest",
+                "template": template,
+                "llm_enriched": llm,
+                "per_item": per_item,
+                "config_json": config_json,
+            },
+            depends_on=("store",),
+        ),
+        PlanNode(
+            id="verify",
+            tool="verify_results",
+            args={
+                "results_json": "$result:synth",
+                "human_in_the_loop": hitl,
+                "llm_verify": "false",
+                "auto_pass_json": auto_pass,
+                "config_json": config_json,
+            },
+            depends_on=("synth",),
+        ),
+        PlanNode(
+            id="output",
+            tool="output_user_results",
+            args={
+                "results_json": "$result:verify",
+                "email_json": json.dumps(email, ensure_ascii=False),
+                "social_json": json.dumps(social, ensure_ascii=False),
+                "config_json": config_json,
+            },
+            depends_on=("verify",),
+        ),
+    ]
+
+    return PlanGraph(
+        id=spec.id,
+        name=spec.name or spec.id,
+        goal=run_goal,
+        nodes=tuple(nodes),
+        source="spec",
+    )
+
+
+__all__ = ["build_plan_graph"]

--- a/agentic/workflows/job_hunt/graph.py
+++ b/agentic/workflows/job_hunt/graph.py
@@ -15,9 +15,9 @@ registered for adapters / ReAct / legacy.
 
 from __future__ import annotations
 
-import json
-from pathlib import Path
 import logging
+from pathlib import Path
+
 log = logging.getLogger(__name__)
 
 from agentic.graph_engine import PlanGraph, PlanNode
@@ -101,15 +101,6 @@ def report_job_run(plan: str = "", search: str = "", draft: str = "", save: str 
     return _report_job_run(plan, search, draft, save)
 
 
-def _load_config() -> dict:
-    path = Path(__file__).resolve().parent / "config.json"
-    try:
-        return json.loads(path.read_text(encoding="utf-8"))
-    except (OSError, ValueError) as exc:
-        log.warning("job_hunt: failed to load %s: %s", path, exc)
-        return {}
-
-
 def build_gen_job_post_graph(
     *,
     goal: str = "Fetch job listings, draft posts, save for human review",
@@ -119,6 +110,7 @@ def build_gen_job_post_graph(
     Prefer ``spec.json`` when present so Layer-3 Specs are honored. Defaults
     below apply only on the config.json fallback path.
     """
+    from agentic.workflows.common.config import load_workflow_config
     from agentic.workflows.common.spec import WorkflowSpec, load_spec
 
     workflow_dir = Path(__file__).resolve().parent
@@ -129,7 +121,7 @@ def build_gen_job_post_graph(
             spec = WorkflowSpec(**{**spec.to_dict(), "goal": goal})
         return build_plan_graph(spec, goal=goal)
 
-    cfg = _load_config()
+    cfg = load_workflow_config(workflow_dir)
     # Defaults matching Layer 2 behavior when keys are absent (config fallback only)
     if "sources" not in cfg:
         cfg = {

--- a/agentic/workflows/job_hunt/graph.py
+++ b/agentic/workflows/job_hunt/graph.py
@@ -24,6 +24,8 @@ from agentic.graph_engine import PlanGraph, PlanNode
 from agentic.registry import TOOLS, tool
 from agentic.workflows.common.graphs import get_graph as get_shared_graph
 from agentic.workflows.common.graphs import register_graph as _register_shared
+from agentic.workflows.common.spec import coerce_config_to_spec
+from agentic.workflows.common.spec_graph import build_plan_graph
 
 # Ensure shared Layer-2 nodes (@tool ingest_data / store_data / …) are registered
 # before this module's graphs are used. plan_from_master may import this file
@@ -112,83 +114,35 @@ def build_gen_job_post_graph(
     *,
     goal: str = "Fetch job listings, draft posts, save for human review",
 ) -> PlanGraph:
-    """Layer 2: five shared nodes; domain work lives in adapters + toolset."""
+    """Layer 3: Spec (or coerced config.json) → shared 5-node PlanGraph."""
     cfg = _load_config()
-    config_json = json.dumps(cfg, ensure_ascii=False)
-    sources = cfg.get("sources") or [{"type": "adapter", "id": "job_hunt", "name": "job_hunt"}]
-    retain = str(cfg.get("retain_days") or cfg.get("dedup_days") or 3)
-    max_items = str(cfg.get("max_results") or 30)
-    hitl = "true" if cfg.get("human_in_the_loop", True) else "false"
-    llm = "true" if cfg.get("llm_enriched", True) else "false"
-    email = cfg.get("email") if isinstance(cfg.get("email"), dict) else {"enabled": False}
-    social = cfg.get("social") if isinstance(cfg.get("social"), list) else []
+    # Defaults matching Layer 2 behavior when keys are absent
+    if "sources" not in cfg:
+        cfg = {
+            **cfg,
+            "sources": [{"type": "adapter", "id": "job_hunt", "name": "job_hunt"}],
+        }
+    if "human_in_the_loop" not in cfg:
+        cfg = {**cfg, "human_in_the_loop": True}
+    if "llm_enriched" not in cfg:
+        cfg = {**cfg, "llm_enriched": True}
+    if "email" not in cfg:
+        cfg = {**cfg, "email": {"enabled": False}}
+    if "social" not in cfg:
+        cfg = {**cfg, "social": []}
+    if "max_items" not in cfg and "max_results" in cfg:
+        cfg = {**cfg, "max_items": cfg["max_results"]}
+    elif "max_items" not in cfg and "max_results" not in cfg:
+        cfg = {**cfg, "max_items": 30}
 
-    nodes = [
-        PlanNode(
-            id="ingest",
-            tool="ingest_data",
-            args={
-                "sources_json": json.dumps(sources),
-                "filters_json": json.dumps(cfg.get("filters") or {}),
-                "parallel": "true",
-                "max_items": max_items,
-                "config_json": config_json,
-            },
-        ),
-        PlanNode(
-            id="store",
-            tool="store_data",
-            args={
-                "workflow_id": "job_hunt",
-                "items_json": "$result:ingest",
-                "mode": "append",
-                "retain_days": retain,
-                "config_json": config_json,
-            },
-            depends_on=("ingest",),
-        ),
-        PlanNode(
-            id="synth",
-            tool="synthesis_data",
-            args={
-                "items_json": "$result:ingest",
-                "template": "",
-                "llm_enriched": llm,
-                "per_item": "true",
-                "config_json": config_json,
-            },
-            depends_on=("store",),
-        ),
-        PlanNode(
-            id="verify",
-            tool="verify_results",
-            args={
-                "results_json": "$result:synth",
-                "human_in_the_loop": hitl,
-                "llm_verify": "false",
-                "auto_pass_json": "{}",
-                "config_json": config_json,
-            },
-            depends_on=("synth",),
-        ),
-        PlanNode(
-            id="output",
-            tool="output_user_results",
-            args={
-                "results_json": "$result:verify",
-                "email_json": json.dumps(email),
-                "social_json": json.dumps(social),
-                "config_json": config_json,
-            },
-            depends_on=("verify",),
-        ),
-    ]
-    return PlanGraph(
-        id="gen_job_post",
+    spec = coerce_config_to_spec(
+        graph_id="gen_job_post",
         name="Job hunt (shared nodes): ingest → store → synth → verify → output",
         goal=goal,
-        nodes=tuple(nodes),
+        config=cfg,
+        workflow_id="job_hunt",
     )
+    return build_plan_graph(spec, goal=goal)
 
 
 def build_gen_job_post_legacy_graph(

--- a/agentic/workflows/job_hunt/graph.py
+++ b/agentic/workflows/job_hunt/graph.py
@@ -114,9 +114,23 @@ def build_gen_job_post_graph(
     *,
     goal: str = "Fetch job listings, draft posts, save for human review",
 ) -> PlanGraph:
-    """Layer 3: Spec (or coerced config.json) → shared 5-node PlanGraph."""
+    """Layer 3: Spec (or coerced config.json) → shared 5-node PlanGraph.
+
+    Prefer ``spec.json`` when present so Layer-3 Specs are honored. Defaults
+    below apply only on the config.json fallback path.
+    """
+    from agentic.workflows.common.spec import WorkflowSpec, load_spec
+
+    workflow_dir = Path(__file__).resolve().parent
+    spec_path = workflow_dir / "spec.json"
+    if spec_path.is_file():
+        spec = load_spec(spec_path)
+        if goal and goal != spec.goal:
+            spec = WorkflowSpec(**{**spec.to_dict(), "goal": goal})
+        return build_plan_graph(spec, goal=goal)
+
     cfg = _load_config()
-    # Defaults matching Layer 2 behavior when keys are absent
+    # Defaults matching Layer 2 behavior when keys are absent (config fallback only)
     if "sources" not in cfg:
         cfg = {
             **cfg,


### PR DESCRIPTION
## Summary
Layer 3: versioned **Workflow Spec** compiles to the shared 5-node `PlanGraph`. Aurora and job_hunt builders no longer hand-roll node lists.

## Changes
- **`common/spec.py`** — `WorkflowSpec` v1, `validate_spec`, `load_spec`, `coerce_config_to_spec` (legacy `config.json` still works), optional `spec.json`
- **`common/spec_graph.py`** — `build_plan_graph(spec)` → `ingest → store → synth → verify → output`
- **`aurora_forecast/graph.py`** / **`job_hunt/graph.py`** — build via Spec + `build_plan_graph`
- **`LAYER3.md`** — schema, non-goals

## Spec shape (v1)
```json
{
  "spec_version": "1",
  "id": "gen_job_post",
  "pipeline": "shared_5",
  "workflow_id": "job_hunt",
  "sources": [{"type": "adapter", "name": "job_hunt"}],
  "human_in_the_loop": true,
  "llm_enriched": true,
  "config": { }
}
```

Domain keys stay under `config` (RSS, `post_fields`, lat/lon, …).

## Not in this PR (Layer 4+)
- Studio UI
- Custom DAGs beyond `shared_5`
- Python codegen from Spec

## Test plan
- [x] `validate_spec` / `coerce_config_to_spec` smoke
- [x] `build_plan_graph` yields five shared tools
- [ ] `get_graph('gen_job_post')` / `aurora_forecast` still register
- [ ] Scheduled runs unchanged for both lanes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for versioned workflow specifications with validation and legacy configuration compatibility.
  - Added a shared five-step workflow pipeline covering ingestion, storage, synthesis, verification, and output.
  - Workflow configurations can now provide defaults for item limits and email or Threads notifications.
  - Workflow specifications can override goals and take precedence over legacy configuration when available.

- **Documentation**
  - Added documentation describing specification formats, validation, workflow integration, and supported pipeline features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->