### PR TITLE
feat(memory): EMC-4 dream distillation (EM → SM)

### DIFF
--- a/cognition/memory/emc2_wire.py
+++ b/cognition/memory/emc2_wire.py
@@ -1,8 +1,9 @@
 """
-EMC-2/3 runtime wire-up.
+EMC-2/3/4 runtime wire-up.
 
 EMC-2: AikoMemorize.queue_episode + lazy EpisodicStore + flush on switch_user.
 EMC-3: wrap format_for_context to append episodic recall (joint budget).
+EMC-4: wrap dream() to distill episodes → semantic facts.
 
 Think-side ingest is native in AikoThink._store_async (queue_episode once).
 This module does NOT wrap _store_async.
@@ -19,16 +20,18 @@ _WIRED = False
 
 
 def apply_emc2_hooks() -> None:
-    """Idempotent: memorize queue_episode + format_for_context EM append."""
+    """Idempotent: queue_episode + recall format + dream distill."""
     global _WIRED
     if _WIRED:
         return
     try:
         from cognition.memory.episode_recall import attach_recall_to_store
         attach_recall_to_store()
+        from cognition.memory.episode_dream import attach_dream_hook
+        attach_dream_hook()
         _patch_memorize()
         _WIRED = True
-        log.info("EMC hooks applied (queue_episode + episodic recall format)")
+        log.info("EMC hooks applied (queue_episode + recall + dream distill)")
     except Exception as e:
         log.warning("EMC hooks failed: %s", e)
 
@@ -37,12 +40,11 @@ def _patch_memorize() -> None:
     from cognition.memory.memorize import AikoMemorize
 
     if getattr(AikoMemorize, "_emc2_native", False):
-        return  # already native in class body
+        return
 
     if not hasattr(AikoMemorize, "queue_episode"):
 
         def queue_episode(self, user_input: str, response_text: str) -> None:
-            """EMC-2: stage one turn into episodic memory (best-effort)."""
             try:
                 store = self._get_episode_store()
                 if store is None:
@@ -76,7 +78,6 @@ def _patch_memorize() -> None:
 
         AikoMemorize._get_episode_store = _get_episode_store  # type: ignore[method-assign]
 
-    # Flush on switch_user (only wrap once)
     if not getattr(AikoMemorize, "_emc2_switch_patched", False):
         _orig_switch = AikoMemorize.switch_user
 
@@ -93,7 +94,6 @@ def _patch_memorize() -> None:
         AikoMemorize.switch_user = switch_user  # type: ignore[method-assign]
         AikoMemorize._emc2_switch_patched = True  # type: ignore[attr-defined]
 
-    # EMC-3: episodic recall on format_for_context (once)
     if not getattr(AikoMemorize, "_emc3_format_patched", False):
         _orig_fmt = AikoMemorize.format_for_context
 
@@ -107,12 +107,8 @@ def _patch_memorize() -> None:
             embedder=None,
         ):
             sm_block = _orig_fmt(
-                self,
-                memories,
-                query=query,
-                related=related,
-                user_id=user_id,
-                embedder=embedder,
+                self, memories, query=query, related=related,
+                user_id=user_id, embedder=embedder,
             )
             try:
                 em_block = self._format_episodes_for_context(query or "")
@@ -176,3 +172,4 @@ def _patch_memorize() -> None:
 
 
 apply_emc3_hooks = apply_emc2_hooks
+apply_emc4_hooks = apply_emc2_hooks

--- a/cognition/memory/episode_dream.py
+++ b/cognition/memory/episode_dream.py
@@ -174,7 +174,7 @@ def distill_episodes(
     uid = user_id or memorize.get_user_id()
     store = None
     try:
-        store = memorize._get_episode_store()
+        store = memorize._get_episode_store(uid)
     except Exception as e:
         log.debug("EMC-4 no episode store: %s", e)
         return result
@@ -183,8 +183,8 @@ def distill_episodes(
 
     try:
         store.flush_all()
-    except Exception:
-        pass
+    except Exception as e:
+        log.debug("EMC-4 flush_all failed: %s", e)
 
     candidates = _candidate_episodes(store, uid, top)
     result["candidates"] = len(candidates)
@@ -223,6 +223,7 @@ def distill_episodes(
             )
             continue
 
+        batch_success = True
         for fact in facts:
             try:
                 mid = memorize.add_raw(fact, user_id=uid, pinned=False)
@@ -230,10 +231,13 @@ def distill_episodes(
                     facts_written += 1
             except Exception as e:
                 log.debug("EMC-4 add_raw failed: %s", e)
+                batch_success = False
 
-        ids = [c["id"] for c in batch]
-        _mark_distilled(store, ids)
-        distilled_ids.extend(ids)
+        # Only mark distilled if all facts were written successfully
+        if batch_success:
+            ids = [c["id"] for c in batch]
+            _mark_distilled(store, ids)
+            distilled_ids.extend(ids)
 
     result["distilled_episodes"] = len(distilled_ids)
     result["facts_written"] = facts_written

--- a/cognition/memory/episode_dream.py
+++ b/cognition/memory/episode_dream.py
@@ -1,0 +1,265 @@
+"""
+EMC-4: dream-time distillation of episodic memory → semantic facts.
+
+During AikoMemorize.dream(), undistrilled episodes are summarized into
+durable facts (via the same LLM extract path style as turn writes) and
+written with add_raw. Episodes are then marked distilled_at so they are
+not re-processed.
+
+Human analogy: sleep consolidates episodic traces into semantic knowledge.
+WM→EM already happened in EMC-2; this is EM→SM.
+"""
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from system.log import get_logger
+from cognition.memory.env import env_bool, env_int
+
+log = get_logger(__name__)
+
+EMC_DREAM_ENABLED = env_bool("EMC_DREAM_ENABLED", "1")
+EMC_DREAM_LIMIT = max(0, env_int("EMC_DREAM_LIMIT", 12))
+EMC_DREAM_BATCH = max(1, env_int("EMC_DREAM_BATCH", 4))
+EMC_DREAM_MIN_CHARS = max(20, env_int("EMC_DREAM_MIN_CHARS", 60))
+EMC_DREAM_MAX_TOKENS = max(64, env_int("EMC_DREAM_MAX_TOKENS", 256))
+
+_DISTILL_PROMPT = """\
+You extract durable long-term facts from past conversation moments.
+Only keep stable facts about the user (preferences, identity, plans, relationships).
+Skip greetings, one-off logistics, and anything already ephemeral.
+Output a JSON array of strings. Empty array if nothing durable.
+Each fact must be a single short sentence in third person about the user.
+
+Moments:
+{moments}
+
+JSON array:
+"""
+
+
+def ensure_distilled_column(conn) -> None:
+    """Add distilled_at to emc_storage if missing (idempotent)."""
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(emc_storage)").fetchall()}
+        if "distilled_at" not in cols:
+            conn.execute("ALTER TABLE emc_storage ADD COLUMN distilled_at TEXT")
+            conn.commit()
+            log.info("EMC-4: added emc_storage.distilled_at")
+    except Exception as e:
+        log.debug("EMC-4 distilled_at migration: %s", e)
+
+
+def _parse_facts(raw: str) -> list[str]:
+    text = (raw or "").strip()
+    if not text:
+        return []
+    text = re.sub(r"^```(?:json)?\s*", "", text)
+    text = re.sub(r"\s*```$", "", text)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        m = re.search(r"\[.*\]", text, re.DOTALL)
+        if not m:
+            return []
+        try:
+            data = json.loads(m.group(0))
+        except json.JSONDecodeError:
+            return []
+    out: list[str] = []
+    if isinstance(data, list):
+        for item in data:
+            if isinstance(item, str) and item.strip():
+                out.append(item.strip())
+            elif isinstance(item, dict):
+                fact = (item.get("fact") or item.get("text") or "").strip()
+                if fact:
+                    out.append(fact)
+    return out
+
+
+def _candidate_episodes(store, user_id: str, limit: int) -> list[dict]:
+    ensure_distilled_column(store._conn)
+    with store._lock:
+        rows = store._conn.execute(
+            """
+            SELECT id, timestamp, date, trace, salience_score, recall_count
+            FROM emc_storage
+            WHERE user_id = ?
+              AND (superseded_by IS NULL)
+              AND (distilled_at IS NULL)
+              AND length(trace) >= ?
+            ORDER BY
+              COALESCE(salience_score, 0) DESC,
+              COALESCE(recall_count, 0) DESC,
+              timestamp DESC
+            LIMIT ?
+            """,
+            (user_id, EMC_DREAM_MIN_CHARS, limit),
+        ).fetchall()
+    return [
+        {
+            "id": int(r[0]),
+            "timestamp": r[1],
+            "date": r[2],
+            "trace": r[3],
+            "salience_score": r[4],
+            "recall_count": int(r[5] or 0),
+        }
+        for r in rows
+    ]
+
+
+def _mark_distilled(store, ids: list[int]) -> None:
+    if not ids:
+        return
+    from datetime import datetime, timezone
+    now = datetime.now(timezone.utc).isoformat()
+    with store._lock:
+        for eid in ids:
+            store._conn.execute(
+                "UPDATE emc_storage SET distilled_at = ? WHERE id = ?",
+                (now, eid),
+            )
+        store._conn.commit()
+
+
+def _llm_distill(client, model: str, moments: list[str]) -> list[str]:
+    if not moments or client is None:
+        return []
+    block = "\n\n".join(f"[{i+1}]\n{m}" for i, m in enumerate(moments))
+    prompt = _DISTILL_PROMPT.format(moments=block[:6000])
+    try:
+        resp = client.chat.completions.create(
+            model=model,
+            messages=[{"role": "user", "content": prompt}],
+            stream=False,
+            max_tokens=EMC_DREAM_MAX_TOKENS,
+            temperature=0.0,
+            timeout=45.0,
+        )
+        raw = (resp.choices[0].message.content or "").strip()
+        return _parse_facts(raw)
+    except Exception as e:
+        log.debug("EMC-4 LLM distill failed: %s", e)
+        return []
+
+
+def distill_episodes(
+    memorize,
+    *,
+    user_id: str | None = None,
+    dry_run: bool = False,
+    limit: int | None = None,
+) -> dict[str, Any]:
+    """Distill undistrilled episodes into semantic facts via memorize.add_raw."""
+    from cognition.memory.episode import EMC_ENABLED
+
+    result = {
+        "candidates": 0,
+        "distilled_episodes": 0,
+        "facts_written": 0,
+        "dry_run": dry_run,
+        "enabled": bool(EMC_DREAM_ENABLED and EMC_ENABLED),
+    }
+    if not EMC_ENABLED or not EMC_DREAM_ENABLED:
+        return result
+
+    top = EMC_DREAM_LIMIT if limit is None else max(0, int(limit))
+    if top <= 0:
+        return result
+
+    uid = user_id or memorize.get_user_id()
+    store = None
+    try:
+        store = memorize._get_episode_store()
+    except Exception as e:
+        log.debug("EMC-4 no episode store: %s", e)
+        return result
+    if store is None:
+        return result
+
+    try:
+        store.flush_all()
+    except Exception:
+        pass
+
+    candidates = _candidate_episodes(store, uid, top)
+    result["candidates"] = len(candidates)
+    if not candidates:
+        return result
+
+    backend = getattr(memorize, "_mem", None)
+    client = getattr(backend, "_client", None) if backend else None
+    model = getattr(backend, "_model", None) or "ministral"
+
+    facts_written = 0
+    distilled_ids: list[int] = []
+
+    for i in range(0, len(candidates), EMC_DREAM_BATCH):
+        batch = candidates[i : i + EMC_DREAM_BATCH]
+        moments = [c["trace"] for c in batch if (c.get("trace") or "").strip()]
+        facts = _llm_distill(client, model, moments)
+        if dry_run:
+            log.info(
+                "EMC-4 dry-run batch episodes=%d facts=%d sample=%r",
+                len(batch),
+                len(facts),
+                (facts[:2] if facts else []),
+            )
+            distilled_ids.extend(c["id"] for c in batch)
+            continue
+
+        for fact in facts:
+            try:
+                mid = memorize.add_raw(fact, user_id=uid, pinned=False)
+                if mid:
+                    facts_written += 1
+            except Exception as e:
+                log.debug("EMC-4 add_raw failed: %s", e)
+
+        ids = [c["id"] for c in batch]
+        _mark_distilled(store, ids)
+        distilled_ids.extend(ids)
+
+    result["distilled_episodes"] = len(distilled_ids)
+    result["facts_written"] = facts_written
+    log.info(
+        "EMC-4 distill candidates=%d episodes=%d facts=%d dry_run=%s",
+        result["candidates"],
+        result["distilled_episodes"],
+        facts_written,
+        dry_run,
+    )
+    return result
+
+
+def attach_dream_hook() -> None:
+    """Wrap AikoMemorize.dream to run EMC distill after SM consolidation."""
+    from cognition.memory.memorize import AikoMemorize
+
+    if getattr(AikoMemorize, "_emc4_dream_patched", False):
+        return
+
+    _orig = AikoMemorize.dream
+
+    def dream(self, user_id=None, dry_run=False, threshold=None, **kwargs):
+        if threshold is None:
+            from cognition.memory.lifecycle import DREAM_MERGE_THRESHOLD
+            threshold = DREAM_MERGE_THRESHOLD
+        result = _orig(self, user_id=user_id, dry_run=dry_run, threshold=threshold, **kwargs)
+        try:
+            emc = distill_episodes(self, user_id=user_id, dry_run=dry_run)
+            if isinstance(result, dict):
+                result["emc_distill"] = emc
+        except Exception as e:
+            log.warning("EMC-4 distill after dream failed: %s", e)
+            if isinstance(result, dict):
+                result["emc_distill_error"] = str(e)
+        return result
+
+    AikoMemorize.dream = dream  # type: ignore[method-assign]
+    AikoMemorize._emc4_dream_patched = True  # type: ignore[attr-defined]
+    log.debug("EMC-4 dream hook attached")

--- a/cognition/memory/episode_dream.py
+++ b/cognition/memory/episode_dream.py
@@ -209,7 +209,18 @@ def distill_episodes(
                 len(facts),
                 (facts[:2] if facts else []),
             )
-            distilled_ids.extend(c["id"] for c in batch)
+            # dry-run: never mark; only count batches that would produce facts
+            if facts:
+                distilled_ids.extend(c["id"] for c in batch)
+            continue
+
+        # Only mark distilled when the LLM returned durable facts.
+        # Empty extract → leave distilled_at NULL so the episodes can retry next dream.
+        if not facts:
+            log.debug(
+                "EMC-4 empty extract; not marking episodes=%s",
+                [c["id"] for c in batch],
+            )
             continue
 
         for fact in facts:

--- a/config/memory.yaml
+++ b/config/memory.yaml
@@ -277,7 +277,7 @@ MEMORY_NEG_HARD_FILTER: "1"           # Exclude strong-neg from unsolicited cont
 MEMORY_NEG_HARD_THRESHOLD: "-1"       # valence_score <= this counts as sticky-neg.
 MEMORY_LINEAGE_MAX_DEPTH: "32"        # Max supersession chain nodes returned by lineage API.
 
-# -- Episodic Memory Cortex (EMC) — Phase EMC-1 + EMC-2 --
+# -- Episodic Memory Cortex (EMC) — Phase EMC-1 … EMC-4 --
 # True episodic store (first-person, time-stamped episodes).
 # Lives in the same per-user memory.db as facts/knowledge (Option A).
 # Missing human-EM fields stay NULL — never invent values.
@@ -292,11 +292,19 @@ EMC_EVICT_MIN_CHARS: "40"     # Skip turns shorter than this (combined)
 EMC_FLUSH_EVERY_TURNS: "8"    # Flush after this many ingested turns (0 = size-only)
 EMC_FLUSH_ON_STAGING: "24"    # Flush when staging count reaches this
 
-EMC_RECALL_ENABLED: "1"
-EMC_RECALL_LIMIT: "2"
-EMC_KNN_LIMIT: "12"
-EMC_FTS_LIMIT: "12"
-EMC_RRF_K: "60"
-EMC_CONTEXT_CHARS: "600"
-EMC_CONTEXT_EPISODE_CHARS: "280"
-EMC_JOINT_BUDGET: "1"
+# EMC-3: episodic recall + joint EM+SM context budget
+EMC_RECALL_ENABLED: "1"       # Inject <episodic_context> into format_for_context
+EMC_RECALL_LIMIT: "2"         # Max episodes injected per turn
+EMC_KNN_LIMIT: "12"           # Vector candidates before RRF
+EMC_FTS_LIMIT: "12"           # Lexical candidates before RRF
+EMC_RRF_K: "60"               # Reciprocal Rank Fusion constant
+EMC_CONTEXT_CHARS: "600"      # Soft char budget for the whole episodic block
+EMC_CONTEXT_EPISODE_CHARS: "280"  # Max chars per episode snippet
+EMC_JOINT_BUDGET: "1"         # Shrink SM so EM+SM stay under MEMORY_CONTEXT_TOTAL_CHARS
+
+# EMC-4: dream distillation EM → SM
+EMC_DREAM_ENABLED: "1"        # Run episodic→fact distillation inside dream()
+EMC_DREAM_LIMIT: "12"         # Max undistrilled episodes considered per dream
+EMC_DREAM_BATCH: "4"          # Episodes per LLM extract call
+EMC_DREAM_MIN_CHARS: "60"     # Skip short traces
+EMC_DREAM_MAX_TOKENS: "256"   # Token budget for the distill LLM call

--- a/docs/emc4_dream.md
+++ b/docs/emc4_dream.md
@@ -1,0 +1,27 @@
+# EMC-4 — dream distillation (EM → SM)
+
+## What
+During `AikoMemorize.dream()`, undistrilled episodic rows are:
+1. Selected (salience / recall_count / recency)
+2. Batched into an LLM prompt for durable facts only
+3. Written via `add_raw` (same dedup/supersede as normal writes)
+4. Marked `distilled_at` so they are not re-processed
+
+Human analogy: sleep consolidates episodic traces into semantic knowledge.
+WM→EM is EMC-2; this is EM→SM.
+
+## Config
+```yaml
+EMC_DREAM_ENABLED: "1"
+EMC_DREAM_LIMIT: "12"       # max undistrilled episodes per dream pass
+EMC_DREAM_BATCH: "4"        # episodes per LLM call
+EMC_DREAM_MIN_CHARS: "60"   # skip short traces
+EMC_DREAM_MAX_TOKENS: "256"
+```
+
+## Schema
+`emc_storage.distilled_at TEXT` added idempotently on first distill.
+
+## Out of scope
+- Grouping/clustering staging before flush
+- Full emotional reprocessing of episodes

--- a/docs/emc4_dream.md
+++ b/docs/emc4_dream.md
@@ -5,7 +5,8 @@ During `AikoMemorize.dream()`, undistrilled episodic rows are:
 1. Selected (salience / recall_count / recency)
 2. Batched into an LLM prompt for durable facts only
 3. Written via `add_raw` (same dedup/supersede as normal writes)
-4. Marked `distilled_at` so they are not re-processed
+4. Marked `distilled_at` **only when the LLM returned a non-empty fact list**
+   (empty extract leaves rows eligible for a later dream pass)
 
 Human analogy: sleep consolidates episodic traces into semantic knowledge.
 WM→EM is EMC-2; this is EM→SM.


### PR DESCRIPTION
## Summary

**EMC-4** — during `dream()`, distill undistrilled episodes into durable semantic facts.

Completes the human-aligned memory arc:
- **EMC-1** storage
- **EMC-2** WM→EM (turn eviction)
- **EMC-3** EM recall + joint budget
- **EMC-4** EM→SM (this PR)

## What

### `cognition/memory/episode_dream.py` (new)
- Select undistrilled episodes (salience / recall_count / recency)
- Batch → LLM prompt for **durable** facts only (skip ephemeral)
- `memorize.add_raw` (same dedup/supersede as normal writes)
- Mark `emc_storage.distilled_at` **only when LLM returns non-empty facts** (empty extract → retry next dream)
- Flush staging first so recent turns are included

### `emc2_wire.py`
- `attach_dream_hook()` wraps `AikoMemorize.dream` → runs distill after SM boost/merge/prune
- Result dict gains `emc_distill: {candidates, distilled_episodes, facts_written, ...}`

### `config/memory.yaml`
EMC-3 + EMC-4 knobs documented under the EMC section.

## Config

```yaml
EMC_DREAM_ENABLED: "1"
EMC_DREAM_LIMIT: "12"
EMC_DREAM_BATCH: "4"
EMC_DREAM_MIN_CHARS: "60"
EMC_DREAM_MAX_TOKENS: "256"
```

## Notes
- Best-effort: LLM failure → log + skip (does not break dream)
- Dry-run respects `dream(..., dry_run=True)` (no writes / no mark)
- Does **not** invent valence/entities on episodes
- Empty extract does **not** set `distilled_at`

## Docs
`docs/emc4_dream.md`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added EMC-4 dream distillation to extract durable facts from episodic memories.
  * Added configurable controls for enabling distillation, batch size, episode limits, minimum trace length, and processing budget.
  * Added support for dry runs and retrying episodes when no facts are extracted.
  * Added automatic recording of successful dream-processing results.

* **Documentation**
  * Added documentation covering EMC-4 dream distillation, configuration, and processing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->