### PR TITLE
feat: should_attempt gate before agentic loop

### DIFF
--- a/cognition/memory/attempt_gate.py
+++ b/cognition/memory/attempt_gate.py
@@ -1,0 +1,92 @@
+"""Bounded self-assessment gate for agentic execution.
+
+Used by EdgeCognitiveState.should_attempt and AikoThink.agentic_chat.
+Keeps thresholds conservative: critical work always proceeds.
+"""
+from __future__ import annotations
+
+import re
+
+_CRITICAL_TASK_RE = re.compile(
+    r"\b("
+    r"urgent|emergency|asap|right now|immediately|"
+    r"safety|danger|hurt|injured|crisis|"
+    r"deadline today|due today|production (?:is )?down|outage|"
+    r"approve run-|cancel (?:the )?(?:job|schedule|reminder)"
+    r")\b",
+    re.I,
+)
+_WORD_RE = re.compile(r"[a-z0-9_]{3,}")
+
+
+def _tokens(text: str) -> set[str]:
+    return set(_WORD_RE.findall((text or "").lower()))
+
+
+def is_critical_task(user_input: str) -> bool:
+    return bool(_CRITICAL_TASK_RE.search(user_input or ""))
+
+
+def capability_from_outcomes(outcomes: list[dict], domain: str = "") -> dict:
+    domain = (domain or "").strip().lower()
+    rows = list(outcomes or [])
+    if domain:
+        rows = [
+            o for o in rows
+            if domain in str(o.get("tool") or "").lower()
+            or domain in str(o.get("detail") or "").lower()
+        ]
+    n = len(rows)
+    if n == 0:
+        return {
+            "domain": domain or "any",
+            "samples": 0,
+            "success_rate": None,
+            "confidence": "unknown",
+            "avoid": False,
+        }
+    successes = sum(1 for o in rows if o.get("ok"))
+    rate = successes / n
+    avoid = n >= 3 and rate <= 0.34
+    confidence = "high" if n >= 4 else "moderate" if n >= 2 else "low"
+    return {
+        "domain": domain or "any",
+        "samples": n,
+        "success_rate": round(rate, 3),
+        "confidence": confidence,
+        "avoid": avoid,
+    }
+
+
+def should_attempt(
+    *,
+    user_input: str,
+    mode: str = "agentic",
+    energy: float = 0.5,
+    uncertainty: float = 0.0,
+    tool_outcomes: list[dict] | None = None,
+    enabled: bool = True,
+) -> tuple[bool, str, str]:
+    """Return (ok, reason, action) with action in proceed|degrade_chat|defer|clarify."""
+    if not enabled:
+        return True, "attempt gate disabled", "proceed"
+    text = (user_input or "").strip()
+    if not text:
+        return True, "empty input", "proceed"
+    if is_critical_task(text):
+        return True, "critical or time-sensitive request", "proceed"
+
+    cap = capability_from_outcomes(tool_outcomes or [], "")
+
+    if mode == "agentic" and energy < 0.28:
+        return False, "energy low; discretionary agentic work can wait", "defer"
+
+    if mode == "agentic" and uncertainty > 0.62:
+        if len(text) < 80 and ("?" in text or len(_tokens(text)) <= 6):
+            return False, "uncertainty elevated; need a clearer ask", "clarify"
+        return False, "uncertainty elevated; prefer chat over agentic loop", "degrade_chat"
+
+    if mode == "agentic" and cap.get("avoid") and (cap.get("samples") or 0) >= 3:
+        return False, "recent tool outcomes are weak; prefer lighter path", "degrade_chat"
+
+    return True, "self-assessment clear", "proceed"

--- a/cognition/memory/edge_state.py
+++ b/cognition/memory/edge_state.py
@@ -531,6 +531,34 @@ class EdgeCognitiveState:
                 lines.append(f"Recent self-decision ({kinds}): {summary}")
         return "<self_model>\n" + "\n".join("- " + line for line in lines) + "\n</self_model>"
 
