### PR TITLE
feat(mcp): Bright Data Scraper Studio MCP + self-heal (removable)

### DIFF
--- a/interface/mcp_server/brightdata/README.md
+++ b/interface/mcp_server/brightdata/README.md
@@ -13,8 +13,9 @@ Self-healing is **not** local selector repair inside Aiko. Bright Data runs an A
    (e.g. `"price is undefined; it is now in span.price-now"`).
 3. API: `POST /dca/collectors/{c_*}/refactor_template` → poll progress.
 4. Job pauses at **`pending_answer` / awaiting approval** (HITL by default).
-5. **`bd_self_heal_approve`** commits the diff (`resume_automation_job`).
-6. Poll **`bd_self_heal_progress`** until `phase=completed` (required before collect).
+5. **`bd_self_heal_approve`** only **submits** the decision (`phase=decision_submitted`).
+   It does **not** mean the heal job finished.
+6. Poll **`bd_self_heal_progress`** until `completed=true` (or `failed=true`).
 7. Same **`c_*` collector id** keeps working; re-run **`bd_run_collect`**.
 
 CLI equivalent: `bdata scraper heal <id> "..."` then `bdata scraper approve`.
@@ -43,9 +44,9 @@ python -m interface.mcp_server.brightdata.server
 | `bd_trigger_collect` | Queue batch run → `collection_id` |
 | `bd_get_results` | Poll / download rows |
 | `bd_run_collect` | Trigger + wait for rows |
-| `bd_self_heal` | Start self-heal; optional `auto_approve` |
-| `bd_self_heal_progress` | Poll heal job |
-| `bd_self_heal_approve` | Approve/reject pending diff |
+| `bd_self_heal` | Start self-heal; optional `auto_approve` (waits for completion) |
+| `bd_self_heal_progress` | Poll heal job (`completed` / `failed` flags) |
+| `bd_self_heal_approve` | Submit approve/reject only (`decision_submitted`) |
 
 ## Aiko client (manual for now)
 
@@ -61,6 +62,8 @@ python -m interface.mcp_server.brightdata.server
 
 1. `bd_run_collect` with URLs → structured rows for deep research / `learn_report`.
 2. If rows empty or fields null → `bd_self_heal` with a fix prompt + sample URL.
-3. Review → `bd_self_heal_approve`.
-4. Poll `bd_self_heal_progress` until `phase=completed`.
+3. Review → `bd_self_heal_approve` → expect `phase=decision_submitted` (not completed).
+4. Poll `bd_self_heal_progress` until `completed=true`.
 5. `bd_run_collect` again with the **same** collector id.
+
+With `bd_self_heal(..., auto_approve=true)`, steps 3–4 are handled inside the tool and the result uses `phase=completed` only after the job finishes.

--- a/interface/mcp_server/brightdata/README.md
+++ b/interface/mcp_server/brightdata/README.md
@@ -9,12 +9,13 @@ Isolated stdio MCP server so Aiko can call **Scraper Studio** collectors and **S
 Self-healing is **not** local selector repair inside Aiko. Bright Data runs an AI refactor on *their* infrastructure:
 
 1. Site layout changes → your collector returns empty / null fields.
-2. You (or the agent) call **`bd_self_heal`** with a plain-language prompt  
+2. You (or the agent) call **`bd_self_heal`** with a plain-language prompt
    (e.g. `"price is undefined; it is now in span.price-now"`).
 3. API: `POST /dca/collectors/{c_*}/refactor_template` → poll progress.
 4. Job pauses at **`pending_answer` / awaiting approval** (HITL by default).
 5. **`bd_self_heal_approve`** commits the diff (`resume_automation_job`).
-6. Same **`c_*` collector id** keeps working; re-run **`bd_run_collect`**.
+6. Poll **`bd_self_heal_progress`** until `phase=completed` (required before collect).
+7. Same **`c_*` collector id** keeps working; re-run **`bd_run_collect`**.
 
 CLI equivalent: `bdata scraper heal <id> "..."` then `bdata scraper approve`.
 
@@ -61,4 +62,5 @@ python -m interface.mcp_server.brightdata.server
 1. `bd_run_collect` with URLs → structured rows for deep research / `learn_report`.
 2. If rows empty or fields null → `bd_self_heal` with a fix prompt + sample URL.
 3. Review → `bd_self_heal_approve`.
