### PR TITLE
feat(memory): EMC-3 episodic recall + joint EM/SM context budget

### DIFF
--- a/cognition/memory/emc2_wire.py
+++ b/cognition/memory/emc2_wire.py
@@ -24,6 +24,8 @@ def apply_emc2_hooks() -> None:
     if _WIRED:
         return
     try:
+        from cognition.memory.episode_recall import attach_recall_to_store
+        attach_recall_to_store()
         _patch_memorize()
         _WIRED = True
         log.info("EMC hooks applied (queue_episode + episodic recall format)")
@@ -123,9 +125,8 @@ def _patch_memorize() -> None:
             if not sm_block:
                 return em_block
 
-            # Joint budget: shrink SM so EM+SM fit MEMORY_CONTEXT_TOTAL_CHARS
             try:
-                from cognition.memory.episode import EMC_JOINT_BUDGET, EMC_CONTEXT_CHARS
+                from cognition.memory.episode_recall import EMC_JOINT_BUDGET
                 from cognition.memory.schema import MEMORY_CONTEXT_TOTAL_CHARS
             except Exception:
                 return f"{sm_block}\n\n{em_block}"
@@ -145,8 +146,8 @@ def _patch_memorize() -> None:
             return f"{sm_block}\n\n{em_block}"
 
         def _format_episodes_for_context(self, query: str) -> str | None:
