### PR TITLE
feat(agentic): unified tool-result cache as first-class DAG steps

### DIFF
--- a/agentic/graph_engine.py
+++ b/agentic/graph_engine.py
@@ -1514,6 +1514,10 @@ def _condition_actual(cond: dict[str, Any], results: dict[str, NodeResult], stat
         if isinstance(value, (dict, list, tuple)):
             return json.dumps(value, ensure_ascii=False)
         return str(value)
+    if "env_truthy" in cond:
+        env_var = str(cond["env_truthy"])
+        env_value = os.getenv(env_var, "").strip().lower()
+        return env_value
     ref = cond.get("node")
     if ref is not None:
         if ref not in results:
@@ -1530,6 +1534,9 @@ def _check_condition(cond: dict[str, Any], actual: str) -> bool:
         return all(_check_condition(c, actual) for c in cond["and"])
     if "or" in cond:
         return any(_check_condition(c, actual) for c in cond["or"])
+    if "env_truthy" in cond:
+        # Check if environment variable is truthy
+        return actual_lower in {"1", "true", "yes", "on"}
     if "equals" in cond:
         return actual_lower == str(cond["equals"]).strip().lower()
     if "contains" in cond:

--- a/agentic/playbook.json
+++ b/agentic/playbook.json
@@ -1,0 +1,183 @@
+[
+  {
+    "id": "research_and_report",
+    "name": "Deep research, combine, synthesize, and write a report",
+    "capabilities": ["research"],
+    "nodes": [
+      {"id": "web", "tool": "deep_research", "args": {"query": "$prompt"}},
+      {"id": "cache_web", "tool": "cache_write", "depends_on": ["web"],
+       "args": {"workflow": "research_and_report", "source": "web", "items": "$result:web", "run_id": "run"}},
+      {"id": "kb", "tool": "kb_search", "depends_on": ["web"], "args": {"query": "$prompt"}},
+      {"id": "cache_kb", "tool": "cache_write", "depends_on": ["kb"],
+       "args": {"workflow": "research_and_report", "source": "kb", "items": "$result:kb", "run_id": "run"}},
+      {"id": "select", "tool": "cache_select", "depends_on": ["cache_web", "cache_kb"],
+       "args": {"workflow": "research_and_report", "run_id": "run", "limit": 12, "keywords": "$prompt"}},
+      {"id": "draft", "tool": "synthesize_report", "depends_on": ["select"],
+       "args": {"evidence": "$result:select", "prompt": "$prompt", "style": "auto"}},
+      {"id": "report", "tool": "write_report", "depends_on": ["draft"],
+       "args": {"title": "$title", "content": "$result:draft", "report_dir": "reports"}},
+      {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
+       "args": {"title": "$title", "text": "$result:draft", "kind": "self_learned"}},
+      {"id": "gc", "tool": "cache_gc", "depends_on": ["learn"],
+       "args": {"workflow": "research_and_report", "keep_runs": 14}}
+    ]
+  },
+  {
+    "id": "search_kb_and_report",
+    "name": "Quick search, combine with KB, synthesize, and write a report",
+    "capabilities": ["research"],
+    "nodes": [
+      {"id": "web", "tool": "adaptive_search", "args": {"query": "$prompt"}},
+      {"id": "cache_web", "tool": "cache_write", "depends_on": ["web"],
+       "args": {"workflow": "search_kb_and_report", "source": "web", "items": "$result:web", "run_id": "run"}},
+      {"id": "kb", "tool": "kb_search", "depends_on": ["web"], "args": {"query": "$prompt"}},
+      {"id": "cache_kb", "tool": "cache_write", "depends_on": ["kb"],
+       "args": {"workflow": "search_kb_and_report", "source": "kb", "items": "$result:kb", "run_id": "run"}},
+      {"id": "select", "tool": "cache_select", "depends_on": ["cache_web", "cache_kb"],
+       "args": {"workflow": "search_kb_and_report", "run_id": "run", "limit": 10, "keywords": "$prompt"}},
+      {"id": "draft", "tool": "synthesize_report", "depends_on": ["select"],
+       "args": {"evidence": "$result:select", "prompt": "$prompt", "style": "auto"}},
+      {"id": "report", "tool": "write_report", "depends_on": ["draft"],
+       "args": {"title": "$title", "content": "$result:draft", "report_dir": "reports"}},
+      {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
+       "args": {"title": "$title", "text": "$result:draft", "kind": "self_learned"}}
+    ]
+  },
+  {
+    "id": "compare_and_report",
+    "name": "Compare two subjects with parallel research, then synthesize",
+    "capabilities": ["research"],
+    "nodes": [
+      {"id": "web_a", "tool": "deep_research", "args": {"query": "$compare_left"}},
+      {"id": "web_b", "tool": "deep_research", "args": {"query": "$compare_right"}},
+      {"id": "cache_a", "tool": "cache_write", "depends_on": ["web_a"],
+       "args": {"workflow": "compare_and_report", "source": "web_a", "items": "$result:web_a", "run_id": "run"}},
+      {"id": "cache_b", "tool": "cache_write", "depends_on": ["web_b"],
+       "args": {"workflow": "compare_and_report", "source": "web_b", "items": "$result:web_b", "run_id": "run"}},
+      {"id": "kb", "tool": "kb_search", "depends_on": ["web_a", "web_b"], "args": {"query": "$prompt"}},
+      {"id": "cache_kb", "tool": "cache_write", "depends_on": ["kb"],
+       "args": {"workflow": "compare_and_report", "source": "kb", "items": "$result:kb", "run_id": "run"}},
+      {"id": "select", "tool": "cache_select", "depends_on": ["cache_a", "cache_b", "cache_kb"],
+       "args": {"workflow": "compare_and_report", "run_id": "run", "limit": 14, "keywords": "$prompt"}},
+      {"id": "draft", "tool": "synthesize_report", "depends_on": ["select"],
+       "args": {"evidence": "$result:select", "prompt": "$prompt", "style": "auto", "comparison_subjects": "$compare_subjects"}},
+      {"id": "report", "tool": "write_report", "depends_on": ["draft"],
+       "args": {"title": "$title", "content": "$result:draft", "report_dir": "reports"}},
+      {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
+       "args": {"title": "$title", "text": "$result:draft", "kind": "self_learned"}}
+    ]
+  },
+  {
+    "id": "parallel_fanout_fanin",
+    "name": "Parallel fan-out research then fan-in synthesis",
+    "capabilities": ["research"],
+    "nodes": [
+      {"id": "web_1", "tool": "deep_research", "args": {"query": "angle 1: technical deep-dive on $prompt"}},
+      {"id": "web_2", "tool": "deep_research", "args": {"query": "angle 2: practical applications of $prompt"}},
+      {"id": "web_3", "tool": "deep_research", "args": {"query": "angle 3: limitations and criticisms of $prompt"}},
+      {"id": "cache_1", "tool": "cache_write", "depends_on": ["web_1"],
+       "args": {"workflow": "parallel_fanout_fanin", "source": "web_1", "items": "$result:web_1", "run_id": "run"}},
+      {"id": "cache_2", "tool": "cache_write", "depends_on": ["web_2"],
+       "args": {"workflow": "parallel_fanout_fanin", "source": "web_2", "items": "$result:web_2", "run_id": "run"}},
+      {"id": "cache_3", "tool": "cache_write", "depends_on": ["web_3"],
+       "args": {"workflow": "parallel_fanout_fanin", "source": "web_3", "items": "$result:web_3", "run_id": "run"}},
+      {"id": "select", "tool": "cache_select", "depends_on": ["cache_1", "cache_2", "cache_3"],
+       "args": {"workflow": "parallel_fanout_fanin", "run_id": "run", "limit": 15, "keywords": "$prompt"}},
+      {"id": "synthesize", "tool": "synthesize_report", "depends_on": ["select"],
+       "args": {"evidence": "$result:select", "prompt": "$prompt", "style": "professional"}},
+      {"id": "report", "tool": "write_report", "depends_on": ["synthesize"],
+       "args": {"title": "$title", "content": "$result:synthesize", "report_dir": "reports"}},
+      {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
+       "args": {"title": "$title", "text": "$result:synthesize", "kind": "self_learned"}}
+    ]
+  },
+  {
+    "id": "orchestrator_workers",
+    "name": "Orchestrator + workers with cached evidence",
+    "capabilities": ["research", "repo"],
+    "nodes": [
+      {"id": "decompose", "tool": "make_plan", "args": {"goal": "$prompt", "max_steps": 8}},
+      {"id": "worker_1", "tool": "deep_research", "depends_on": ["decompose"], "args": {"query": "Subtask 1 of: $prompt"}},
+      {"id": "worker_2", "tool": "repo_search_text", "depends_on": ["decompose"], "args": {"query": "Subtask 2 of: $prompt", "limit": 20}},
+      {"id": "worker_3", "tool": "kb_search", "depends_on": ["decompose"], "args": {"query": "Subtask 3 of: $prompt"}},
+      {"id": "cache_1", "tool": "cache_write", "depends_on": ["worker_1"],
+       "args": {"workflow": "orchestrator_workers", "source": "worker_1", "items": "$result:worker_1", "run_id": "run"}},
+      {"id": "cache_2", "tool": "cache_write", "depends_on": ["worker_2"],
+       "args": {"workflow": "orchestrator_workers", "source": "worker_2", "items": "$result:worker_2", "run_id": "run"}},
+      {"id": "cache_3", "tool": "cache_write", "depends_on": ["worker_3"],
+       "args": {"workflow": "orchestrator_workers", "source": "worker_3", "items": "$result:worker_3", "run_id": "run"}},
+      {"id": "select", "tool": "cache_select", "depends_on": ["cache_1", "cache_2", "cache_3"],
+       "args": {"workflow": "orchestrator_workers", "run_id": "run", "limit": 14, "keywords": "$prompt"}},
+      {"id": "final", "tool": "synthesize_report", "depends_on": ["select"],
+       "args": {"evidence": "$result:select", "prompt": "Final integrated answer: $prompt", "style": "professional"}},
+      {"id": "report", "tool": "write_report", "depends_on": ["final"],
+       "args": {"title": "$title", "content": "$result:final", "report_dir": "reports"}},
+      {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
+       "args": {"title": "$title", "text": "$result:final", "kind": "self_learned"}}
+    ]
+  },
+  {
+    "id": "planning_and_execution",
+    "name": "Plan then execute with cached step evidence",
+    "capabilities": ["research", "repo"],
+    "nodes": [
+      {"id": "plan", "tool": "make_plan", "args": {"goal": "$prompt", "max_steps": 6}},
+      {"id": "step_1", "tool": "deep_research", "depends_on": ["plan"], "args": {"query": "Step 1 execution for: $prompt"}},
+      {"id": "step_2", "tool": "deep_research", "depends_on": ["plan"], "args": {"query": "Step 2 execution for: $prompt"}},
+      {"id": "cache_1", "tool": "cache_write", "depends_on": ["step_1"],
+       "args": {"workflow": "planning_and_execution", "source": "step_1", "items": "$result:step_1", "run_id": "run"}},
+      {"id": "cache_2", "tool": "cache_write", "depends_on": ["step_2"],
+       "args": {"workflow": "planning_and_execution", "source": "step_2", "items": "$result:step_2", "run_id": "run"}},
+      {"id": "select", "tool": "cache_select", "depends_on": ["cache_1", "cache_2"],
+       "args": {"workflow": "planning_and_execution", "run_id": "run", "limit": 12, "keywords": "$prompt"}},
+      {"id": "final", "tool": "synthesize_report", "depends_on": ["select"],
+       "args": {"evidence": "$result:select", "prompt": "$prompt", "style": "professional"}},
+      {"id": "report", "tool": "write_report", "depends_on": ["final"],
+       "args": {"title": "$title", "content": "$result:final", "report_dir": "reports"}},
+      {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
+       "args": {"title": "$title", "text": "$result:final", "kind": "self_learned"}}
+    ]
+  },
+  {
+    "id": "multi_agent_collab",
+    "name": "Multi-role collaboration with cached researcher evidence",
+    "capabilities": ["research", "reports"],
+    "nodes": [
+      {"id": "researcher", "tool": "deep_research", "args": {"query": "$prompt"}},
+      {"id": "cache_r", "tool": "cache_write", "depends_on": ["researcher"],
+       "args": {"workflow": "multi_agent_collab", "source": "researcher", "items": "$result:researcher", "run_id": "run"}},
+      {"id": "select", "tool": "cache_select", "depends_on": ["cache_r"],
+       "args": {"workflow": "multi_agent_collab", "run_id": "run", "limit": 12, "keywords": "$prompt"}},
+      {"id": "analyst", "tool": "synthesize_report", "depends_on": ["select"],
+       "args": {"evidence": "$result:select", "prompt": "Analyst role: structure findings for: $prompt", "style": "auto"}},
+      {"id": "writer", "tool": "synthesize_report", "depends_on": ["analyst"],
+       "args": {"evidence": "$result:analyst", "prompt": "Writer role: report for: $prompt", "style": "professional"}},
+      {"id": "reviewer", "tool": "synthesize_report", "depends_on": ["writer"],
+       "args": {"evidence": "$result:writer", "prompt": "Reviewer role: critique the draft", "style": "plain"}},
+      {"id": "final", "tool": "synthesize_report", "depends_on": ["writer", "reviewer"],
+       "args": {"evidence": "$result:writer\n\nReview:\n$result:reviewer", "prompt": "Final deliverable", "style": "professional"}},
+      {"id": "report", "tool": "write_report", "depends_on": ["final"],
+       "args": {"title": "$title", "content": "$result:final", "report_dir": "reports"}},
+      {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
+       "args": {"title": "$title", "text": "$result:final", "kind": "self_learned"}}
+    ]
+  },
+  {
+    "id": "lane_d_job_hunt",
+    "name": "Lane D — nightly tech job teaser (cache-first)",
+    "capabilities": ["research", "job_hunt"],
+    "nodes": [
+      {"id": "fetch_rss", "tool": "search_jobs", "args": {"query": "$prompt"}, "timeout_seconds": 120},
+      {"id": "cache_rss", "tool": "cache_write", "depends_on": ["fetch_rss"],
+       "args": {"workflow": "lane_d_job_hunt", "source": "rss", "items": "$result:fetch_rss", "run_id": "run"}},
+      {"id": "select_jobs", "tool": "cache_select", "depends_on": ["cache_rss"],
+       "args": {"workflow": "lane_d_job_hunt", "run_id": "run", "matched_only": true, "limit": 10}},
+      {"id": "draft_teaser", "tool": "draft_job_post_social", "depends_on": ["select_jobs"],
+       "args": {"platform": "threads"}, "timeout_seconds": 90},
+      {"id": "save_draft", "tool": "write_report", "depends_on": ["draft_teaser"],
+       "args": {"title": "Lane D job teaser", "content": "$result:draft_teaser", "report_dir": "reports/job_hunt"}},
+      {"id": "gc", "tool": "cache_gc", "depends_on": ["save_draft"],
+       "args": {"workflow": "lane_d_job_hunt", "keep_runs": 14}}
+    ]
+  }
+]

--- a/agentic/playbook.json
+++ b/agentic/playbook.json
@@ -6,12 +6,12 @@
     "nodes": [
       {"id": "web", "tool": "deep_research", "args": {"query": "$prompt"}},
       {"id": "cache_web", "tool": "cache_write", "depends_on": ["web"],
-       "args": {"workflow": "research_and_report", "source": "web", "items": "$result:web", "run_id": "run"}},
+       "args": {"workflow": "research_and_report", "source": "web", "items": "$result:web"}},
       {"id": "kb", "tool": "kb_search", "depends_on": ["web"], "args": {"query": "$prompt"}},
       {"id": "cache_kb", "tool": "cache_write", "depends_on": ["kb"],
-       "args": {"workflow": "research_and_report", "source": "kb", "items": "$result:kb", "run_id": "run"}},
+       "args": {"workflow": "research_and_report", "source": "kb", "items": "$result:kb"}},
       {"id": "select", "tool": "cache_select", "depends_on": ["cache_web", "cache_kb"],
-       "args": {"workflow": "research_and_report", "run_id": "run", "limit": 12, "keywords": "$prompt"}},
+       "args": {"workflow": "research_and_report", "limit": 12, "keywords": "$prompt"}},
       {"id": "draft", "tool": "synthesize_report", "depends_on": ["select"],
        "args": {"evidence": "$result:select", "prompt": "$prompt", "style": "auto"}},
       {"id": "report", "tool": "write_report", "depends_on": ["draft"],
@@ -29,18 +29,20 @@
     "nodes": [
       {"id": "web", "tool": "adaptive_search", "args": {"query": "$prompt"}},
       {"id": "cache_web", "tool": "cache_write", "depends_on": ["web"],
-       "args": {"workflow": "search_kb_and_report", "source": "web", "items": "$result:web", "run_id": "run"}},
+       "args": {"workflow": "search_kb_and_report", "source": "web", "items": "$result:web"}},
       {"id": "kb", "tool": "kb_search", "depends_on": ["web"], "args": {"query": "$prompt"}},
       {"id": "cache_kb", "tool": "cache_write", "depends_on": ["kb"],
-       "args": {"workflow": "search_kb_and_report", "source": "kb", "items": "$result:kb", "run_id": "run"}},
+       "args": {"workflow": "search_kb_and_report", "source": "kb", "items": "$result:kb"}},
       {"id": "select", "tool": "cache_select", "depends_on": ["cache_web", "cache_kb"],
-       "args": {"workflow": "search_kb_and_report", "run_id": "run", "limit": 10, "keywords": "$prompt"}},
+       "args": {"workflow": "search_kb_and_report", "limit": 10, "keywords": "$prompt"}},
       {"id": "draft", "tool": "synthesize_report", "depends_on": ["select"],
        "args": {"evidence": "$result:select", "prompt": "$prompt", "style": "auto"}},
       {"id": "report", "tool": "write_report", "depends_on": ["draft"],
        "args": {"title": "$title", "content": "$result:draft", "report_dir": "reports"}},
       {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
-       "args": {"title": "$title", "text": "$result:draft", "kind": "self_learned"}}
+       "args": {"title": "$title", "text": "$result:draft", "kind": "self_learned"}},
+      {"id": "gc", "tool": "cache_gc", "depends_on": ["learn"],
+       "args": {"workflow": "search_kb_and_report", "keep_runs": 14}}
     ]
   },
   {
@@ -51,20 +53,22 @@
       {"id": "web_a", "tool": "deep_research", "args": {"query": "$compare_left"}},
       {"id": "web_b", "tool": "deep_research", "args": {"query": "$compare_right"}},
       {"id": "cache_a", "tool": "cache_write", "depends_on": ["web_a"],
-       "args": {"workflow": "compare_and_report", "source": "web_a", "items": "$result:web_a", "run_id": "run"}},
+       "args": {"workflow": "compare_and_report", "source": "web_a", "items": "$result:web_a"}},
       {"id": "cache_b", "tool": "cache_write", "depends_on": ["web_b"],
-       "args": {"workflow": "compare_and_report", "source": "web_b", "items": "$result:web_b", "run_id": "run"}},
+       "args": {"workflow": "compare_and_report", "source": "web_b", "items": "$result:web_b"}},
       {"id": "kb", "tool": "kb_search", "depends_on": ["web_a", "web_b"], "args": {"query": "$prompt"}},
       {"id": "cache_kb", "tool": "cache_write", "depends_on": ["kb"],
-       "args": {"workflow": "compare_and_report", "source": "kb", "items": "$result:kb", "run_id": "run"}},
+       "args": {"workflow": "compare_and_report", "source": "kb", "items": "$result:kb"}},
       {"id": "select", "tool": "cache_select", "depends_on": ["cache_a", "cache_b", "cache_kb"],
-       "args": {"workflow": "compare_and_report", "run_id": "run", "limit": 14, "keywords": "$prompt"}},
+       "args": {"workflow": "compare_and_report", "limit": 14, "keywords": "$prompt"}},
       {"id": "draft", "tool": "synthesize_report", "depends_on": ["select"],
        "args": {"evidence": "$result:select", "prompt": "$prompt", "style": "auto", "comparison_subjects": "$compare_subjects"}},
       {"id": "report", "tool": "write_report", "depends_on": ["draft"],
        "args": {"title": "$title", "content": "$result:draft", "report_dir": "reports"}},
       {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
-       "args": {"title": "$title", "text": "$result:draft", "kind": "self_learned"}}
+       "args": {"title": "$title", "text": "$result:draft", "kind": "self_learned"}},
+      {"id": "gc", "tool": "cache_gc", "depends_on": ["learn"],
+       "args": {"workflow": "compare_and_report", "keep_runs": 14}}
     ]
   },
   {
@@ -76,19 +80,21 @@
       {"id": "web_2", "tool": "deep_research", "args": {"query": "angle 2: practical applications of $prompt"}},
       {"id": "web_3", "tool": "deep_research", "args": {"query": "angle 3: limitations and criticisms of $prompt"}},
       {"id": "cache_1", "tool": "cache_write", "depends_on": ["web_1"],
-       "args": {"workflow": "parallel_fanout_fanin", "source": "web_1", "items": "$result:web_1", "run_id": "run"}},
+       "args": {"workflow": "parallel_fanout_fanin", "source": "web_1", "items": "$result:web_1"}},
       {"id": "cache_2", "tool": "cache_write", "depends_on": ["web_2"],
-       "args": {"workflow": "parallel_fanout_fanin", "source": "web_2", "items": "$result:web_2", "run_id": "run"}},
+       "args": {"workflow": "parallel_fanout_fanin", "source": "web_2", "items": "$result:web_2"}},
       {"id": "cache_3", "tool": "cache_write", "depends_on": ["web_3"],
-       "args": {"workflow": "parallel_fanout_fanin", "source": "web_3", "items": "$result:web_3", "run_id": "run"}},
+       "args": {"workflow": "parallel_fanout_fanin", "source": "web_3", "items": "$result:web_3"}},
       {"id": "select", "tool": "cache_select", "depends_on": ["cache_1", "cache_2", "cache_3"],
-       "args": {"workflow": "parallel_fanout_fanin", "run_id": "run", "limit": 15, "keywords": "$prompt"}},
+       "args": {"workflow": "parallel_fanout_fanin", "limit": 15, "keywords": "$prompt"}},
       {"id": "synthesize", "tool": "synthesize_report", "depends_on": ["select"],
        "args": {"evidence": "$result:select", "prompt": "$prompt", "style": "professional"}},
       {"id": "report", "tool": "write_report", "depends_on": ["synthesize"],
        "args": {"title": "$title", "content": "$result:synthesize", "report_dir": "reports"}},
       {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
-       "args": {"title": "$title", "text": "$result:synthesize", "kind": "self_learned"}}
+       "args": {"title": "$title", "text": "$result:synthesize", "kind": "self_learned"}},
+      {"id": "gc", "tool": "cache_gc", "depends_on": ["learn"],
+       "args": {"workflow": "parallel_fanout_fanin", "keep_runs": 14}}
     ]
   },
   {
@@ -101,19 +107,21 @@
       {"id": "worker_2", "tool": "repo_search_text", "depends_on": ["decompose"], "args": {"query": "Subtask 2 of: $prompt", "limit": 20}},
       {"id": "worker_3", "tool": "kb_search", "depends_on": ["decompose"], "args": {"query": "Subtask 3 of: $prompt"}},
       {"id": "cache_1", "tool": "cache_write", "depends_on": ["worker_1"],
-       "args": {"workflow": "orchestrator_workers", "source": "worker_1", "items": "$result:worker_1", "run_id": "run"}},
+       "args": {"workflow": "orchestrator_workers", "source": "worker_1", "items": "$result:worker_1"}},
       {"id": "cache_2", "tool": "cache_write", "depends_on": ["worker_2"],
-       "args": {"workflow": "orchestrator_workers", "source": "worker_2", "items": "$result:worker_2", "run_id": "run"}},
+       "args": {"workflow": "orchestrator_workers", "source": "worker_2", "items": "$result:worker_2"}},
       {"id": "cache_3", "tool": "cache_write", "depends_on": ["worker_3"],
-       "args": {"workflow": "orchestrator_workers", "source": "worker_3", "items": "$result:worker_3", "run_id": "run"}},
+       "args": {"workflow": "orchestrator_workers", "source": "worker_3", "items": "$result:worker_3"}},
       {"id": "select", "tool": "cache_select", "depends_on": ["cache_1", "cache_2", "cache_3"],
-       "args": {"workflow": "orchestrator_workers", "run_id": "run", "limit": 14, "keywords": "$prompt"}},
+       "args": {"workflow": "orchestrator_workers", "limit": 14, "keywords": "$prompt"}},
       {"id": "final", "tool": "synthesize_report", "depends_on": ["select"],
        "args": {"evidence": "$result:select", "prompt": "Final integrated answer: $prompt", "style": "professional"}},
       {"id": "report", "tool": "write_report", "depends_on": ["final"],
        "args": {"title": "$title", "content": "$result:final", "report_dir": "reports"}},
       {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
-       "args": {"title": "$title", "text": "$result:final", "kind": "self_learned"}}
+       "args": {"title": "$title", "text": "$result:final", "kind": "self_learned"}},
+      {"id": "gc", "tool": "cache_gc", "depends_on": ["learn"],
+       "args": {"workflow": "orchestrator_workers", "keep_runs": 14}}
     ]
   },
   {
@@ -125,17 +133,19 @@
       {"id": "step_1", "tool": "deep_research", "depends_on": ["plan"], "args": {"query": "Step 1 execution for: $prompt"}},
       {"id": "step_2", "tool": "deep_research", "depends_on": ["plan"], "args": {"query": "Step 2 execution for: $prompt"}},
       {"id": "cache_1", "tool": "cache_write", "depends_on": ["step_1"],
-       "args": {"workflow": "planning_and_execution", "source": "step_1", "items": "$result:step_1", "run_id": "run"}},
+       "args": {"workflow": "planning_and_execution", "source": "step_1", "items": "$result:step_1"}},
       {"id": "cache_2", "tool": "cache_write", "depends_on": ["step_2"],
-       "args": {"workflow": "planning_and_execution", "source": "step_2", "items": "$result:step_2", "run_id": "run"}},
+       "args": {"workflow": "planning_and_execution", "source": "step_2", "items": "$result:step_2"}},
       {"id": "select", "tool": "cache_select", "depends_on": ["cache_1", "cache_2"],
-       "args": {"workflow": "planning_and_execution", "run_id": "run", "limit": 12, "keywords": "$prompt"}},
+       "args": {"workflow": "planning_and_execution", "limit": 12, "keywords": "$prompt"}},
       {"id": "final", "tool": "synthesize_report", "depends_on": ["select"],
        "args": {"evidence": "$result:select", "prompt": "$prompt", "style": "professional"}},
       {"id": "report", "tool": "write_report", "depends_on": ["final"],
        "args": {"title": "$title", "content": "$result:final", "report_dir": "reports"}},
       {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
-       "args": {"title": "$title", "text": "$result:final", "kind": "self_learned"}}
+       "args": {"title": "$title", "text": "$result:final", "kind": "self_learned"}},
+      {"id": "gc", "tool": "cache_gc", "depends_on": ["learn"],
+       "args": {"workflow": "planning_and_execution", "keep_runs": 14}}
     ]
   },
   {
@@ -145,9 +155,9 @@
     "nodes": [
       {"id": "researcher", "tool": "deep_research", "args": {"query": "$prompt"}},
       {"id": "cache_r", "tool": "cache_write", "depends_on": ["researcher"],
-       "args": {"workflow": "multi_agent_collab", "source": "researcher", "items": "$result:researcher", "run_id": "run"}},
+       "args": {"workflow": "multi_agent_collab", "source": "researcher", "items": "$result:researcher"}},
       {"id": "select", "tool": "cache_select", "depends_on": ["cache_r"],
-       "args": {"workflow": "multi_agent_collab", "run_id": "run", "limit": 12, "keywords": "$prompt"}},
+       "args": {"workflow": "multi_agent_collab", "limit": 12, "keywords": "$prompt"}},
       {"id": "analyst", "tool": "synthesize_report", "depends_on": ["select"],
        "args": {"evidence": "$result:select", "prompt": "Analyst role: structure findings for: $prompt", "style": "auto"}},
       {"id": "writer", "tool": "synthesize_report", "depends_on": ["analyst"],
@@ -159,7 +169,9 @@
       {"id": "report", "tool": "write_report", "depends_on": ["final"],
        "args": {"title": "$title", "content": "$result:final", "report_dir": "reports"}},
       {"id": "learn", "tool": "learn_report", "depends_on": ["report"],
-       "args": {"title": "$title", "text": "$result:final", "kind": "self_learned"}}
+       "args": {"title": "$title", "text": "$result:final", "kind": "self_learned"}},
+      {"id": "gc", "tool": "cache_gc", "depends_on": ["learn"],
+       "args": {"workflow": "multi_agent_collab", "keep_runs": 14}}
     ]
   },
   {
@@ -169,9 +181,9 @@
     "nodes": [
       {"id": "fetch_rss", "tool": "search_jobs", "args": {"query": "$prompt"}, "timeout_seconds": 120},
       {"id": "cache_rss", "tool": "cache_write", "depends_on": ["fetch_rss"],
-       "args": {"workflow": "lane_d_job_hunt", "source": "rss", "items": "$result:fetch_rss", "run_id": "run"}},
+       "args": {"workflow": "lane_d_job_hunt", "source": "rss", "items": "$result:fetch_rss"}},
       {"id": "select_jobs", "tool": "cache_select", "depends_on": ["cache_rss"],
-       "args": {"workflow": "lane_d_job_hunt", "run_id": "run", "matched_only": true, "limit": 10}},
+       "args": {"workflow": "lane_d_job_hunt", "matched_only": true, "limit": 10}},
       {"id": "draft_teaser", "tool": "draft_job_post_social", "depends_on": ["select_jobs"],
        "args": {"platform": "threads"}, "timeout_seconds": 90},
       {"id": "save_draft", "tool": "write_report", "depends_on": ["draft_teaser"],

--- a/agentic/playbooks/lane_d_job_hunt.json
+++ b/agentic/playbooks/lane_d_job_hunt.json
@@ -1,0 +1,122 @@
+{
+  "id": "lane_d_job_hunt",
+  "name": "Lane D \u2014 nightly tech job teaser",
+  "summary": "Fetch RSS (+ optional email), cache full results, select a small matched set, draft Threads teaser. Tool outputs never enter LLM ctx in bulk.",
+  "triggers": [
+    "tech jobs today",
+    "job hunt lane d",
+    "civicjobs lower mainland",
+    "draft job teaser threads"
+  ],
+  "semantic_triggers": [
+    "list today's tech jobs from configured RSS feeds and draft a short social teaser"
+  ],
+  "nodes": [
+    {
+      "id": "init_run",
+      "tool": "set_state",
+      "args": {
+        "run_id": "${utc_run_id}",
+        "workflow": "lane_d_job_hunt"
+      },
+      "depends_on": []
+    },
+    {
+      "id": "fetch_rss",
+      "tool": "search_jobs",
+      "args": {
+        "feeds": "civicjobs_lower_mainland,job_bank_canada_tech",
+        "keywords_env": "TECH_JOB_KEYWORDS",
+        "to_state": "rss_raw"
+      },
+      "depends_on": ["init_run"],
+      "timeout_seconds": 120,
+      "max_retries": 1
+    },
+    {
+      "id": "cache_rss",
+      "tool": "cache_write",
+      "args": {
+        "workflow": "lane_d_job_hunt",
+        "source": "rss",
+        "from_state": "rss_raw",
+        "run_id": "${run_id}"
+      },
+      "depends_on": ["fetch_rss"]
+    },
+    {
+      "id": "fetch_email",
+      "tool": "fetch_job_emails",
+      "args": {
+        "mailbox": "job_alerts",
+        "to_state": "email_raw"
+      },
+      "depends_on": ["init_run"],
+      "timeout_seconds": 120,
+      "max_retries": 1,
+      "run_if": { "env_truthy": "LANE_D_EMAIL_ENABLED" }
+    },
+    {
+      "id": "cache_email",
+      "tool": "cache_write",
+      "args": {
+        "workflow": "lane_d_job_hunt",
+        "source": "email",
+        "from_state": "email_raw",
+        "run_id": "${run_id}"
+      },
+      "depends_on": ["fetch_email"],
+      "run_if": { "env_truthy": "LANE_D_EMAIL_ENABLED" }
+    },
+    {
+      "id": "select_jobs",
+      "tool": "cache_select",
+      "args": {
+        "workflow": "lane_d_job_hunt",
+        "run_id": "${run_id}",
+        "matched_only": true,
+        "limit": 10,
+        "keywords_env": "TECH_JOB_KEYWORDS",
+        "to_state": "selection"
+      },
+      "depends_on": ["cache_rss", "cache_email"]
+    },
+    {
+      "id": "draft_teaser",
+      "tool": "draft_job_post_social",
+      "args": {
+        "platform": "threads",
+        "from_state": "selection",
+        "style": "concise_teaser_list",
+        "to_state": "draft"
+      },
+      "depends_on": ["select_jobs"],
+      "timeout_seconds": 90
+    },
+    {
+      "id": "save_draft",
+      "tool": "write_report",
+      "args": {
+        "from_state": "draft",
+        "path": "agentic/workflows/job_hunt/drafts/${run_id}_threads.md",
+        "kind": "social_draft"
+      },
+      "depends_on": ["draft_teaser"]
+    },
+    {
+      "id": "cache_gc",
+      "tool": "cache_gc",
+      "args": {
+        "workflow": "lane_d_job_hunt",
+        "keep_runs": 14
+      },
+      "depends_on": ["save_draft"]
+    }
+  ],
+  "notes": [
+    "cache_write stores full RSS/email rows on disk (JSONL).",
+    "cache_select puts only ~10 compact rows on state.selection for the LLM.",
+    "Do not ADD raw job rows into long-term memories; optional later promote of 'posted teaser for date X' only.",
+    "fetch_email is optional via LANE_D_EMAIL_ENABLED; depends_on list still allows select after rss-only runs if graph treats missing optional branch as satisfied \u2014 adjust executor if needed to depend_on cache_rss only when email disabled."
+  ]
+}

--- a/agentic/toolkit/tool_result_cache.py
+++ b/agentic/toolkit/tool_result_cache.py
@@ -1,0 +1,385 @@
+"""Unified on-disk tool-result cache for agentic DAG workflows.
+
+Full tool outputs land here by default (JSONL). Only cache_select() output
+should be injected into LLM synthesis. Same schema for email/RSS/web/tools.
+See docs/WORKFLOW_SPEC.md.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from system.log import get_logger
+from system.userspace import user_state_dir
+
+log = get_logger(__name__)
+
+CACHE_ROOT_ENV = "AIKO_TOOL_RESULT_CACHE_ROOT"
+DEFAULT_RETENTION_RUNS = int(os.getenv("AIKO_CACHE_RETENTION_RUNS", "14"))
+MAX_BODY_CHARS = int(os.getenv("AIKO_CACHE_MAX_BODY_CHARS", "20000"))
+SELECT_DEFAULT_LIMIT = int(os.getenv("AIKO_CACHE_SELECT_LIMIT", "12"))
+SELECT_TITLE_CHARS = int(os.getenv("AIKO_CACHE_SELECT_TITLE_CHARS", "120"))
+SELECT_BODY_CHARS = int(os.getenv("AIKO_CACHE_SELECT_BODY_CHARS", "400"))
+
+_SOURCE_RE = re.compile(r"^[a-z0-9_]{1,32}$")
+_WORKFLOW_RE = re.compile(r"^[a-z0-9_][a-z0-9_\-]{0,63}$")
+
+
+def _utc_run_id() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H%M%SZ")
+
+
+def _cache_root() -> Path:
+    override = os.getenv(CACHE_ROOT_ENV)
+    if override:
+        return Path(override).expanduser().resolve()
+    return user_state_dir() / "agentic" / "cache"
+
+
+def _validate_workflow(workflow: str) -> str:
+    w = (workflow or "").strip().lower().replace(" ", "_")
+    if not _WORKFLOW_RE.match(w):
+        raise ValueError(f"invalid workflow id: {workflow!r}")
+    return w
+
+
+def _validate_source(source: str) -> str:
+    s = (source or "tool").strip().lower()
+    if not _SOURCE_RE.match(s):
+        raise ValueError(f"invalid source: {source!r}")
+    return s
+
+
+def workflow_dir(workflow: str) -> Path:
+    d = _cache_root() / _validate_workflow(workflow)
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def _truncate(text: str, n: int) -> str:
+    t = text or ""
+    if len(t) <= n:
+        return t
+    return t[: max(0, n - 15)] + "\n\u2026[truncated]"
+
+
+def normalize_record(
+    item: Any,
+    *,
+    workflow: str,
+    source: str,
+    run_id: str,
+    fetched_at: str | None = None,
+) -> dict[str, Any]:
+    now = fetched_at or datetime.now(timezone.utc).isoformat()
+    if isinstance(item, str):
+        return {
+            "id": str(uuid.uuid4()),
+            "workflow": workflow,
+            "source": source,
+            "run_id": run_id,
+            "fetched_at": now,
+            "title": _truncate(item.split("\n", 1)[0], SELECT_TITLE_CHARS),
+            "body": _truncate(item, MAX_BODY_CHARS),
+            "url": "",
+            "score": 0.0,
+            "matched": True,
+            "meta": {},
+        }
+    if not isinstance(item, dict):
+        item = {"body": str(item)}
+
+    title = str(item.get("title") or item.get("subject") or item.get("name") or "")
+    body = str(
+        item.get("body")
+        or item.get("content")
+        or item.get("summary")
+        or item.get("description")
+        or item.get("text")
+        or ""
+    )
+    url = str(item.get("url") or item.get("link") or item.get("href") or "")
+    score = item.get("score")
+    try:
+        score_f = float(score) if score is not None else 0.0
+    except (TypeError, ValueError):
+        score_f = 0.0
+    matched = item.get("matched")
+    if matched is None:
+        matched = True
+    meta = item.get("meta") if isinstance(item.get("meta"), dict) else {}
+    for k in ("from", "source_feed", "published", "company", "location", "keywords"):
+        if k in item and k not in meta:
+            meta[k] = item[k]
+
+    return {
+        "id": str(item.get("id") or uuid.uuid4()),
+        "workflow": workflow,
+        "source": source,
+        "run_id": run_id,
+        "fetched_at": str(item.get("fetched_at") or now),
+        "title": _truncate(title, 500),
+        "body": _truncate(body, MAX_BODY_CHARS),
+        "url": url[:2000],
+        "score": score_f,
+        "matched": bool(matched),
+        "meta": meta,
+    }
+
+
+def cache_write(
+    items: Iterable[Any] | Any,
+    *,
+    workflow: str,
+    source: str = "tool",
+    run_id: str | None = None,
+    state: Any = None,
+    from_state: str | None = None,
+) -> dict[str, Any]:
+    workflow = _validate_workflow(workflow)
+    source = _validate_source(source)
+    run_id = run_id or _utc_run_id()
+
+    if from_state and state is not None:
+        raw = state.get(from_state) if hasattr(state, "get") else None
+        if raw is None and isinstance(getattr(state, "data", None), dict):
+            raw = state.data.get(from_state)
+        items = raw if raw is not None else items
+
+    if items is None:
+        items = []
+    if isinstance(items, dict):
+        if all(isinstance(v, (dict, str)) for v in items.values()):
+            seq = list(items.values())
+        else:
+            seq = [items]
+    elif isinstance(items, (str, bytes)):
+        seq = [items]
+    else:
+        try:
+            seq = list(items)
+        except TypeError:
+            seq = [items]
+
+    records = [
+        normalize_record(it, workflow=workflow, source=source, run_id=run_id)
+        for it in seq
+    ]
+    path = workflow_dir(workflow) / f"{run_id}_{source}.jsonl"
+    with path.open("a", encoding="utf-8") as f:
+        for rec in records:
+            f.write(json.dumps(rec, ensure_ascii=False) + "\n")
+
+    index_path = workflow_dir(workflow) / "index.jsonl"
+    with index_path.open("a", encoding="utf-8") as f:
+        f.write(
+            json.dumps(
+                {
+                    "run_id": run_id,
+                    "source": source,
+                    "path": str(path),
+                    "count": len(records),
+                    "written_at": datetime.now(timezone.utc).isoformat(),
+                },
+                ensure_ascii=False,
+            )
+            + "\n"
+        )
+
+    log.info(
+        "cache_write workflow=%s source=%s run_id=%s n=%d path=%s",
+        workflow, source, run_id, len(records), path,
+    )
+    out = {
+        "ok": True,
+        "workflow": workflow,
+        "source": source,
+        "run_id": run_id,
+        "path": str(path),
+        "count": len(records),
+        "ids": [r["id"] for r in records[:50]],
+    }
+    if state is not None and hasattr(state, "set"):
+        state.set(f"cache_{source}_path", str(path))
+        state.set(f"cache_{source}_run_id", run_id)
+        state.set("cache_last_run_id", run_id)
+    return out
+
+
+def _iter_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.is_file():
+        return rows
+    with path.open(encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if isinstance(obj, dict):
+                rows.append(obj)
+    return rows
+
+
+def cache_read(
+    *,
+    workflow: str,
+    source: str | None = None,
+    run_id: str | None = None,
+    limit: int = 500,
+) -> dict[str, Any]:
+    workflow = _validate_workflow(workflow)
+    d = workflow_dir(workflow)
+    files = sorted(d.glob("*.jsonl"))
+    files = [p for p in files if p.name != "index.jsonl"]
+    if run_id:
+        files = [p for p in files if p.name.startswith(run_id)]
+    if source:
+        source = _validate_source(source)
+        files = [p for p in files if p.stem.endswith(f"_{source}")]
+
+    records: list[dict[str, Any]] = []
+    for p in files:
+        records.extend(_iter_jsonl(p))
+        if len(records) >= limit:
+            records = records[:limit]
+            break
+    return {
+        "ok": True,
+        "workflow": workflow,
+        "source": source,
+        "run_id": run_id,
+        "count": len(records),
+        "records": records,
+    }
+
+
+def cache_select(
+    *,
+    workflow: str,
+    source: str | None = None,
+    run_id: str | None = None,
+    keywords: list[str] | str | None = None,
+    matched_only: bool = True,
+    limit: int = SELECT_DEFAULT_LIMIT,
+    state: Any = None,
+    to_state: str = "selection",
+) -> dict[str, Any]:
+    workflow = _validate_workflow(workflow)
+    if run_id is None and state is not None and hasattr(state, "get"):
+        run_id = state.get("cache_last_run_id") or state.get("run_id")
+
+    raw = cache_read(workflow=workflow, source=source, run_id=run_id, limit=2000)
+    records = list(raw.get("records") or [])
+
+    if matched_only:
+        records = [r for r in records if r.get("matched", True)]
+
+    kw: list[str] = []
+    if isinstance(keywords, str):
+        kw = [k.strip().lower() for k in keywords.split(",") if k.strip()]
+    elif keywords:
+        kw = [str(k).strip().lower() for k in keywords if str(k).strip()]
+
+    def rank(r: dict[str, Any]) -> tuple:
+        text = f"{r.get('title', '')} {r.get('body', '')}".lower()
+        hits = sum(1 for k in kw if k in text) if kw else 0
+        return (hits, float(r.get("score") or 0.0), r.get("fetched_at") or "")
+
+    records.sort(key=rank, reverse=True)
+    selected = records[: max(1, int(limit))]
+
+    compact = []
+    for r in selected:
+        compact.append(
+            {
+                "id": r.get("id"),
+                "source": r.get("source"),
+                "title": _truncate(str(r.get("title") or ""), SELECT_TITLE_CHARS),
+                "body": _truncate(str(r.get("body") or ""), SELECT_BODY_CHARS),
+                "url": r.get("url") or "",
+                "score": r.get("score"),
+                "meta": {
+                    k: r.get("meta", {}).get(k)
+                    for k in ("company", "location", "from", "source_feed")
+                    if isinstance(r.get("meta"), dict) and r.get("meta", {}).get(k)
+                },
+            }
+        )
+
+    approx_chars = sum(len(x.get("title", "")) + len(x.get("body", "")) for x in compact)
+
+    if state is not None and hasattr(state, "set"):
+        state.set(to_state, compact)
+        state.set(f"{to_state}_count", len(compact))
+        state.set(f"{to_state}_chars", approx_chars)
+
+    log.info(
+        "cache_select workflow=%s source=%s run_id=%s n=%d chars\u2248%d",
+        workflow, source, run_id, len(compact), approx_chars,
+    )
+    return {
+        "ok": True,
+        "workflow": workflow,
+        "source": source,
+        "run_id": run_id,
+        "count": len(compact),
+        "approx_chars": approx_chars,
+        "selection": compact,
+        "to_state": to_state,
+    }
+
+
+def cache_gc(
+    *,
+    workflow: str,
+    keep_runs: int = DEFAULT_RETENTION_RUNS,
+) -> dict[str, Any]:
+    workflow = _validate_workflow(workflow)
+    d = workflow_dir(workflow)
+    files = [p for p in d.glob("*.jsonl") if p.name != "index.jsonl"]
+    by_run: dict[str, list[Path]] = {}
+    for p in files:
+        stem = p.stem
+        if "_" not in stem:
+            continue
+        run_id, _src = stem.rsplit("_", 1)
+        by_run.setdefault(run_id, []).append(p)
+
+    run_ids = sorted(by_run.keys(), reverse=True)
+    drop = run_ids[max(0, int(keep_runs)) :]
+    removed = 0
+    for rid in drop:
+        for p in by_run[rid]:
+            try:
+                p.unlink(missing_ok=True)
+                removed += 1
+            except OSError as e:
+                log.warning("cache_gc unlink %s: %s", p, e)
+    return {
+        "ok": True,
+        "workflow": workflow,
+        "kept_runs": run_ids[:keep_runs],
+        "dropped_runs": drop,
+        "files_removed": removed,
+    }
+
+
+__all__ = [
+    "cache_write",
+    "cache_read",
+    "cache_select",
+    "cache_gc",
+    "normalize_record",
+    "workflow_dir",
+    "SELECT_DEFAULT_LIMIT",
+    "DEFAULT_RETENTION_RUNS",
+]

--- a/agentic/toolkit/tool_result_cache.py
+++ b/agentic/toolkit/tool_result_cache.py
@@ -369,32 +369,27 @@ def cache_gc(
     workflow: str,
     keep_runs: int = DEFAULT_RETENTION_RUNS,
 ) -> dict[str, Any]:
+    try:
+        keep_runs = int(keep_runs)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("keep_runs must be an integer") from exc
+    if keep_runs < 0:
+        raise ValueError("keep_runs must be non-negative")
+
     workflow = _validate_workflow(workflow)
     d = workflow_dir(workflow)
     files = [p for p in d.glob("*.jsonl") if p.name != "index.jsonl"]
-
-    # Validate and convert keep_runs to int, reject negative values
-    try:
-        keep_runs_int = int(keep_runs)
-        if keep_runs_int < 0:
-            keep_runs_int = 0
-    except (TypeError, ValueError):
-        keep_runs_int = DEFAULT_RETENTION_RUNS
 
     by_run: dict[str, list[Path]] = {}
     for p in files:
         stem = p.stem
         if "_" not in stem:
             continue
-        # Fix: use split to get run_id from the start, not rsplit from the end
-        # Filename format is: {run_id}_{source}.jsonl
-        # e.g., "2024-01-15T120000Z_job_feed.jsonl"
-        # We need to split on the LAST underscore before the source part
         run_id, _src = stem.rsplit("_", 1)
         by_run.setdefault(run_id, []).append(p)
 
     run_ids = sorted(by_run.keys(), reverse=True)
-    drop = run_ids[keep_runs_int:]
+    drop = run_ids[keep_runs:]
     removed = 0
     for rid in drop:
         for p in by_run[rid]:
@@ -406,7 +401,7 @@ def cache_gc(
     return {
         "ok": True,
         "workflow": workflow,
-        "kept_runs": run_ids[:keep_runs_int],
+        "kept_runs": run_ids[:keep_runs],
         "dropped_runs": drop,
         "files_removed": removed,
     }

--- a/agentic/toolkit/tool_result_cache.py
+++ b/agentic/toolkit/tool_result_cache.py
@@ -132,6 +132,18 @@ def normalize_record(
     }
 
 
+def _validate_run_id(run_id: str) -> str:
+    """Validate run_id to prevent path traversal attacks."""
+    rid = (run_id or "").strip()
+    if not rid:
+        raise ValueError("run_id cannot be empty")
+    if "/" in rid or "\\" in rid or rid.startswith("."):
+        raise ValueError(f"run_id contains invalid path separators: {run_id!r}")
+    if rid != os.path.basename(rid):
+        raise ValueError(f"run_id resolves outside intended directory: {run_id!r}")
+    return rid
+
+
 def cache_write(
     items: Iterable[Any] | Any,
     *,
@@ -143,7 +155,7 @@ def cache_write(
 ) -> dict[str, Any]:
     workflow = _validate_workflow(workflow)
     source = _validate_source(source)
-    run_id = run_id or _utc_run_id()
+    run_id = _validate_run_id(run_id or _utc_run_id())
 
     if from_state and state is not None:
         raw = state.get(from_state) if hasattr(state, "get") else None
@@ -154,7 +166,17 @@ def cache_write(
     if items is None:
         items = []
     if isinstance(items, dict):
-        if all(isinstance(v, (dict, str)) for v in items.values()):
+        # Detect if this looks like a single record dict vs a mapping of multiple records
+        # Single record indicators: has common single-record field names
+        single_record_fields = {"subject", "body", "title", "content", "from", "to",
+                               "text", "description", "url", "link", "id", "name"}
+        has_single_record_field = any(k in single_record_fields for k in items.keys())
+
+        # If it looks like a single record, treat it as one record
+        if has_single_record_field:
+            seq = [items]
+        # Otherwise, check if all values are dicts or strings (mapping of records)
+        elif all(isinstance(v, (dict, str)) for v in items.values()):
             seq = list(items.values())
         else:
             seq = [items]
@@ -237,6 +259,8 @@ def cache_read(
     limit: int = 500,
 ) -> dict[str, Any]:
     workflow = _validate_workflow(workflow)
+    if run_id:
+        run_id = _validate_run_id(run_id)
     d = workflow_dir(workflow)
     files = sorted(d.glob("*.jsonl"))
     files = [p for p in files if p.name != "index.jsonl"]
@@ -276,6 +300,8 @@ def cache_select(
     workflow = _validate_workflow(workflow)
     if run_id is None and state is not None and hasattr(state, "get"):
         run_id = state.get("cache_last_run_id") or state.get("run_id")
+    if run_id:
+        run_id = _validate_run_id(run_id)
 
     raw = cache_read(workflow=workflow, source=source, run_id=run_id, limit=2000)
     records = list(raw.get("records") or [])
@@ -346,16 +372,29 @@ def cache_gc(
     workflow = _validate_workflow(workflow)
     d = workflow_dir(workflow)
     files = [p for p in d.glob("*.jsonl") if p.name != "index.jsonl"]
+
+    # Validate and convert keep_runs to int, reject negative values
+    try:
+        keep_runs_int = int(keep_runs)
+        if keep_runs_int < 0:
+            keep_runs_int = 0
+    except (TypeError, ValueError):
+        keep_runs_int = DEFAULT_RETENTION_RUNS
+
     by_run: dict[str, list[Path]] = {}
     for p in files:
         stem = p.stem
         if "_" not in stem:
             continue
+        # Fix: use split to get run_id from the start, not rsplit from the end
+        # Filename format is: {run_id}_{source}.jsonl
+        # e.g., "2024-01-15T120000Z_job_feed.jsonl"
+        # We need to split on the LAST underscore before the source part
         run_id, _src = stem.rsplit("_", 1)
         by_run.setdefault(run_id, []).append(p)
 
     run_ids = sorted(by_run.keys(), reverse=True)
-    drop = run_ids[max(0, int(keep_runs)) :]
+    drop = run_ids[keep_runs_int:]
     removed = 0
     for rid in drop:
         for p in by_run[rid]:
@@ -367,7 +406,7 @@ def cache_gc(
     return {
         "ok": True,
         "workflow": workflow,
-        "kept_runs": run_ids[:keep_runs],
+        "kept_runs": run_ids[:keep_runs_int],
         "dropped_runs": drop,
         "files_removed": removed,
     }

--- a/agentic/toolkit/tool_result_cache_tools.py
+++ b/agentic/toolkit/tool_result_cache_tools.py
@@ -1,0 +1,130 @@
+"""Graph-registered wrappers for unified tool-result cache."""
+from __future__ import annotations
+
+from agentic.registry import tool
+from agentic.toolkit.tool_result_cache import (
+    SELECT_DEFAULT_LIMIT,
+    DEFAULT_RETENTION_RUNS,
+    cache_write,
+    cache_select,
+    cache_read,
+    cache_gc,
+)
+
+
+@tool(
+    "cache_write",
+    description=(
+        "Append tool results to the unified on-disk JSONL tool-result cache. "
+        "Use after fetch/search so full payloads stay out of the LLM context. "
+        "Pass items directly or from_state to read a GraphState key."
+    ),
+    props={
+        "items": {"type": "array", "description": "List of result objects or strings"},
+        "workflow": {"type": "string", "description": "Workflow id, e.g. lane_d_job_hunt"},
+        "source": {"type": "string", "description": "rss|email|web|tool"},
+        "run_id": {"type": "string"},
+        "from_state": {"type": "string", "description": "GraphState key holding items"},
+    },
+    required=["workflow"],
+    domain="cache",
+    react=False,
+    graph=True,
+)
+def cache_write_tool(
+    workflow: str,
+    items: list | dict | str | None = None,
+    source: str = "tool",
+    run_id: str | None = None,
+    from_state: str | None = None,
+    state=None,
+) -> dict:
+    return cache_write(
+        items if items is not None else [],
+        workflow=workflow,
+        source=source,
+        run_id=run_id,
+        state=state,
+        from_state=from_state,
+    )
+
+
+@tool(
+    "cache_select",
+    description=(
+        "Select a compact ranked subset from the tool-result cache for LLM synthesis. "
+        "Only this slice should enter context — not the full JSONL."
+    ),
+    props={
+        "workflow": {"type": "string"},
+        "source": {"type": "string"},
+        "run_id": {"type": "string"},
+        "keywords": {"type": "array", "items": {"type": "string"}},
+        "matched_only": {"type": "boolean"},
+        "limit": {"type": "integer"},
+        "to_state": {"type": "string"},
+    },
+    required=["workflow"],
+    domain="cache",
+    react=False,
+    graph=True,
+)
+def cache_select_tool(
+    workflow: str,
+    source: str | None = None,
+    run_id: str | None = None,
+    keywords: list | str | None = None,
+    matched_only: bool = True,
+    limit: int = SELECT_DEFAULT_LIMIT,
+    to_state: str = "selection",
+    state=None,
+) -> dict:
+    return cache_select(
+        workflow=workflow,
+        source=source,
+        run_id=run_id,
+        keywords=keywords,
+        matched_only=matched_only,
+        limit=limit,
+        state=state,
+        to_state=to_state,
+    )
+
+
+@tool(
+    "cache_read",
+    description="Read records from the tool-result cache (debug / drill-down).",
+    props={
+        "workflow": {"type": "string"},
+        "source": {"type": "string"},
+        "run_id": {"type": "string"},
+        "limit": {"type": "integer"},
+    },
+    required=["workflow"],
+    domain="cache",
+    react=False,
+    graph=True,
+)
+def cache_read_tool(
+    workflow: str,
+    source: str | None = None,
+    run_id: str | None = None,
+    limit: int = 500,
+) -> dict:
+    return cache_read(workflow=workflow, source=source, run_id=run_id, limit=limit)
+
+
+@tool(
+    "cache_gc",
+    description="Drop old tool-result cache runs for a workflow (retention).",
+    props={
+        "workflow": {"type": "string"},
+        "keep_runs": {"type": "integer"},
+    },
+    required=["workflow"],
+    domain="cache",
+    react=False,
+    graph=True,
+)
+def cache_gc_tool(workflow: str, keep_runs: int = DEFAULT_RETENTION_RUNS) -> dict:
+    return cache_gc(workflow=workflow, keep_runs=keep_runs)

--- a/agentic/toolkit/tool_result_cache_tools.py
+++ b/agentic/toolkit/tool_result_cache_tools.py
@@ -15,20 +15,24 @@ from agentic.toolkit.tool_result_cache import (
     cache_gc,
 )
 
-# Match the graph node result limit to prevent exceeding substitution size
-GRAPH_NODE_RESULT_MAX_CHARS = int(os.getenv("GRAPH_NODE_RESULT_MAX_CHARS", "20000"))
+# Must stay <= graph_engine._substitute $result: slice (currently 4000).
+# Prefer a shared env so both sides can be raised together later.
+GRAPH_RESULT_SUBSTITUTE_MAX_CHARS = int(
+    os.getenv("GRAPH_RESULT_SUBSTITUTE_MAX_CHARS", "4000")
+)
 
 
 def _selection_to_evidence(selection: list[dict[str, Any]]) -> str:
     """Format compact selection as plain text for synthesize_report evidence.
 
     Tracks cumulative character budget and only includes whole records that fit
-    within GRAPH_NODE_RESULT_MAX_CHARS to prevent exceeding graph substitution limit.
-    Preserves record boundaries and ranking order.
+    within GRAPH_RESULT_SUBSTITUTE_MAX_CHARS so graph_engine._substitute does not
+    silently truncate mid-set. Preserves record boundaries and ranking order.
     """
     blocks: list[str] = []
     total_chars = 0
     separator_chars = 2  # "\n\n" between blocks
+    budget = max(1, GRAPH_RESULT_SUBSTITUTE_MAX_CHARS)
 
     for i, r in enumerate(selection or [], 1):
         title = (r.get("title") or "").strip()
@@ -41,15 +45,10 @@ def _selection_to_evidence(selection: list[dict[str, Any]]) -> str:
         if url:
             parts.append(url)
 
-        # Build the complete record block
         block = "\n".join(parts)
         block_chars = len(block)
-
-        # Check if adding this whole record would exceed the budget
-        # (account for separator unless this is the first block)
         needed_chars = block_chars + (separator_chars if blocks else 0)
-        if total_chars + needed_chars > GRAPH_NODE_RESULT_MAX_CHARS:
-            # Stop here - don't include partial records
+        if total_chars + needed_chars > budget:
             break
 
         blocks.append(block)
@@ -127,8 +126,6 @@ def cache_select_tool(
     to_state: str = "selection",
     state=None,
 ) -> str:
-    import os
-
     # Resolve keywords from environment variable if keywords_env is provided
     resolved_keywords = keywords
     if keywords_env:

--- a/agentic/toolkit/tool_result_cache_tools.py
+++ b/agentic/toolkit/tool_result_cache_tools.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import Any
 
 from agentic.registry import tool
@@ -14,10 +15,21 @@ from agentic.toolkit.tool_result_cache import (
     cache_gc,
 )
 
+# Match the graph node result limit to prevent exceeding substitution size
+GRAPH_NODE_RESULT_MAX_CHARS = int(os.getenv("GRAPH_NODE_RESULT_MAX_CHARS", "20000"))
+
 
 def _selection_to_evidence(selection: list[dict[str, Any]]) -> str:
-    """Format compact selection as plain text for synthesize_report evidence."""
+    """Format compact selection as plain text for synthesize_report evidence.
+
+    Tracks cumulative character budget and only includes whole records that fit
+    within GRAPH_NODE_RESULT_MAX_CHARS to prevent exceeding graph substitution limit.
+    Preserves record boundaries and ranking order.
+    """
     blocks: list[str] = []
+    total_chars = 0
+    separator_chars = 2  # "\n\n" between blocks
+
     for i, r in enumerate(selection or [], 1):
         title = (r.get("title") or "").strip()
         body = (r.get("body") or "").strip()
@@ -28,7 +40,21 @@ def _selection_to_evidence(selection: list[dict[str, Any]]) -> str:
             parts.append(body)
         if url:
             parts.append(url)
-        blocks.append("\n".join(parts))
+
+        # Build the complete record block
+        block = "\n".join(parts)
+        block_chars = len(block)
+
+        # Check if adding this whole record would exceed the budget
+        # (account for separator unless this is the first block)
+        needed_chars = block_chars + (separator_chars if blocks else 0)
+        if total_chars + needed_chars > GRAPH_NODE_RESULT_MAX_CHARS:
+            # Stop here - don't include partial records
+            break
+
+        blocks.append(block)
+        total_chars += needed_chars
+
     return "\n\n".join(blocks)
 
 

--- a/agentic/toolkit/tool_result_cache_tools.py
+++ b/agentic/toolkit/tool_result_cache_tools.py
@@ -1,6 +1,9 @@
 """Graph-registered wrappers for unified tool-result cache."""
 from __future__ import annotations
 
+import json
+from typing import Any
+
 from agentic.registry import tool
 from agentic.toolkit.tool_result_cache import (
     SELECT_DEFAULT_LIMIT,
@@ -12,17 +15,34 @@ from agentic.toolkit.tool_result_cache import (
 )
 
 
+def _selection_to_evidence(selection: list[dict[str, Any]]) -> str:
+    """Format compact selection as plain text for synthesize_report evidence."""
+    blocks: list[str] = []
+    for i, r in enumerate(selection or [], 1):
+        title = (r.get("title") or "").strip()
+        body = (r.get("body") or "").strip()
+        url = (r.get("url") or "").strip()
+        head = f"{i}. {title}" if title else f"{i}."
+        parts = [head]
+        if body:
+            parts.append(body)
+        if url:
+            parts.append(url)
+        blocks.append("\n".join(parts))
+    return "\n\n".join(blocks)
+
+
 @tool(
     "cache_write",
     description=(
         "Append tool results to the unified on-disk JSONL tool-result cache. "
         "Use after fetch/search so full payloads stay out of the LLM context. "
-        "Pass items directly or from_state to read a GraphState key."
+        "Pass items (string or list) or from_state to read a GraphState key."
     ),
     props={
-        "items": {"type": "array", "description": "List of result objects or strings"},
-        "workflow": {"type": "string", "description": "Workflow id, e.g. lane_d_job_hunt"},
-        "source": {"type": "string", "description": "rss|email|web|tool"},
+        "items": {"description": "Result object(s) or text from prior node ($result:...)"},
+        "workflow": {"type": "string", "description": "Workflow id, e.g. research_and_report"},
+        "source": {"type": "string", "description": "rss|email|web|kb|tool"},
         "run_id": {"type": "string"},
         "from_state": {"type": "string", "description": "GraphState key holding items"},
     },
@@ -53,7 +73,7 @@ def cache_write_tool(
     "cache_select",
     description=(
         "Select a compact ranked subset from the tool-result cache for LLM synthesis. "
-        "Only this slice should enter context — not the full JSONL."
+        "Returns plain-text evidence (not full JSONL) for synthesize_report."
     ),
     props={
         "workflow": {"type": "string"},
@@ -78,8 +98,8 @@ def cache_select_tool(
     limit: int = SELECT_DEFAULT_LIMIT,
     to_state: str = "selection",
     state=None,
-) -> dict:
-    return cache_select(
+) -> str:
+    out = cache_select(
         workflow=workflow,
         source=source,
         run_id=run_id,
@@ -89,6 +109,7 @@ def cache_select_tool(
         state=state,
         to_state=to_state,
     )
+    return _selection_to_evidence(list(out.get("selection") or []))
 
 
 @tool(
@@ -110,8 +131,9 @@ def cache_read_tool(
     source: str | None = None,
     run_id: str | None = None,
     limit: int = 500,
-) -> dict:
-    return cache_read(workflow=workflow, source=source, run_id=run_id, limit=limit)
+) -> str:
+    out = cache_read(workflow=workflow, source=source, run_id=run_id, limit=limit)
+    return json.dumps({"count": out.get("count"), "records": out.get("records")}, ensure_ascii=False)
 
 
 @tool(
@@ -126,5 +148,6 @@ def cache_read_tool(
     react=False,
     graph=True,
 )
-def cache_gc_tool(workflow: str, keep_runs: int = DEFAULT_RETENTION_RUNS) -> dict:
-    return cache_gc(workflow=workflow, keep_runs=keep_runs)
+def cache_gc_tool(workflow: str, keep_runs: int = DEFAULT_RETENTION_RUNS) -> str:
+    out = cache_gc(workflow=workflow, keep_runs=keep_runs)
+    return json.dumps(out, ensure_ascii=False)

--- a/agentic/toolkit/tool_result_cache_tools.py
+++ b/agentic/toolkit/tool_result_cache_tools.py
@@ -80,6 +80,7 @@ def cache_write_tool(
         "source": {"type": "string"},
         "run_id": {"type": "string"},
         "keywords": {"type": "array", "items": {"type": "string"}},
+        "keywords_env": {"type": "string", "description": "Environment variable name containing comma-separated keywords"},
         "matched_only": {"type": "boolean"},
         "limit": {"type": "integer"},
         "to_state": {"type": "string"},
@@ -94,16 +95,26 @@ def cache_select_tool(
     source: str | None = None,
     run_id: str | None = None,
     keywords: list | str | None = None,
+    keywords_env: str | None = None,
     matched_only: bool = True,
     limit: int = SELECT_DEFAULT_LIMIT,
     to_state: str = "selection",
     state=None,
 ) -> str:
+    import os
+
+    # Resolve keywords from environment variable if keywords_env is provided
+    resolved_keywords = keywords
+    if keywords_env:
+        env_value = os.getenv(keywords_env, "").strip()
+        if env_value:
+            resolved_keywords = env_value
+
     out = cache_select(
         workflow=workflow,
         source=source,
         run_id=run_id,
-        keywords=keywords,
+        keywords=resolved_keywords,
         matched_only=matched_only,
         limit=limit,
         state=state,

--- a/agentic/tools.py
+++ b/agentic/tools.py
@@ -30,6 +30,7 @@ from agentic.toolkit import photography  # noqa: F401
 from agentic.toolkit import self_improve  # noqa: F401
 from agentic.toolkit import reports  # noqa: F401
 from agentic.toolkit import research  # noqa: F401
+from agentic.toolkit import tool_result_cache  # noqa: F401  # unified DAG tool-result cache
 from agentic.workflows.job_hunt import toolset  # noqa: F401
 from agentic.toolkit import social  # noqa: F401
 

--- a/agentic/tools.py
+++ b/agentic/tools.py
@@ -30,7 +30,8 @@ from agentic.toolkit import photography  # noqa: F401
 from agentic.toolkit import self_improve  # noqa: F401
 from agentic.toolkit import reports  # noqa: F401
 from agentic.toolkit import research  # noqa: F401
-from agentic.toolkit import tool_result_cache  # noqa: F401  # unified DAG tool-result cache
+from agentic.toolkit import tool_result_cache  # noqa: F401
+from agentic.toolkit import tool_result_cache_tools  # noqa: F401  # registers cache_* graph tools
 from agentic.workflows.job_hunt import toolset  # noqa: F401
 from agentic.toolkit import social  # noqa: F401
 

--- a/docs/WORKFLOW_SPEC.md
+++ b/docs/WORKFLOW_SPEC.md
@@ -1,0 +1,93 @@
+# Aiko Workflow Spec (DAG + tool-result cache)
+
+**Goal:** Every agentic DAG workflow is a declarative **spec** (JSON playbook).  
+**Caching is a first-class step**, not an ad-hoc script side effect.
+
+## Principles
+
+1. **Tool outputs → cache by default** (full/near-full results on disk).
+2. **Only a selected slice enters LLM context** for synthesis.
+3. **Same record format** across email, RSS, web, fetch, etc.
+4. **Same pipeline** for all workflows; separate *files* per run/source OK.
+5. **Do not** dump bulk tool results into normal chat memory / persona cache.
+6. Promote only **durable outcomes** (0–N facts) into L1 memory after synthesis.
+
+## Pipeline (every DAG)
+
+```text
+fetch / tool
+  → cache_write          # append JSONL records
+  → cache_select         # rank/filter → small working set
+  → synthesize / draft   # LLM sees only the selection
+  → write_report / post
+  → optional memory_add  # durable facts only
+```
+
+## Spec shape (playbook node)
+
+Compatible with existing `PlanNode` fields in `graph_engine.py`:
+
+```json
+{
+  "id": "cache_rss",
+  "tool": "cache_write",
+  "args": {
+    "workflow": "lane_d_job_hunt",
+    "source": "rss",
+    "from_state": "rss_raw",
+    "run_id": "${run_id}"
+  },
+  "depends_on": ["fetch_rss"]
+}
+```
+
+### Standard cache tools
+
+| Tool | Role |
+|------|------|
+| `cache_write` | Normalize + append tool results to JSONL under workflow cache dir |
+| `cache_select` | Load cache → filter/rank → put compact list on graph state |
+| `cache_read` | Read records by run_id / source (debug, drill-down) |
+| `cache_gc` | Drop old runs (retention policy) |
+
+## Directory layout
+
+```text
+~/.aiko/<user_id>/agentic/cache/
+  <workflow_id>/
+    2026-08-17T230000Z_rss.jsonl
+    2026-08-17T230000Z_email.jsonl
+    index.jsonl          # optional: one line per file written
+```
+
+## Record schema (one JSON object per line)
+
+```json
+{
+  "id": "uuid",
+  "workflow": "lane_d_job_hunt",
+  "source": "rss|email|web|tool",
+  "run_id": "2026-08-17T230000Z",
+  "fetched_at": "ISO-8601",
+  "title": "...",
+  "body": "...",
+  "url": "",
+  "score": 0.0,
+  "matched": true,
+  "meta": {}
+}
+```
+
+## What stays out of this cache
+
+- Persona / `kind=identity` (L3 chat fast path)
+- In-process `TTLCache` for search/fetch dedup within a single process
+- Long-term `memories` table (only after explicit promote)
+
+## Migration
+
+| Today | Spec |
+|-------|------|
+| Lane D `fetch_*_email_*.jsonl` + `fetch_*_rss_*.jsonl` ad hoc | Same files optional; **same schema** + `cache_write` / `cache_select` nodes |
+| Research DAG dumps big text into node results | `cache_write` then `cache_select` / condense before synthesize |
+| Skill markdown only | Keep skills for human docs; **execution** is playbook JSON with cache steps |


### PR DESCRIPTION
## Summary

Adds a **unified on-disk tool-result cache** and migrates **research-heavy DAG playbooks** to cache-first specs so full tool outputs stay out of the limited LLM context.

Pipeline: `fetch → cache_write → cache_select → synthesize → report`

## Changes

| File | Role |
|------|------|
| `agentic/toolkit/tool_result_cache.py` | Core JSONL cache API |
| `agentic/toolkit/tool_result_cache_tools.py` | Graph tools (`cache_select` returns evidence text) |
| `agentic/tools.py` | Register cache tools on boot |
| `docs/WORKFLOW_SPEC.md` | Spec + migration notes |
| `agentic/playbook.json` | **Migrated** playbook node graphs |
| `agentic/playbooks/lane_d_job_hunt.json` | Lane D example |

## Migrated to cache-first (via `agentic/playbook.json` merge)

- `research_and_report`
- `search_kb_and_report`
- `compare_and_report`
- `parallel_fanout_fanin`
- `orchestrator_workers`
- `planning_and_execution`
- `multi_agent_collab`
- `lane_d_job_hunt` (example path)

## Left on code defaults (no bulk tool dump)

- `checklist_and_save` / `simple_save_note` — no heavy fetch
- `evaluator_optimizer` / `prompt_chaining` / `routing_classifier` — mostly LLM refine, not raw tool dumps
- `gen_job_post` — still `graph_id` + `job_hunt` toolset (live RSS/email); wire to `cache_*` as a follow-up

## Note on playbook loading

`load_playbooks()` merges `agentic/playbook.json` **over** code defaults by `id`. Shipping this file activates the cache-first nodes for the IDs above without rewriting `_default_playbooks()` in `graph_engine.py`.

If a machine already has a seeded user `playbook.json`, restart/reseed or merge manually so these node lists apply.

## Test plan

- [ ] `from agentic.tools import registry` — `cache_write` / `cache_select` registered
- [ ] `load_playbooks()` — `research_and_report` nodes include `cache_web` / `select`
- [ ] Smoke one research graph run; confirm JSONL under `~/.aiko/<user>/agentic/cache/`
- [ ] Confirm synthesize only sees `cache_select` text, not full `deep_research` dump in the draft node args


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added eight configurable research, collaboration, reporting, and job-hunting workflows.
  * Added persistent caching, ranked result selection, configurable retention, and cleanup.
  * Added optional RSS and email job-alert collection with retries and timeouts.
  * Added environment-controlled workflow conditions and optional Threads teaser reports.

* **Documentation**
  * Added workflow specifications covering execution, caching, reporting, and data handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->