-4. `bd_run_collect` again with the **same** collector id.
+4. Poll `bd_self_heal_progress` until `phase=completed`.
+5. `bd_run_collect` again with the **same** collector id.

--- a/interface/mcp_server/brightdata/README.md
+++ b/interface/mcp_server/brightdata/README.md
@@ -1,0 +1,64 @@
+# Bright Data Scraper Studio MCP (optional)
+
+Isolated stdio MCP server so Aiko can call **Scraper Studio** collectors and **Self-Healing** without baking Bright Data into core research code.
+
+**Remove later:** delete this directory and any client spawn that points at `interface.mcp_server.brightdata.server`.
+
+## How self-healing works (Bright Data)
+
+Self-healing is **not** local selector repair inside Aiko. Bright Data runs an AI refactor on *their* infrastructure:
+
+1. Site layout changes → your collector returns empty / null fields.
+2. You (or the agent) call **`bd_self_heal`** with a plain-language prompt  
+   (e.g. `"price is undefined; it is now in span.price-now"`).
+3. API: `POST /dca/collectors/{c_*}/refactor_template` → poll progress.
+4. Job pauses at **`pending_answer` / awaiting approval** (HITL by default).
+5. **`bd_self_heal_approve`** commits the diff (`resume_automation_job`).
+6. Same **`c_*` collector id** keeps working; re-run **`bd_run_collect`**.
+
+CLI equivalent: `bdata scraper heal <id> "..."` then `bdata scraper approve`.
+
+## Env
+
+```bash
+export BRIGHT_DATA_API_TOKEN=...          # required for live calls
+export BRIGHT_DATA_COLLECTOR_ID=c_...     # default collector
+# optional:
+# export BRIGHT_DATA_API_BASE=https://api.brightdata.com
+```
+
+Hackathon credits: Bright Data promo code `wemakedevs` (see Scrape-Verse).
+
+## Run standalone
+
+```bash
+python -m interface.mcp_server.brightdata.server
+```
+
+## Tools
+
+| Tool | Purpose |
+|------|---------|
+| `bd_trigger_collect` | Queue batch run → `collection_id` |
+| `bd_get_results` | Poll / download rows |
+| `bd_run_collect` | Trigger + wait for rows |
+| `bd_self_heal` | Start self-heal; optional `auto_approve` |
+| `bd_self_heal_progress` | Poll heal job |
+| `bd_self_heal_approve` | Approve/reject pending diff |
+
+## Aiko client (manual for now)
+
+Point a stdio MCP client at:
+
+```text
+python -m interface.mcp_server.brightdata.server
+```
+
+(with the same env as Aiko). Core `agentic/mcp_client` currently boots the social server only; wire a second process or temporary swap when testing. Prefer **not** merging permanent research graph changes until the experiment is kept.
+
+## Typical agent flow
+
+1. `bd_run_collect` with URLs → structured rows for deep research / `learn_report`.
+2. If rows empty or fields null → `bd_self_heal` with a fix prompt + sample URL.
+3. Review → `bd_self_heal_approve`.
+4. `bd_run_collect` again with the **same** collector id.

--- a/interface/mcp_server/brightdata/__init__.py
+++ b/interface/mcp_server/brightdata/__init__.py
@@ -1,0 +1,1 @@
+"""Bright Data Scraper Studio MCP server (optional, removable)."""

--- a/interface/mcp_server/brightdata/api_client.py
+++ b/interface/mcp_server/brightdata/api_client.py
@@ -25,6 +25,24 @@ import requests
 BASE = os.getenv("BRIGHT_DATA_API_BASE", "https://api.brightdata.com").rstrip("/")
 
 