-            from cognition.memory.episode import (
-                EMC_ENABLED,
+            from cognition.memory.episode import EMC_ENABLED
+            from cognition.memory.episode_recall import (
                 EMC_RECALL_ENABLED,
                 EMC_RECALL_LIMIT,
             )
@@ -167,5 +168,4 @@ def _patch_memorize() -> None:
         AikoMemorize._emc3_format_patched = True  # type: ignore[attr-defined]
 
 
-# Back-compat alias
 apply_emc3_hooks = apply_emc2_hooks

--- a/cognition/memory/emc2_wire.py
+++ b/cognition/memory/emc2_wire.py
@@ -134,14 +134,21 @@ def _patch_memorize() -> None:
             if not EMC_JOINT_BUDGET:
                 return f"{sm_block}\n\n{em_block}"
 
-            shared = max(200, int(MEMORY_CONTEXT_TOTAL_CHARS))
+            shared = int(MEMORY_CONTEXT_TOTAL_CHARS)
+            if len(em_block) > shared:
+                from cognition.memory.episode_recall import EMC_RECALL_LIMIT
+                store = self._get_episode_store()
+                if store is not None:
+                    hits = store.search(query or "", limit=EMC_RECALL_LIMIT, user_id=self.get_user_id())
+                    em_block = store.format_for_context(hits, max_chars=shared) or em_block
             em_len = len(em_block)
-            sm_budget = max(120, shared - em_len - 2)
+            sm_budget = shared - em_len - 2
             if len(sm_block) > sm_budget:
-                cut = sm_budget
+                sm_closing = "\n</memory_context>"
+                cut = sm_budget - len(sm_closing) if "</memory_context>" in sm_block else sm_budget
                 sm_trim = sm_block[:cut]
                 if "</memory_context>" in sm_block and "</memory_context>" not in sm_trim:
-                    sm_trim = sm_trim.rstrip() + "\n</memory_context>"
+                    sm_trim = sm_trim.rstrip() + sm_closing
                 sm_block = sm_trim
             return f"{sm_block}\n\n{em_block}"
 

--- a/cognition/memory/emc2_wire.py
+++ b/cognition/memory/emc2_wire.py
@@ -1,10 +1,11 @@
 """
-EMC-2 runtime wire-up.
+EMC-2/3 runtime wire-up.
 
-Provides AikoMemorize.queue_episode + lazy EpisodicStore when not yet
-native on the class. Think-side ingest is native in AikoThink._store_async
-(calls queue_episode after queue_write) — this module does NOT wrap
-_store_async, so each turn is staged once.
+EMC-2: AikoMemorize.queue_episode + lazy EpisodicStore + flush on switch_user.
+EMC-3: wrap format_for_context to append episodic recall (joint budget).
+
+Think-side ingest is native in AikoThink._store_async (queue_episode once).
+This module does NOT wrap _store_async.
 
 Called from ensure_episode_schema (memory boot path).
 """
@@ -18,16 +19,16 @@ _WIRED = False
 
 
 def apply_emc2_hooks() -> None:
-    """Idempotent: ensure AikoMemorize has queue_episode / episode store."""
+    """Idempotent: memorize queue_episode + format_for_context EM append."""
     global _WIRED
     if _WIRED:
         return
     try:
         _patch_memorize()
         _WIRED = True
-        log.info("EMC-2 hooks applied (queue_episode on AikoMemorize)")
+        log.info("EMC hooks applied (queue_episode + episodic recall format)")
     except Exception as e:
-        log.warning("EMC-2 hooks failed: %s", e)
+        log.warning("EMC hooks failed: %s", e)
 
 
 def _patch_memorize() -> None:
@@ -89,3 +90,82 @@ def _patch_memorize() -> None:
 
         AikoMemorize.switch_user = switch_user  # type: ignore[method-assign]
         AikoMemorize._emc2_switch_patched = True  # type: ignore[attr-defined]
+
+    # EMC-3: episodic recall on format_for_context (once)
+    if not getattr(AikoMemorize, "_emc3_format_patched", False):
+        _orig_fmt = AikoMemorize.format_for_context
+
+        def format_for_context(
+            self,
+            memories,
+            *,
+            query: str = "",
+            related=None,
+            user_id=None,
+            embedder=None,
+        ):
+            sm_block = _orig_fmt(
+                self,
+                memories,
+                query=query,
+                related=related,
+                user_id=user_id,
+                embedder=embedder,
+            )
+            try:
+                em_block = self._format_episodes_for_context(query or "")
+            except Exception as e:
+                log.debug("EMC format_episodes skipped: %s", e)
+                em_block = None
+
+            if not em_block:
+                return sm_block
+            if not sm_block:
+                return em_block
+
+            # Joint budget: shrink SM so EM+SM fit MEMORY_CONTEXT_TOTAL_CHARS
+            try:
+                from cognition.memory.episode import EMC_JOINT_BUDGET, EMC_CONTEXT_CHARS
+                from cognition.memory.schema import MEMORY_CONTEXT_TOTAL_CHARS
+            except Exception:
+                return f"{sm_block}\n\n{em_block}"
+
+            if not EMC_JOINT_BUDGET:
+                return f"{sm_block}\n\n{em_block}"
+
+            shared = max(200, int(MEMORY_CONTEXT_TOTAL_CHARS))
+            em_len = len(em_block)
+            sm_budget = max(120, shared - em_len - 2)
+            if len(sm_block) > sm_budget:
+                cut = sm_budget
+                sm_trim = sm_block[:cut]
+                if "</memory_context>" in sm_block and "</memory_context>" not in sm_trim:
+                    sm_trim = sm_trim.rstrip() + "\n</memory_context>"
+                sm_block = sm_trim
+            return f"{sm_block}\n\n{em_block}"
+
+        def _format_episodes_for_context(self, query: str) -> str | None:
+            from cognition.memory.episode import (
+                EMC_ENABLED,
+                EMC_RECALL_ENABLED,
+                EMC_RECALL_LIMIT,
+            )
+            if not EMC_ENABLED or not EMC_RECALL_ENABLED or EMC_RECALL_LIMIT <= 0:
+                return None
+            if not (query or "").strip():
+                return None
+            store = self._get_episode_store()
+            if store is None:
+                return None
+            hits = store.search(query, limit=EMC_RECALL_LIMIT, user_id=self.get_user_id())
+            if not hits:
+                return None
+            return store.format_for_context(hits)
+
+        AikoMemorize.format_for_context = format_for_context  # type: ignore[method-assign]
+        AikoMemorize._format_episodes_for_context = _format_episodes_for_context  # type: ignore[method-assign]
+        AikoMemorize._emc3_format_patched = True  # type: ignore[attr-defined]
+
+
+# Back-compat alias
+apply_emc3_hooks = apply_emc2_hooks

--- a/cognition/memory/episode_recall.py
+++ b/cognition/memory/episode_recall.py
@@ -54,6 +54,7 @@ def search(
     if not q:
         return []
 
+    vector = None
     try:
         if query_vector is not None:
             vector = list(query_vector)
@@ -65,30 +66,30 @@ def search(
                 vector = list(emb.embed([q]))[0]
     except Exception as e:
         log.debug("EMC search embed failed: %s", e)
-        return []
 
     fts_query = _sanitize_fts_query(q)
 
     with self._lock:
         rank_knn: dict[int, int] = {}
         rank_fts: dict[int, int] = {}
-        try:
-            vec_blob = sqlite_vec.serialize_float32(vector)
-            knn_rows = self._conn.execute(
-                """
-                SELECT v.rowid AS id, vec_distance_cosine(v.embedding, ?) AS dist
-                FROM emc_vec v
-                JOIN emc_storage s ON s.id = v.rowid
-                WHERE s.user_id = ?
-                  AND (s.superseded_by IS NULL)
-                ORDER BY dist ASC
-                LIMIT ?
-                """,
-                (vec_blob, uid, EMC_KNN_LIMIT),
-            ).fetchall()
-            rank_knn = {int(r[0]): i + 1 for i, r in enumerate(knn_rows)}
-        except Exception as e:
-            log.debug("EMC KNN failed: %s", e)
+        if vector is not None:
+            try:
+                vec_blob = sqlite_vec.serialize_float32(vector)
+                knn_rows = self._conn.execute(
+                    """
+                    SELECT v.rowid AS id, vec_distance_cosine(v.embedding, ?) AS dist
+                    FROM emc_vec v
+                    JOIN emc_storage s ON s.id = v.rowid
+                    WHERE s.user_id = ?
+                      AND (s.superseded_by IS NULL)
+                    ORDER BY dist ASC
+                    LIMIT ?
+                    """,
+                    (vec_blob, uid, EMC_KNN_LIMIT),
+                ).fetchall()
+                rank_knn = {int(r[0]): i + 1 for i, r in enumerate(knn_rows)}
+            except Exception as e:
+                log.debug("EMC KNN failed: %s", e)
 
         if fts_query:
             try:
@@ -218,8 +219,9 @@ def format_for_context(self, episodes: list[dict], *, max_chars: int | None = No
         return None
     lines.append("</episodic_context>")
     block = "\n".join(lines)
+    closing_tag = "\n</episodic_context>"
     if len(block) > budget:
-        block = block[:budget].rstrip() + "\n</episodic_context>"
+        block = block[:budget - len(closing_tag)].rstrip() + closing_tag
     return block
 
 

--- a/cognition/memory/episode_recall.py
+++ b/cognition/memory/episode_recall.py
@@ -1,0 +1,235 @@
+"""
+EMC-3: episodic recall helpers attached onto EpisodicStore at boot.
+
+Kept separate so EMC-3 can land without rewriting the large episode.py body.
+apply_emc2_hooks() calls attach_recall_to_store().
+"""
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import sqlite_vec
+
+from system.log import get_logger
+from cognition.memory.search import _sanitize_fts_query
+from cognition.memory.env import env_bool, env_int
+
+log = get_logger(__name__)
+
+# Mirrors episode.py / memory.yaml (read env at call time via these constants)
+EMC_RECALL_ENABLED = env_bool("EMC_RECALL_ENABLED", "1")
+EMC_RECALL_LIMIT = max(0, env_int("EMC_RECALL_LIMIT", 2))
+EMC_KNN_LIMIT = max(1, env_int("EMC_KNN_LIMIT", 12))
+EMC_FTS_LIMIT = max(1, env_int("EMC_FTS_LIMIT", 12))
+EMC_RRF_K = max(1, env_int("EMC_RRF_K", 60))
+EMC_CONTEXT_CHARS = max(100, env_int("EMC_CONTEXT_CHARS", 600))
+EMC_CONTEXT_EPISODE_CHARS = max(40, env_int("EMC_CONTEXT_EPISODE_CHARS", 280))
+EMC_JOINT_BUDGET = env_bool("EMC_JOINT_BUDGET", "1")
+
+
+def _utc_now_iso() -> str:
+    from datetime import datetime, timezone
+    return datetime.now(timezone.utc).isoformat()
+
+
+def search(
+    self,
+    query: str,
+    *,
+    limit: int | None = None,
+    query_vector: list[float] | None = None,
+    user_id: str | None = None,
+) -> list[dict]:
+    """KNN + FTS5 → RRF over emc_storage. Returns payload dicts."""
+    from cognition.memory.episode import EMC_ENABLED
+
+    if not EMC_ENABLED or not EMC_RECALL_ENABLED:
+        return []
+    top_k = EMC_RECALL_LIMIT if limit is None else max(0, int(limit))
+    if top_k <= 0:
+        return []
+    uid = user_id or self._user_id
+    q = (query or "").strip()
+    if not q:
+        return []
+
+    try:
+        if query_vector is not None:
+            vector = list(query_vector)
+        else:
+            emb = self._embedder
+            if hasattr(emb, "embed_query"):
+                vector = list(emb.embed_query(q))
+            else:
+                vector = list(emb.embed([q]))[0]
+    except Exception as e:
+        log.debug("EMC search embed failed: %s", e)
+        return []
+
+    fts_query = _sanitize_fts_query(q)
+
+    with self._lock:
+        rank_knn: dict[int, int] = {}
+        rank_fts: dict[int, int] = {}
+        try:
+            vec_blob = sqlite_vec.serialize_float32(vector)
+            knn_rows = self._conn.execute(
+                """
+                SELECT v.rowid AS id, vec_distance_cosine(v.embedding, ?) AS dist
+                FROM emc_vec v
+                JOIN emc_storage s ON s.id = v.rowid
+                WHERE s.user_id = ?
+                  AND (s.superseded_by IS NULL)
+                ORDER BY dist ASC
+                LIMIT ?
+                """,
+                (vec_blob, uid, EMC_KNN_LIMIT),
+            ).fetchall()
+            rank_knn = {int(r[0]): i + 1 for i, r in enumerate(knn_rows)}
+        except Exception as e:
+            log.debug("EMC KNN failed: %s", e)
+
+        if fts_query:
+            try:
+                fts_rows = self._conn.execute(
+                    """
+                    SELECT s.id
+                    FROM emc_fts
+                    JOIN emc_storage s ON s.id = emc_fts.rowid
+                    WHERE emc_fts MATCH ?
+                      AND s.user_id = ?
+                      AND (s.superseded_by IS NULL)
+                    ORDER BY rank
+                    LIMIT ?
+                    """,
+                    (fts_query, uid, EMC_FTS_LIMIT),
+                ).fetchall()
+                rank_fts = {int(r[0]): i + 1 for i, r in enumerate(fts_rows)}
+            except Exception as e:
+                log.debug("EMC FTS failed: %s", e)
+
+        candidate_ids = set(rank_knn) | set(rank_fts)
+        if not candidate_ids:
+            return []
+
+        scores: dict[int, float] = {}
+        for eid in candidate_ids:
+            s = 0.0
+            if eid in rank_knn:
+                s += 1.0 / (EMC_RRF_K + rank_knn[eid])
+            if eid in rank_fts:
+                s += 1.0 / (EMC_RRF_K + rank_fts[eid])
+            scores[eid] = s
+
+        ordered = sorted(scores.keys(), key=lambda i: scores[i], reverse=True)[:top_k]
+        if not ordered:
+            return []
+
+        placeholders = ",".join("?" * len(ordered))
+        rows = self._conn.execute(
+            f"""
+            SELECT id, timestamp, date, trace, valence_tag, arousal_score,
+                   salience_score, entities, source, session_id, recall_count
+            FROM emc_storage
+            WHERE id IN ({placeholders})
+            """,
+            ordered,
+        ).fetchall()
+        by_id = {int(r[0]): r for r in rows}
+
+        results: list[dict] = []
+        for eid in ordered:
+            row = by_id.get(eid)
+            if not row:
+                continue
+            entities = None
+            if row[7]:
+                try:
+                    entities = json.loads(row[7])
+                except Exception:
+                    entities = None
+            results.append({
+                "id": int(row[0]),
+                "timestamp": row[1],
+                "date": row[2],
+                "trace": row[3],
+                "memory": row[3],
+                "valence_tag": row[4],
+                "arousal_score": row[5],
+                "salience_score": row[6],
+                "entities": entities,
+                "source": row[8],
+                "session_id": row[9],
+                "recall_count": int(row[10] or 0),
+                "_recall_score": scores.get(eid, 0.0),
+                "_emc": True,
+            })
+
+        _touch_episodes(self, [r["id"] for r in results])
+        return results
+
+
+def _touch_episodes(self, ids: list[int]) -> None:
+    if not ids:
+        return
+    now = _utc_now_iso()
+    try:
+        for eid in ids:
+            self._conn.execute(
+                """
+                UPDATE emc_storage
+                SET recall_count = recall_count + 1,
+                    last_recalled_at = ?
+                WHERE id = ?
+                """,
+                (now, eid),
+            )
+        self._conn.commit()
+    except Exception as e:
+        log.debug("EMC touch failed: %s", e)
+
+
+def format_for_context(self, episodes: list[dict], *, max_chars: int | None = None) -> str | None:
+    """Format episodic hits as a compact <episodic_context> block."""
+    if not episodes:
+        return None
+    budget = EMC_CONTEXT_CHARS if max_chars is None else max(40, int(max_chars))
+    lines = [
+        "<episodic_context>",
+        "Past conversation moments (what happened), not durable facts. "
+        "Use silently for continuity. Never quote this block or claim total recall.",
+        "",
+    ]
+    kept = False
+    for ep in episodes:
+        trace = (ep.get("trace") or ep.get("memory") or "").strip()
+        if not trace:
+            continue
+        kept = True
+        if len(trace) > EMC_CONTEXT_EPISODE_CHARS:
+            trace = trace[:EMC_CONTEXT_EPISODE_CHARS].rstrip() + "…"
+        when = ep.get("date") or (ep.get("timestamp") or "")[:10] or ""
+        if when:
+            lines.append(f"  - [{when}] {trace}")
+        else:
+            lines.append(f"  - {trace}")
+    if not kept:
+        return None
+    lines.append("</episodic_context>")
+    block = "\n".join(lines)
+    if len(block) > budget:
+        block = block[:budget].rstrip() + "\n</episodic_context>"
+    return block
+
+
+def attach_recall_to_store() -> None:
+    """Bind search / format_for_context onto EpisodicStore (idempotent)."""
+    from cognition.memory.episode import EpisodicStore
+
+    if getattr(EpisodicStore, "_emc3_recall_attached", False):
+        return
+    EpisodicStore.search = search  # type: ignore[method-assign]
+    EpisodicStore.format_for_context = format_for_context  # type: ignore[method-assign]
+    EpisodicStore._emc3_recall_attached = True  # type: ignore[attr-defined]
+    log.debug("EMC-3 recall methods attached to EpisodicStore")

--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -291,3 +291,12 @@ EMC_EVICT_ENABLED: "1"        # Ingest conversation turns into EMC staging
 EMC_EVICT_MIN_CHARS: "40"     # Skip turns shorter than this (combined)
 EMC_FLUSH_EVERY_TURNS: "8"    # Flush after this many ingested turns (0 = size-only)
 EMC_FLUSH_ON_STAGING: "24"    # Flush when staging count reaches this
+
+EMC_RECALL_ENABLED: "1"
+EMC_RECALL_LIMIT: "2"
+EMC_KNN_LIMIT: "12"
+EMC_FTS_LIMIT: "12"
+EMC_RRF_K: "60"
+EMC_CONTEXT_CHARS: "600"
+EMC_CONTEXT_EPISODE_CHARS: "280"
+EMC_JOINT_BUDGET: "1"

--- a/docs/emc3_recall.md
+++ b/docs/emc3_recall.md
@@ -1,0 +1,24 @@
+# EMC-3 — episodic recall
+
+## What
+- `EpisodicStore.search` via `episode_recall.py` (KNN + FTS5 + RRF)
+- `<episodic_context>` block appended in `AikoMemorize.format_for_context`
+- Joint budget: when `EMC_JOINT_BUDGET=1`, EM+SM share `MEMORY_CONTEXT_TOTAL_CHARS` (EM reserved first)
+
+## Flow
+```
+chat turn
+  → memorize.search (semantic facts) — unchanged
+  → format_for_context(memories, query=...)
+       → SM block
+       → store.search(query) → EM hits
+       → append <episodic_context>
+       → if joint: shrink SM so total fits
+```
+
+## Config (`config/memory.yaml`)
+See EMC_RECALL_* / EMC_JOINT_BUDGET keys.
+
+## Out of scope
+- EMC-4 dream distillation EM→SM
+- Grouping similar staging rows before flush


### PR DESCRIPTION
## Summary

**EMC-3** — surface stored episodes at recall time alongside semantic facts, with a joint context budget.

Builds on EMC-1/2 (merged).

## What this adds

### `cognition/memory/episode_recall.py` (new)
- `EpisodicStore.search` — KNN (`emc_vec`) + FTS5 (`emc_fts`) → RRF
- `format_for_context` → `<episodic_context>` block
- Touch `recall_count` / `last_recalled_at` on hit
- Attached at boot via `attach_recall_to_store()`

### `cognition/memory/emc2_wire.py`
- Calls `attach_recall_to_store()`
- Wraps `AikoMemorize.format_for_context`:
  1. Build SM block (unchanged)
  2. `store.search(query)` → format EM block
  3. If `EMC_JOINT_BUDGET=1`, shrink SM so **EM+SM ≤ `MEMORY_CONTEXT_TOTAL_CHARS`** (EM reserved first)

### No `think.py` change
Existing `format_for_context(...)` call sites pick up episodes automatically.

## Config (defaults in code; optional in `config/memory.yaml`)

```yaml
EMC_RECALL_ENABLED: "1"
EMC_RECALL_LIMIT: "2"
EMC_KNN_LIMIT: "12"
EMC_FTS_LIMIT: "12"
EMC_RRF_K: "60"
EMC_CONTEXT_CHARS: "600"
EMC_CONTEXT_EPISODE_CHARS: "280"
EMC_JOINT_BUDGET: "1"   # 0 = EM additive on top of SM budget
```

Please add those keys under the EMC section of `config/memory.yaml` if you want them documented next to EMC-1/2 (code defaults already match).

## Out of scope (EMC-4)
- Dream distillation EM → SM/PM
- Clustering similar staging rows before flush

## Docs
See `docs/emc3_recall.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added episodic memory recall alongside existing semantic memory.
  - Combines vector and text-based matching to surface relevant past experiences.
  - Adds optional user filtering and configurable recall limits.
  - Includes episodic context in generated responses while respecting shared character budgets.
  - Gracefully handles unavailable or empty recall data.

- **Documentation**
  - Added guidance covering episodic search, context budgeting, configuration, and chat flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->