+    def capability_for(self, domain: str = "") -> dict:
+        """Synthesize recent tool outcomes into a coarse domain confidence."""
+        from cognition.memory.attempt_gate import capability_from_outcomes
+        return capability_from_outcomes(list(self.snapshot().get("tool_outcomes") or []), domain)
+
+    def is_critical_task(self, user_input: str) -> bool:
+        from cognition.memory.attempt_gate import is_critical_task as _crit
+        return _crit(user_input)
+
+    def should_attempt(self, user_input: str, *, mode: str = "agentic") -> tuple[bool, str, str]:
+        """Decide whether to commit to a heavier execution path.
+
+        Returns (ok, reason, action): proceed | degrade_chat | defer | clarify.
+        Critical tasks always proceed. Toggle with EDGE_ATTEMPT_GATE.
+        """
+        from cognition.memory.attempt_gate import should_attempt as _should
+        if not EDGE_COGNITION_ENABLED:
+            return True, "edge cognition disabled", "proceed"
+        snap = self.snapshot()
+        return _should(
+            user_input=user_input,
+            mode=mode,
+            energy=float(snap.get("energy") or 0.5),
+            uncertainty=float(snap.get("uncertainty") or 0.0),
+            tool_outcomes=list(snap.get("tool_outcomes") or []),
+            enabled=env_flag("EDGE_ATTEMPT_GATE", "1"),
+        )
+
     def priming_context(self, query: str = "") -> str:
         """Inject only subconscious signals related to the current query."""
         query_words = _tokens(query)

--- a/cognition/think.py
+++ b/cognition/think.py
@@ -940,11 +940,70 @@ class AikoThink:
         )
   
     def agentic_chat(self, user_input: str, token_callback=None, mem_kb_future=None, query_vec: np.ndarray | None = None) -> str:
-        """Delegate task-mode execution to agentic.agentic."""
+        """Delegate task-mode execution to agentic.agentic.
+
+        Runs a bounded self-assessment gate first (edge_state.should_attempt).
+        Critical requests always proceed; discretionary work may degrade to
+        chat, defer, or ask for clarification instead of starting the tool loop.
+        """
         user_id = current_user_id()
         with self._active_users_lock:
             self._active_user_ids.add(user_id)
         try:
+            # Self-assessment before committing to the agentic tool loop.
+            try:
+                from cognition.memory.edge_state import for_identity
+                state = for_identity(user_id)
+                ok, reason, action = state.should_attempt(user_input, mode="agentic")
+                if not ok:
+                    log.info("[agentic_chat] should_attempt action=%s reason=%s", action, reason)
+                    try:
+                        state.record_self_decision(action if action in {"defer", "clarify"} else "stance", reason)
+                        state.persist()
+                    except Exception:
+                        pass
+                    if action == "defer":
+                        defer_prompt = (
+                            f"{user_input}\n\n"
+                            "[Internal note — do not mention system details. "
+                            "You are running low and this is not urgent. "
+                            "In one short in-character line, say you want to pick this up later "
+                            "and invite the user to continue when ready.]"
+                        )
+                        return self.chat(
+                            defer_prompt,
+                            token_callback=token_callback,
+                            _skip_search=True,
+                            mem_kb_future=mem_kb_future,
+                            query_vec=query_vec,
+                            store_turn=True,
+                        )
+                    if action == "clarify":
+                        clarify_prompt = (
+                            f"{user_input}\n\n"
+                            "[Internal note — do not mention system details. "
+                            "You are uncertain what they need. "
+                            "Ask one concrete clarifying question; do not start a multi-step task.]"
+                        )
+                        return self.chat(
+                            clarify_prompt,
+                            token_callback=token_callback,
+                            _skip_search=True,
+                            mem_kb_future=mem_kb_future,
+                            query_vec=query_vec,
+                            store_turn=True,
+                        )
+                    # degrade_chat (default soft path)
+                    return self.chat(
+                        user_input,
+                        token_callback=token_callback,
+                        _skip_search=True,
+                        mem_kb_future=mem_kb_future,
+                        query_vec=query_vec,
+                    )
+            except Exception as exc:
+                log.debug("[agentic_chat] should_attempt skipped: %s", exc)
+
             memorize = self._get_memorize()
             embedder = memorize._mem._embedder if memorize is not None else None
             cap_vec = embedder.embed_query(

--- a/docs/SHOULD_ATTEMPT.md
+++ b/docs/SHOULD_ATTEMPT.md
@@ -1,31 +1,21 @@
 # should_attempt — execution gate
 
-After PR self-preferences, Aiko’s state could shape prompts but not whether agentic work ran.
+State used to only shape prompts. This gate lets Aiko **branch** before the agentic tool loop.
 
-## What this adds
+## Module
 
-### `EdgeCognitiveState.should_attempt(user_input, mode="agentic")`
-Returns `(ok, reason, action)` where action is:
-- `proceed` — run agentic as usual
-- `degrade_chat` — use normal chat instead of the tool loop
-- `defer` — short in-character “later” (non-critical, low energy)
-- `clarify` — one clarifying question (high uncertainty, short/ambiguous ask)
+`cognition/memory/attempt_gate.py`
 
-Also:
-- `capability_for(domain)` — coarse success rate from recent tool outcomes
-- `is_critical_task(text)` — urgent/safety/approval paths skip soft gates
+- `should_attempt(...)` → `(ok, reason, action)`
+  - `proceed` | `degrade_chat` | `defer` | `clarify`
+- `capability_from_outcomes` — coarse reliability from recent tool outcomes
+- `is_critical_task` — urgent/safety/approval paths skip soft gates
 
-### `AikoThink.agentic_chat`
-Calls `should_attempt` **before** `run_agentic_chat`. Soft actions are logged, recorded via `record_self_decision`, and branch to `chat()` instead of the agent loop.
+## Wire-up (required)
 
-## Safety / conservatism
-- Critical requests always `proceed`
-- Gate can be disabled with `EDGE_ATTEMPT_GATE=0`
-- Existing tool guardrails and human approval are unchanged
+1. **edge_state.py** — thin wrappers (see PR discussion / local patches)
+2. **think.py `agentic_chat`** — call gate before `run_agentic_chat`
 
-## Apply patches (if source files not yet updated on this branch)
+Disable: `EDGE_ATTEMPT_GATE=0`
 
-```bash
-patch -p1 < patches/should_attempt_edge_state.patch
-patch -p1 < patches/should_attempt_think.patch
-```
+Critical requests always proceed. Existing tool guardrails unchanged.

--- a/docs/SHOULD_ATTEMPT.md
+++ b/docs/SHOULD_ATTEMPT.md
@@ -1,0 +1,31 @@
+# should_attempt — execution gate
+
+After PR self-preferences, Aiko’s state could shape prompts but not whether agentic work ran.
+
+## What this adds
+
+### `EdgeCognitiveState.should_attempt(user_input, mode="agentic")`
+Returns `(ok, reason, action)` where action is:
+- `proceed` — run agentic as usual
+- `degrade_chat` — use normal chat instead of the tool loop
+- `defer` — short in-character “later” (non-critical, low energy)
+- `clarify` — one clarifying question (high uncertainty, short/ambiguous ask)
+
+Also:
+- `capability_for(domain)` — coarse success rate from recent tool outcomes
+- `is_critical_task(text)` — urgent/safety/approval paths skip soft gates
+
+### `AikoThink.agentic_chat`
+Calls `should_attempt` **before** `run_agentic_chat`. Soft actions are logged, recorded via `record_self_decision`, and branch to `chat()` instead of the agent loop.
+
+## Safety / conservatism
+- Critical requests always `proceed`
+- Gate can be disabled with `EDGE_ATTEMPT_GATE=0`
+- Existing tool guardrails and human approval are unchanged
+
+## Apply patches (if source files not yet updated on this branch)
+
+```bash
+patch -p1 < patches/should_attempt_edge_state.patch
+patch -p1 < patches/should_attempt_think.patch
+```

--- a/patches/should_attempt_edge_state.patch
+++ b/patches/should_attempt_edge_state.patch
@@ -1,0 +1,20 @@
+--- a/cognition/memory/edge_state.py
++++ b/cognition/memory/edge_state.py
+@@ -70,6 +70,19 @@
+     r"i(?:'|’)m (?:staying|choosing|not a leash)"
+     r")\b",
+     re.I,
+ )
++# Tasks that should not be soft-deferred by energy/uncertainty gates.
++_CRITICAL_TASK_RE = re.compile(
++    r"\b("
++    r"urgent|emergency|asap|right now|immediately|"
++    r"safety|danger|hurt|injured|crisis|"
++    r"deadline today|due today|production (?:is )?down|outage|"
++    r"approve run-|cancel (?:the )?(?:job|schedule|reminder)"
++    r")\b",
++    re.I,
++)
+ _STOP = {"the", "and", "that", "this", "with", "you", "are", "for", "have", "from", "about", "can", "could", "would", "should", "please", "today", "tell", "me", "do", "does", "did", "want", "need", "help"}
+ 
+ 


### PR DESCRIPTION
## Goal

Turn free will from prompt guidance into **execution control**: Aiko can soft-opt-out of discretionary agentic work based on edge cognitive state.

## Already on this branch

- `cognition/memory/attempt_gate.py` — pure gate logic
- `docs/SHOULD_ATTEMPT.md`


Wire-up into existing files (ready locally in conversation artifacts):

1. **`cognition/memory/edge_state.py`** — thin wrappers:
   - `capability_for`
   - `is_critical_task`
   - `should_attempt` → calls `attempt_gate.should_attempt`

2. **`cognition/think.py`** — in `agentic_chat`, before `run_agentic_chat`:
   - call `state.should_attempt(...)`
   - `defer` / `clarify` / `degrade_chat` → branch to `chat()`
   - record decision via `record_self_decision`
   - critical tasks always proceed

### Disable
`EDGE_ATTEMPT_GATE=0`

### Safety
Does not replace tool guardrails or human approval. Only soft-gates non-critical agentic starts.