+def _validate_collector_id(cid: str) -> str:
+    """Validate and return a safe collector ID.
+
+    Requires c_ prefix and rejects path/query/fragment separators to prevent URL injection.
+    """
+    cid = cid.strip()
+    if not cid:
+        raise ValueError("collector_id required (or set BRIGHT_DATA_COLLECTOR_ID)")
+    if not cid.startswith("c_"):
+        raise ValueError("collector_id must start with 'c_' prefix")
+    # Reject path separators, query strings, fragments, and encoded variants
+    dangerous_chars = ['/', '?', '#', '%2F', '%2f', '%3F', '%3f', '%23']
+    for char in dangerous_chars:
+        if char in cid:
+            raise ValueError(f"collector_id contains invalid character(s): {char}")
+    return cid
+
+
 def _token() -> str:
     return (
         os.getenv("BRIGHT_DATA_API_TOKEN", "").strip()
@@ -152,14 +170,12 @@ def trigger_self_heal(
     timeout: float = 60.0,
 ) -> dict[str, Any]:
     """Start Self-Healing refactor (plain-language fix, same collector id)."""
-    cid = (collector_id or default_collector_id()).strip()
-    if not cid:
-        raise ValueError("collector_id required")
+    cid = _validate_collector_id(collector_id or default_collector_id())
     prompt = (prompt or "").strip()
     if not prompt:
         raise ValueError("prompt required (max 1000 chars)")
     if len(prompt) > 1000:
-        prompt = prompt[:1000]
+        raise ValueError(f"prompt exceeds maximum length of 1000 characters (got {len(prompt)})")
 
     url = f"{BASE}/dca/collectors/{cid}/refactor_template"
     body: dict[str, Any] = {"prompt": prompt}
@@ -181,9 +197,7 @@ def self_heal_progress(
     timeout: float = 60.0,
 ) -> dict[str, Any]:
     """Poll Self-Healing job progress until ready / pending_answer / error."""
-    cid = (collector_id or default_collector_id()).strip()
-    if not cid:
-        raise ValueError("collector_id required")
+    cid = _validate_collector_id(collector_id or default_collector_id())
     url = f"{BASE}/dca/collectors/{cid}/refactor_template/progress"
     resp = requests.get(url, headers=_headers(), timeout=timeout)
     if not (200 <= resp.status_code < 300):
@@ -200,9 +214,7 @@ def resume_self_heal(
     timeout: float = 60.0,
 ) -> dict[str, Any]:
     """Approve or reject a pending Self-Healing diff."""
-    cid = (collector_id or default_collector_id()).strip()
-    if not cid:
-        raise ValueError("collector_id required")
+    cid = _validate_collector_id(collector_id or default_collector_id())
     url = f"{BASE}/dca/collectors/{cid}/resume_automation_job"
     body = {"message": bool(approve), "auto_save": bool(auto_save) and bool(approve)}
     resp = requests.post(url, headers=_headers(), json=body, timeout=timeout)
@@ -237,13 +249,38 @@ def run_self_heal(
         if status in {"pending_answer", "awaiting_approval", "waiting_for_approval"}:
             if auto_approve:
                 resume = resume_self_heal(collector_id, approve=True, auto_save=True)
+                # Continue polling until completion after auto-approval
+                while time.monotonic() < deadline:
+                    last = self_heal_progress(collector_id)
+                    status = str(last.get("status") or last.get("state") or "").lower()
+                    if status in {"done", "completed", "success", "ready", "finished"}:
+                        return {
+                            "ok": True,
+                            "phase": "completed",
+                            "collector_id": collector_id or default_collector_id(),
+                            "trigger": started,
+                            "progress": last,
+                            "resume": resume,
+                        }
+                    if status in {"error", "failed", "canceled", "cancelled"}:
+                        return {
+                            "ok": False,
+                            "phase": "failed",
+                            "collector_id": collector_id or default_collector_id(),
+                            "trigger": started,
+                            "progress": last,
+                            "resume": resume,
+                        }
+                    time.sleep(max(2.0, poll_seconds))
+                # Timeout after approval
                 return {
-                    "ok": True,
-                    "phase": "approved",
+                    "ok": False,
+                    "phase": "timeout",
                     "collector_id": collector_id or default_collector_id(),
                     "trigger": started,
                     "progress": last,
                     "resume": resume,
+                    "error": "timed out waiting for self-heal completion after approval",
                 }
             return {
                 "ok": True,

--- a/interface/mcp_server/brightdata/api_client.py
+++ b/interface/mcp_server/brightdata/api_client.py
@@ -1,0 +1,281 @@
+"""HTTP client for Bright Data Scraper Studio Collection + Self-Healing APIs.
+
+Collection (get data):
+  POST /dca/trigger?collector=c_...
+  GET  /dca/dataset?id=j_...   (poll until JSON array)
+
+Self-healing (fix scraper in place, same collector id):
+  POST /dca/collectors/{c_*}/refactor_template
+  GET  /dca/collectors/{c_*}/refactor_template/progress
+  POST /dca/collectors/{c_*}/resume_automation_job
+
+Self-healing is NOT automatic when a site changes — you (or Aiko) must
+trigger it with a plain-language prompt when extraction goes empty/wrong.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from typing import Any
+
+import requests
+
+BASE = os.getenv("BRIGHT_DATA_API_BASE", "https://api.brightdata.com").rstrip("/")
+
+
+def _token() -> str:
+    return (
+        os.getenv("BRIGHT_DATA_API_TOKEN", "").strip()
+        or os.getenv("BRIGHTDATA_API_TOKEN", "").strip()
+        or os.getenv("BRIGHT_DATA_API_KEY", "").strip()
+    )
+
+
+def _headers() -> dict[str, str]:
+    tok = _token()
+    if not tok:
+        raise ValueError(
+            "BRIGHT_DATA_API_TOKEN is not set — create a key in Bright Data "
+            "account settings and export it before calling this MCP server"
+        )
+    return {
+        "Authorization": f"Bearer {tok}",
+        "Content-Type": "application/json",
+    }
+
+
+def default_collector_id() -> str:
+    return os.getenv("BRIGHT_DATA_COLLECTOR_ID", "").strip()
+
+
+def trigger_collect(
+    collector_id: str,
+    inputs: list[dict[str, Any]],
+    *,
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    """Queue a batch collection run. Returns collection_id / snapshot id."""
+    cid = (collector_id or default_collector_id()).strip()
+    if not cid:
+        raise ValueError("collector_id required (or set BRIGHT_DATA_COLLECTOR_ID)")
+    if not inputs:
+        raise ValueError("inputs must be a non-empty list of objects")
+
+    url = f"{BASE}/dca/trigger"
+    resp = requests.post(
+        url,
+        params={"collector": cid},
+        headers=_headers(),
+        json=inputs,
+        timeout=timeout,
+    )
+    if not (200 <= resp.status_code < 300):
+        raise RuntimeError(f"trigger failed HTTP {resp.status_code}: {resp.text[:800]}")
+    data = resp.json() if resp.content else {}
+    if not isinstance(data, dict):
+        raise RuntimeError(f"unexpected trigger response: {data!r}")
+    return data
+
+
+def get_dataset(
+    snapshot_id: str,
+    *,
+    timeout: float = 60.0,
+) -> Any:
+    """Fetch batch results. While running, API returns an object; when ready, a JSON array."""
+    sid = (snapshot_id or "").strip()
+    if not sid:
+        raise ValueError("snapshot_id / collection_id required")
+    url = f"{BASE}/dca/dataset"
+    resp = requests.get(
+        url,
+        params={"id": sid},
+        headers=_headers(),
+        timeout=timeout,
+    )
+    if not (200 <= resp.status_code < 300):
+        raise RuntimeError(f"dataset failed HTTP {resp.status_code}: {resp.text[:800]}")
+    try:
+        return resp.json()
+    except json.JSONDecodeError:
+        return {"raw": resp.text[:4000]}
+
+
+def run_collect(
+    collector_id: str,
+    inputs: list[dict[str, Any]],
+    *,
+    poll_seconds: float = 5.0,
+    max_wait_seconds: float = 300.0,
+) -> dict[str, Any]:
+    """Trigger + poll until results are a list (or timeout)."""
+    trigger = trigger_collect(collector_id, inputs)
+    snapshot_id = str(
+        trigger.get("collection_id")
+        or trigger.get("snapshot_id")
+        or trigger.get("id")
+        or ""
+    ).strip()
+    if not snapshot_id:
+        return {"ok": False, "error": "no collection_id in trigger response", "trigger": trigger}
+
+    deadline = time.monotonic() + max(10.0, max_wait_seconds)
+    last: Any = None
+    while time.monotonic() < deadline:
+        last = get_dataset(snapshot_id)
+        if isinstance(last, list):
+            return {
+                "ok": True,
+                "collection_id": snapshot_id,
+                "collector_id": collector_id or default_collector_id(),
+                "row_count": len(last),
+                "rows": last,
+            }
+        # still running / status object
+        time.sleep(max(1.0, poll_seconds))
+
+    return {
+        "ok": False,
+        "error": "timed out waiting for dataset",
+        "collection_id": snapshot_id,
+        "last_status": last,
+    }
+
+
+def trigger_self_heal(
+    collector_id: str,
+    prompt: str,
+    *,
+    custom_input: list[dict[str, Any]] | None = None,
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    """Start Self-Healing refactor (plain-language fix, same collector id)."""
+    cid = (collector_id or default_collector_id()).strip()
+    if not cid:
+        raise ValueError("collector_id required")
+    prompt = (prompt or "").strip()
+    if not prompt:
+        raise ValueError("prompt required (max 1000 chars)")
+    if len(prompt) > 1000:
+        prompt = prompt[:1000]
+
+    url = f"{BASE}/dca/collectors/{cid}/refactor_template"
+    body: dict[str, Any] = {"prompt": prompt}
+    if custom_input is not None:
+        body["custom_input"] = custom_input
+    else:
+        body["custom_input"] = [{}]
+
+    resp = requests.post(url, headers=_headers(), json=body, timeout=timeout)
+    if not (200 <= resp.status_code < 300):
+        raise RuntimeError(f"self-heal trigger failed HTTP {resp.status_code}: {resp.text[:800]}")
+    data = resp.json() if resp.content else {}
+    return data if isinstance(data, dict) else {"raw": data}
+
+
+def self_heal_progress(
+    collector_id: str,
+    *,
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    """Poll Self-Healing job progress until ready / pending_answer / error."""
+    cid = (collector_id or default_collector_id()).strip()
+    if not cid:
+        raise ValueError("collector_id required")
+    url = f"{BASE}/dca/collectors/{cid}/refactor_template/progress"
+    resp = requests.get(url, headers=_headers(), timeout=timeout)
+    if not (200 <= resp.status_code < 300):
+        raise RuntimeError(f"self-heal progress failed HTTP {resp.status_code}: {resp.text[:800]}")
+    data = resp.json() if resp.content else {}
+    return data if isinstance(data, dict) else {"raw": data}
+
+
+def resume_self_heal(
+    collector_id: str,
+    *,
+    approve: bool = True,
+    auto_save: bool = True,
+    timeout: float = 60.0,
+) -> dict[str, Any]:
+    """Approve or reject a pending Self-Healing diff."""
+    cid = (collector_id or default_collector_id()).strip()
+    if not cid:
+        raise ValueError("collector_id required")
+    url = f"{BASE}/dca/collectors/{cid}/resume_automation_job"
+    body = {"message": bool(approve), "auto_save": bool(auto_save) and bool(approve)}
+    resp = requests.post(url, headers=_headers(), json=body, timeout=timeout)
+    if not (200 <= resp.status_code < 300):
+        raise RuntimeError(f"resume self-heal failed HTTP {resp.status_code}: {resp.text[:800]}")
+    data = resp.json() if resp.content else {}
+    return data if isinstance(data, dict) else {"raw": data}
+
+
+def run_self_heal(
+    collector_id: str,
+    prompt: str,
+    *,
+    custom_input: list[dict[str, Any]] | None = None,
+    auto_approve: bool = False,
+    poll_seconds: float = 10.0,
+    max_wait_seconds: float = 900.0,
+) -> dict[str, Any]:
+    """Full self-heal loop: trigger → poll → optional auto-approve.
+
+    Self-heal can take up to ~15 minutes on Bright Data side.
+    Default is HITL: stop at pending_answer so a human (or agent) reviews.
+    Set auto_approve=True only when you trust unattended commits.
+    """
+    started = trigger_self_heal(collector_id, prompt, custom_input=custom_input)
+    deadline = time.monotonic() + max(30.0, max_wait_seconds)
+    last: dict[str, Any] = {}
+
+    while time.monotonic() < deadline:
+        last = self_heal_progress(collector_id)
+        status = str(last.get("status") or last.get("state") or "").lower()
+        if status in {"pending_answer", "awaiting_approval", "waiting_for_approval"}:
+            if auto_approve:
+                resume = resume_self_heal(collector_id, approve=True, auto_save=True)
+                return {
+                    "ok": True,
+                    "phase": "approved",
+                    "collector_id": collector_id or default_collector_id(),
+                    "trigger": started,
+                    "progress": last,
+                    "resume": resume,
+                }
+            return {
+                "ok": True,
+                "phase": "awaiting_approval",
+                "collector_id": collector_id or default_collector_id(),
+                "message": "Review proposed diff, then call bd_self_heal_approve",
+                "trigger": started,
+                "progress": last,
+            }
+        if status in {"done", "completed", "success", "ready", "finished"}:
+            return {
+                "ok": True,
+                "phase": "completed",
+                "collector_id": collector_id or default_collector_id(),
+                "trigger": started,
+                "progress": last,
+            }
+        if status in {"error", "failed", "canceled", "cancelled"}:
+            return {
+                "ok": False,
+                "phase": "failed",
+                "collector_id": collector_id or default_collector_id(),
+                "trigger": started,
+                "progress": last,
+            }
+        time.sleep(max(2.0, poll_seconds))
+
+    return {
+        "ok": False,
+        "phase": "timeout",
+        "collector_id": collector_id or default_collector_id(),
+        "trigger": started,
+        "progress": last,
+        "error": "timed out waiting for self-heal job",
+    }

--- a/interface/mcp_server/brightdata/server.py
+++ b/interface/mcp_server/brightdata/server.py
@@ -143,10 +143,27 @@ def bd_self_heal(
 
 @mcp.tool()
 def bd_self_heal_progress(collector_id: str = "") -> str:
-    """Poll Self-Healing job status for a collector."""
+    """Poll Self-Healing job status for a collector.
+
+    Use after bd_self_heal_approve (or during an in-flight heal) until progress
+    status is a terminal value (done/completed/failed). Do not treat approve
+    alone as completion.
+    """
     try:
         data = bd.self_heal_progress(collector_id)
-        return _ok({"ok": True, "progress": data})
+        status = str(
+            (data or {}).get("status") or (data or {}).get("state") or ""
+        ).lower() if isinstance(data, dict) else ""
+        terminal_ok = status in {"done", "completed", "success", "ready", "finished"}
+        terminal_bad = status in {"error", "failed", "canceled", "cancelled"}
+        return _ok({
+            "ok": True,
+            "progress": data,
+            "status": status or None,
+            "completed": terminal_ok,
+            "failed": terminal_bad,
+            "terminal": terminal_ok or terminal_bad,
+        })
     except Exception as e:
         return _err(e)
 
@@ -160,16 +177,33 @@ def bd_self_heal_approve(
     """Approve or reject a pending Self-Healing diff (HITL gate).
 
     Call after bd_self_heal returns phase=awaiting_approval.
-    After approval, poll bd_self_heal_progress until phase=completed
-    before calling bd_run_collect.
+
+    This only *submits* the decision. It does NOT mean the heal job is finished.
+    Next steps:
+      1. Poll bd_self_heal_progress until completed=true (or failed=true)
+      2. Then call bd_run_collect with the same collector_id
     """
     try:
+        cid = (collector_id or bd.default_collector_id()).strip()
         data = bd.resume_self_heal(
             collector_id,
             approve=bool(approve),
             auto_save=bool(auto_save),
         )
-        return _ok({"ok": True, "resume": data})
+        return _ok({
+            "ok": True,
+            "phase": "decision_submitted",
+            "decision_submitted": True,
+            "approval_submitted": bool(approve),
+            "completed": False,
+            "collector_id": cid or None,
+            "resume": data,
+            "next_action": (
+                "Poll bd_self_heal_progress until completed=true before bd_run_collect"
+                if approve
+                else "Diff rejected; no further collect expected for this heal"
+            ),
+        })
     except Exception as e:
         return _err(e)
 

--- a/interface/mcp_server/brightdata/server.py
+++ b/interface/mcp_server/brightdata/server.py
@@ -1,0 +1,182 @@
+"""Bright Data Scraper Studio MCP server (stdio).
+
+Removable package for Aiko research / Scrape-Verse experiments.
+Spawn:
+  python -m interface.mcp_server.brightdata.server
+
+Env:
+  BRIGHT_DATA_API_TOKEN   — required for live calls
+  BRIGHT_DATA_COLLECTOR_ID — default c_* collector
+  BRIGHT_DATA_API_BASE    — optional (default https://api.brightdata.com)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any
+
+from mcp.server.fastmcp import FastMCP
+
+from interface.mcp_server.brightdata import api_client as bd
+
+mcp = FastMCP("Aiko Bright Data Scraper Studio MCP")
+
+
+def _ok(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, default=str)
+
+
+def _err(exc: Exception) -> str:
+    return json.dumps({"ok": False, "error": str(exc)}, ensure_ascii=False)
+
+
+def _parse_inputs(inputs_json: str) -> list[dict[str, Any]]:
+    raw = (inputs_json or "").strip()
+    if not raw:
+        return [{"url": ""}]
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"inputs_json must be valid JSON: {e}") from e
+    if isinstance(data, dict):
+        return [data]
+    if isinstance(data, list):
+        out = [x for x in data if isinstance(x, dict)]
+        if not out:
+            raise ValueError("inputs_json list must contain objects")
+        return out
+    raise ValueError("inputs_json must be an object or array of objects")
+
+
+@mcp.tool()
+def bd_trigger_collect(collector_id: str = "", inputs_json: str = "[{\"url\": \"\"}]") -> str:
+    """Queue a Bright Data Scraper Studio batch collection run.
+
+    collector_id: c_* id (default BRIGHT_DATA_COLLECTOR_ID).
+    inputs_json: JSON array of input objects matching the collector schema
+      (usually [{"url": "https://..."}, ...]).
+
+    Returns collection_id for bd_get_results.
+    """
+    try:
+        inputs = _parse_inputs(inputs_json)
+        data = bd.trigger_collect(collector_id, inputs)
+        return _ok({"ok": True, **data})
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def bd_get_results(collection_id: str) -> str:
+    """Fetch or poll status for a collection/snapshot id from bd_trigger_collect.
+
+    When ready, Bright Data returns a JSON array of rows; while running, an object.
+    """
+    try:
+        data = bd.get_dataset(collection_id)
+        if isinstance(data, list):
+            return _ok({"ok": True, "ready": True, "row_count": len(data), "rows": data})
+        return _ok({"ok": True, "ready": False, "status": data})
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def bd_run_collect(
+    collector_id: str = "",
+    inputs_json: str = "[{\"url\": \"\"}]",
+    max_wait_seconds: float = 300.0,
+) -> str:
+    """Trigger a collector and wait until structured rows are ready (or timeout).
+
+    Preferred one-shot tool for deep research / agent use.
+    """
+    try:
+        inputs = _parse_inputs(inputs_json)
+        result = bd.run_collect(
+            collector_id,
+            inputs,
+            max_wait_seconds=float(max_wait_seconds),
+        )
+        return _ok(result)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def bd_self_heal(
+    prompt: str,
+    collector_id: str = "",
+    sample_url: str = "",
+    auto_approve: bool = False,
+    max_wait_seconds: float = 900.0,
+) -> str:
+    """Trigger Bright Data Self-Healing when extraction breaks after a site change.
+
+    Self-healing is Bright Data's AI refactor: you describe the break in plain
+    language; they rewrite scraper code in place. Collector ID stays the same.
+
+    prompt: e.g. "price returns null after redesign — capture span.price-now"
+    sample_url: optional URL to anchor the heal (passed as custom_input).
+    auto_approve: if false (default), stops at awaiting_approval for HITL.
+      If true, auto-approves and auto-saves (unattended).
+
+    After approval, re-run bd_run_collect with the same collector_id.
+    """
+    try:
+        custom = None
+        if (sample_url or "").strip():
+            custom = [{"url": sample_url.strip()}]
+        result = bd.run_self_heal(
+            collector_id,
+            prompt,
+            custom_input=custom,
+            auto_approve=bool(auto_approve),
+            max_wait_seconds=float(max_wait_seconds),
+        )
+        return _ok(result)
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def bd_self_heal_progress(collector_id: str = "") -> str:
+    """Poll Self-Healing job status for a collector."""
+    try:
+        data = bd.self_heal_progress(collector_id)
+        return _ok({"ok": True, "progress": data})
+    except Exception as e:
+        return _err(e)
+
+
+@mcp.tool()
+def bd_self_heal_approve(
+    collector_id: str = "",
+    approve: bool = True,
+    auto_save: bool = True,
+) -> str:
+    """Approve or reject a pending Self-Healing diff (HITL gate).
+
+    Call after bd_self_heal returns phase=awaiting_approval.
+    """
+    try:
+        data = bd.resume_self_heal(
+            collector_id,
+            approve=bool(approve),
+            auto_save=bool(auto_save),
+        )
+        return _ok({"ok": True, "resume": data})
+    except Exception as e:
+        return _err(e)
+
+
+def main() -> None:
+    if not bd._token():
+        # Still start so list_tools works; tool calls will error clearly.
+        pass
+    mcp.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/interface/mcp_server/brightdata/server.py
+++ b/interface/mcp_server/brightdata/server.py
@@ -120,9 +120,10 @@ def bd_self_heal(
     prompt: e.g. "price returns null after redesign — capture span.price-now"
     sample_url: optional URL to anchor the heal (passed as custom_input).
     auto_approve: if false (default), stops at awaiting_approval for HITL.
-      If true, auto-approves and auto-saves (unattended).
+      If true, auto-approves, auto-saves, and waits for completion (unattended).
 
-    After approval, re-run bd_run_collect with the same collector_id.
+    Returns phase=completed when self-healing is done. After completion,
+    re-run bd_run_collect with the same collector_id.
     """
     try:
         custom = None
@@ -159,6 +160,8 @@ def bd_self_heal_approve(
     """Approve or reject a pending Self-Healing diff (HITL gate).
 
     Call after bd_self_heal returns phase=awaiting_approval.
+    After approval, poll bd_self_heal_progress until phase=completed
+    before calling bd_run_collect.
     """
     try:
         data = bd.resume_self_heal(


### PR DESCRIPTION
## Summary

Adds an **optional, isolated** stdio MCP server for [Bright Data Scraper Studio](https://docs.brightdata.com/datasets/scraper-studio/overview):

- Trigger / poll / wait for **structured collection** results
- **Self-healing** via Bright Data AI Flow (`refactor_template` → progress → `resume_automation_job`)

Designed for Scrape-Verse / deep-research experiments so the package can be **deleted** without touching core research graphs.

## Self-healing (how it works)

Self-healing is **Bright Data’s** feature, not local selector repair in Aiko:

1. Site changes → collector returns empty/null fields
2. Call `bd_self_heal` with a plain-language prompt (≤1000 chars)
3. Bright Data rewrites scraper code **in place** (same `c_*` collector id)
4. Default **HITL**: job stops at `awaiting_approval` → `bd_self_heal_approve`
5. Optional `auto_approve=true` for unattended runs
6. Re-run `bd_run_collect` with the same collector

API surface matches official docs / CLI (`bdata scraper heal` / `approve`).

## Layout

```
interface/mcp_server/brightdata/
  api_client.py   # HTTP: trigger, dataset, self-heal
  server.py       # FastMCP tools (stdio)
  README.md
```

## Tools

| Tool | Role |
|------|------|
| `bd_trigger_collect` | Queue batch run |
| `bd_get_results` | Poll dataset |
| `bd_run_collect` | Trigger + wait |
| `bd_self_heal` | Start heal (+ optional auto-approve) |
| `bd_self_heal_progress` | Poll heal |
| `bd_self_heal_approve` | Approve/reject diff |

## Env

- `BRIGHT_DATA_API_TOKEN` (required for live calls)
- `BRIGHT_DATA_COLLECTOR_ID` (default `c_*`)
- optional `BRIGHT_DATA_API_BASE`

## Out of scope (intentional)

- No permanent wiring into `agentic/mcp_client` (still social-only) — spawn this module separately while testing
- No changes to `deep_research` graph yet
- Collectors themselves are created in Scraper Studio / CLI (`bdata scraper create`), not in this PR

## Test plan

- [ ] Set token + collector id
- [ ] `python -m interface.mcp_server.brightdata.server` lists tools
- [ ] `bd_run_collect` returns rows for a known public URL
- [ ] `bd_self_heal` with a deliberate prompt reaches `awaiting_approval` or completes with `auto_approve`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional Bright Data integration for running scraper collections and retrieving results.
  * Added self-healing workflows that identify scraper issues, propose repairs, and support manual or automatic approval.
  * Added tools for monitoring collection and repair progress, including status polling and timeout handling.

* **Documentation**
  * Added setup guidance, configuration requirements, standalone usage instructions, available tools, approval states, and typical collection and repair workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->