### PR TITLE
feat: thin agency polish (soft prompts, load, light self-check)

### DIFF
--- a/cognition/memory/attempt_gate.py
+++ b/cognition/memory/attempt_gate.py
@@ -65,6 +65,31 @@ def capability_from_outcomes(outcomes: list[dict], domain: str = "") -> dict:
     }
 
 
+def soft_user_prompt(user_input: str, action: str, reason: str = "") -> str:
+    """Single structured prompt for soft gate outcomes (no multi-step tasks).
+
+    Replaces ad-hoc "[Internal note…]" blocks scattered in think.py.
+    The model must not mention system details; one short in-character reply only.
+    """
+    text = (user_input or "").strip()
+    action = (action or "").strip().lower()
+    # reason is logged/recorded elsewhere; keep user-facing prompt free of internals.
+    if action == "defer":
+        return (
+            f"{text}\n\n"
+            "[Style only — never quote this. One short in-character line: "
+            "you are low-energy and this is not urgent; offer to continue later.]"
+        )
+    if action == "clarify":
+        return (
+            f"{text}\n\n"
+            "[Style only — never quote this. Ask exactly one concrete clarifying "
+            "question about what they need. Do not start a multi-step task.]"
+        )
+    # degrade_chat / unknown → pass through unchanged
+    return text
+
+
 def should_attempt(
     *,
     user_input: str,
@@ -72,9 +97,13 @@ def should_attempt(
     energy: float = 0.5,
     uncertainty: float = 0.0,
     tool_outcomes: list[dict] | None = None,
+    load: float = 0.0,
     enabled: bool = True,
 ) -> tuple[bool, str, str]:
-    """Return (ok, reason, action) with action in proceed|degrade_chat|defer|clarify."""
+    """Return (ok, reason, action) with action in proceed|degrade_chat|defer|clarify.
+
+    load — coarse 0..1 "running hot" from recent turn latency (optional).
+    """
     if not enabled:
         return True, "attempt gate disabled", "proceed"
     text = (user_input or "").strip()
@@ -85,6 +114,7 @@ def should_attempt(
 
     mode_norm = (mode or "").strip().lower()
     soft = mode_norm in _SOFT_MODES
+    load_v = max(0.0, min(1.0, float(load or 0.0)))
 
     if mode_norm == "agentic":
         text_tokens = _tokens(text)
@@ -94,10 +124,18 @@ def should_attempt(
         ]
         cap = capability_from_outcomes(scoped_outcomes, "")
     else:
-        # Pre-route (mode="route"): task/tool isn't resolved yet, so there is
-        # no reliable way to scope outcomes to "the current task/tool" — skip
-        # the avoid-rule rather than risk unrelated failures triggering it.
-        cap = {"domain": "any", "samples": 0, "success_rate": None, "confidence": "unknown", "avoid": False}
+        # Pre-route: no reliable task/tool scope — skip avoid-rule.
+        cap = {
+            "domain": "any",
+            "samples": 0,
+            "success_rate": None,
+            "confidence": "unknown",
+            "avoid": False,
+        }
+
+    # Running hot + discretionary: prefer defer over heavy path.
+    if soft and load_v >= 0.75 and energy < 0.45:
+        return False, "running hot and energy soft; discretionary work can wait", "defer"
 
     if soft and energy < 0.28:
         return False, "energy low; discretionary work can wait", "defer"

--- a/cognition/memory/edge_state.py
+++ b/cognition/memory/edge_state.py
@@ -479,7 +479,7 @@ class EdgeCognitiveState:
             candidates.append("An active goal may be connected to an unresolved thread.")
         if len(self._events) >= 3:
             recent = [_tokens(event.user) for event in list(self._events)[-3:]]
-            recurring = set.intersection(*(set(r) for r in recent)) if recent else set()
+            recurring = set.intersection(*recent) if recent else set()
             recurring -= {"can", "could", "please", "today"}
             if recurring:
                 candidates.append("Recurring focus detected: " + " ".join(sorted(recurring)[:4]) + ".")

--- a/cognition/memory/edge_state.py
+++ b/cognition/memory/edge_state.py
@@ -132,6 +132,8 @@ class EdgeCognitiveState:
         self._self_preference_counts: dict[str, int] = {}
         self._self_preferences: dict[str, str] = {}
         self._self_notes: deque[str] = deque(maxlen=5)
+        # Recent turn wall-clock seconds (bounded) for coarse "running hot".
+        self._turn_latencies: deque[float] = deque(maxlen=5)
         self._lock = threading.RLock()
         self._last_tick = time.monotonic()
 
@@ -174,7 +176,7 @@ class EdgeCognitiveState:
 
     def clear(self) -> None:
         with self._lock:
-            self._events.clear(); self._open_loops.clear(); self._goals.clear(); self._lessons.clear(); self._tool_outcomes.clear(); self._perceptions.clear(); self._activity = ""; self._response_reviews.clear(); self._contradictions.clear(); self._durable_lessons.clear(); self._lesson_counts.clear(); self._self_decisions.clear(); self._self_preference_counts.clear(); self._self_preferences.clear(); self._self_notes.clear(); self._affect = 0.0; self._energy = 0.5; self._uncertainty = 0.0; self._attention = ""
+            self._events.clear(); self._open_loops.clear(); self._goals.clear(); self._lessons.clear(); self._tool_outcomes.clear(); self._perceptions.clear(); self._activity = ""; self._response_reviews.clear(); self._contradictions.clear(); self._durable_lessons.clear(); self._lesson_counts.clear(); self._self_decisions.clear(); self._self_preference_counts.clear(); self._self_preferences.clear(); self._self_notes.clear(); self._turn_latencies.clear(); self._affect = 0.0; self._energy = 0.5; self._uncertainty = 0.0; self._attention = ""
 
 
     @staticmethod
@@ -540,6 +542,33 @@ class EdgeCognitiveState:
         from cognition.memory.attempt_gate import is_critical_task as _crit
         return _crit(user_input)
 
+    def record_turn_latency(self, seconds: float) -> None:
+        """Record one turn's wall-clock duration for coarse load sensing."""
+        if not EDGE_COGNITION_ENABLED:
+            return
+        try:
+            s = float(seconds)
+        except (TypeError, ValueError):
+            return
+        if s < 0:
+            return
+        with self._lock:
+            self._turn_latencies.appendleft(min(s, 120.0))
+
+    def load_signal(self) -> float:
+        """Coarse 0..1 load from recent turn latencies (not a full metrics stack).
+
+        ~median of last few turns: <4s → 0, ~12s → ~0.5, >=20s → 1.
+        """
+        with self._lock:
+            samples = list(self._turn_latencies)
+        if not samples:
+            return 0.0
+        ordered = sorted(samples)
+        mid = ordered[len(ordered) // 2]
+        # Map 4s..20s → 0..1
+        return max(0.0, min(1.0, (mid - 4.0) / 16.0))
+
     def should_attempt(self, user_input: str, *, mode: str = "agentic") -> tuple[bool, str, str]:
         """Decide whether to commit to a heavier execution path.
 
@@ -556,6 +585,7 @@ class EdgeCognitiveState:
             energy=float(snap.get("energy") or 0.5),
             uncertainty=float(snap.get("uncertainty") or 0.0),
             tool_outcomes=list(snap.get("tool_outcomes") or []),
+            load=self.load_signal(),
             enabled=env_flag("EDGE_ATTEMPT_GATE", "1"),
         )
 
@@ -902,10 +932,32 @@ class EdgeCognitiveState:
             flags.append("draft may not answer the user question")
         if snap.get("contradictions"):
             flags.append("recent user statements conflict; clarification may be needed")
+        # Light self-consistency: only recent Aiko lines, not SOUL.md.
+        self_flag = self._self_consistency_flag(text)
+        if self_flag:
+            flags.append(self_flag)
         review = {"flags": flags, "confidence": "low" if len(flags) >= 2 else "moderate" if flags else "high", "response_chars": len(text)}
         with self._lock:
             self._response_reviews.appendleft(review)
         return review
+
+    def _self_consistency_flag(self, response: str) -> str:
+        """Flag possible self-contradiction vs the last 1–2 Aiko replies only."""
+        draft_tokens = _tokens(response)
+        if len(draft_tokens) < 4:
+            return ""
+        draft_neg = bool(_NEGATION_RE.search(response or ""))
+        with self._lock:
+            recent = [e.assistant for e in list(self._events)[-2:] if e.assistant]
+        for prior in recent:
+            prior_tokens = _tokens(prior)
+            overlap = draft_tokens & prior_tokens
+            if len(overlap) < 3:
+                continue
+            prior_neg = bool(_NEGATION_RE.search(prior))
+            if draft_neg != prior_neg:
+                return "draft may conflict with a recent self-statement"
+        return ""
 
     def grounded_context(self, now=None, idle_seconds: float = 0.0, resting: bool = False, scheduled_jobs: list[dict] | None = None, project_signals: list[str] | None = None) -> str:
         """Render bounded real-world signals, including known scheduled work."""

--- a/cognition/memory/edge_state.py
+++ b/cognition/memory/edge_state.py
@@ -481,7 +481,7 @@ class EdgeCognitiveState:
             candidates.append("An active goal may be connected to an unresolved thread.")
         if len(self._events) >= 3:
             recent = [_tokens(event.user) for event in list(self._events)[-3:]]
-            recurring = set.intersection(*recent) if recent else set()
+            recurring = set(recent[0]).intersection(*recent[1:]) if recent else set()
             recurring -= {"can", "could", "please", "today"}
             if recurring:
                 candidates.append("Recurring focus detected: " + " ".join(sorted(recurring)[:4]) + ".")
@@ -985,9 +985,9 @@ class EdgeCognitiveState:
             duration = latest.get("duration_s")
             lines.append("Recent perception: " + str(latest.get("source", "unknown")) + (f" utterance={duration}s" if duration is not None else ""))
             cues = []
-            if latest.get("words_per_second") is not None: cues.append(f"pace={latest["words_per_second"]}wps")
-            if latest.get("pause_density") is not None: cues.append(f"pauses={latest["pause_density"]}")
-            if latest.get("rms") is not None: cues.append(f"energy={latest["rms"]}")
+            if latest.get("words_per_second") is not None: cues.append(f"pace={latest.get('words_per_second')}wps")
+            if latest.get("pause_density") is not None: cues.append(f"pauses={latest.get('pause_density')}")
+            if latest.get("rms") is not None: cues.append(f"energy={latest.get('rms')}")
             if cues: lines.append("Voice cues: " + ", ".join(cues))
         if outcomes:
             rendered = []
@@ -1035,7 +1035,7 @@ class EdgeCognitiveState:
             return ""
         health = self.cognitive_health()
         lines = ["<situation_model>", "Organized from available evidence; treat it as context, not certainty.", f"Current query: {query[:260]}"]
-        lines.append(f"Cognitive state: {health["status"]}; population={health["population"]}")
+        lines.append(f"Cognitive state: {health.get('status')}; population={health.get('population')}")
         if health["status"] == "empty":
             lines.append("Memory discipline: do not imply personal recall without evidence; ask for the missing context.")
         if entities:
@@ -1065,7 +1065,7 @@ class EdgeCognitiveState:
             lines.append("Stable interaction preferences: " + " | ".join(f"{key}={value}" for key, value in snap["preferences"].items()))
         energy = "low" if snap["energy"] < 0.35 else "high" if snap["energy"] > 0.65 else "steady"
         uncertainty = "elevated" if snap["uncertainty"] > 0.35 else "ordinary"
-        lines.append(f"Internal cues: mood={snap["mood"]}, energy={energy}, uncertainty={uncertainty}")
+        lines.append(f"Internal cues: mood={snap.get('mood')}, energy={energy}, uncertainty={uncertainty}")
         lines.append("Evidence confidence: " + ("moderate" if facts else "low"))
         return "\n".join(lines) + "\n</situation_model>"
 

--- a/cognition/think.py
+++ b/cognition/think.py
@@ -535,6 +535,11 @@ class AikoThink:
             from agentic.agentic import _maybe_resume_approval
             resumed = _maybe_resume_approval(self, user_input, token_callback=token_callback)
             if resumed is not None:
+                try:
+                    from cognition.memory.edge_state import for_identity
+                    for_identity(user_id).record_turn_latency(time.monotonic() - _route_t0)
+                except Exception:
+                    pass
                 return resumed
         except Exception as exc:
             log.debug("[route] approval resume pre-check skipped: %s", exc)
@@ -578,7 +583,7 @@ class AikoThink:
             )
 
             if intent == "agentic":
-                return self.agentic_chat(user_input, token_callback=token_callback, mem_kb_future=mem_kb_future, query_vec=query_vec)
+                return self.agentic_chat(user_input, token_callback=token_callback, mem_kb_future=mem_kb_future, query_vec=query_vec, _from_route=True)
             if intent == "webchat":
                 return self.webchat(user_input, token_callback=token_callback, mem_kb_future=mem_kb_future, query_vec=query_vec)
             return self.chat(user_input, token_callback=token_callback, _skip_search=True, mem_kb_future=mem_kb_future, query_vec=query_vec)
@@ -995,7 +1000,7 @@ class AikoThink:
             store_turn=True,
         )
 
-    def agentic_chat(self, user_input: str, token_callback=None, mem_kb_future=None, query_vec: np.ndarray | None = None) -> str:
+    def agentic_chat(self, user_input: str, token_callback=None, mem_kb_future=None, query_vec: np.ndarray | None = None, _from_route: bool = False) -> str:
         """Delegate task-mode execution to agentic.agentic.
 
         Runs a bounded self-assessment gate first (edge_state.should_attempt).
@@ -1007,6 +1012,7 @@ class AikoThink:
         user_id = current_user_id()
         with self._active_users_lock:
             self._active_user_ids.add(user_id)
+        _agentic_t0 = time.monotonic()
         try:
             # Self-assessment before committing to the agentic tool loop
             # (covers scheduled/direct agentic entry; normal turns already gated in route).
@@ -1036,6 +1042,13 @@ class AikoThink:
             response = run_agentic_chat(self, user_input, token_callback=token_callback, mem_kb_future=mem_kb_future, query_vec=query_vec, cap_vec=cap_vec)
             return response
         finally:
+            # Only record latency if called directly (not from route, which already records)
+            if not _from_route:
+                try:
+                    from cognition.memory.edge_state import for_identity
+                    for_identity(user_id).record_turn_latency(time.monotonic() - _agentic_t0)
+                except Exception:
+                    pass
             with self._active_users_lock:
                 self._active_user_ids.discard(user_id)
                 if not self._active_user_ids:

--- a/cognition/think.py
+++ b/cognition/think.py
@@ -526,6 +526,7 @@ class AikoThink:
         with self._active_users_lock:
             self._active_user_ids.add(user_id)
         self._note_user_activity()
+        _route_t0 = time.monotonic()
         # Approval commands ("approve run-<id>", "yes") must be handled
         # BEFORE intent classification — the quaternary intent LLM labels
         # terse commands like "Approve run-…" as chat, which would skip
@@ -582,6 +583,11 @@ class AikoThink:
                 return self.webchat(user_input, token_callback=token_callback, mem_kb_future=mem_kb_future, query_vec=query_vec)
             return self.chat(user_input, token_callback=token_callback, _skip_search=True, mem_kb_future=mem_kb_future, query_vec=query_vec)
         finally:
+            try:
+                from cognition.memory.edge_state import for_identity
+                for_identity(user_id).record_turn_latency(time.monotonic() - _route_t0)
+            except Exception:
+                pass
             with self._active_users_lock:
                 self._active_user_ids.discard(user_id)
                 if not self._active_user_ids:
@@ -968,6 +974,7 @@ class AikoThink:
         """Handle defer / clarify / degrade_chat without starting agentic tools.
 
         Used by route() (pre-routing) and agentic_chat() (direct agentic entry).
+        Prompts come from attempt_gate.soft_user_prompt (one short reply only).
         """
         try:
             from cognition.memory.edge_state import for_identity
@@ -977,44 +984,15 @@ class AikoThink:
             state.persist()
         except Exception:
             pass
-        if action == "defer":
-            defer_prompt = (
-                f"{user_input}\n\n"
-                "[Internal note — do not mention system details. "
-                "You are running low and this is not urgent. "
-                "In one short in-character line, say you want to pick this up later "
-                "and invite the user to continue when ready.]"
-            )
-            return self.chat(
-                defer_prompt,
-                token_callback=token_callback,
-                _skip_search=True,
-                mem_kb_future=mem_kb_future,
-                query_vec=query_vec,
-                store_turn=True,
-            )
-        if action == "clarify":
-            clarify_prompt = (
-                f"{user_input}\n\n"
-                "[Internal note — do not mention system details. "
-                "You are uncertain what they need. "
-                "Ask one concrete clarifying question; do not start a multi-step task.]"
-            )
-            return self.chat(
-                clarify_prompt,
-                token_callback=token_callback,
-                _skip_search=True,
-                mem_kb_future=mem_kb_future,
-                query_vec=query_vec,
-                store_turn=True,
-            )
-        # degrade_chat (default soft path) — localchat, no tool loop
+        from cognition.memory.attempt_gate import soft_user_prompt
+        prompt = soft_user_prompt(user_input, action, reason)
         return self.chat(
-            user_input,
+            prompt,
             token_callback=token_callback,
             _skip_search=True,
             mem_kb_future=mem_kb_future,
             query_vec=query_vec,
+            store_turn=True,
         )
 
     def agentic_chat(self, user_input: str, token_callback=None, mem_kb_future=None, query_vec: np.ndarray | None = None) -> str:

--- a/scripts/apply_thin_agency_polish.py
+++ b/scripts/apply_thin_agency_polish.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""Apply thin agency polish patch to edge_state.py and think.py."""
+from __future__ import annotations
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PATCH = Path(__file__).resolve().parent / "thin_agency_polish.patch"
+
+
+def main() -> int:
+    if not PATCH.exists():
+        print(f"missing {PATCH}", file=sys.stderr)
+        return 1
+    r = subprocess.run(
+        ["git", "apply", "--check", str(PATCH)],
+        cwd=ROOT, capture_output=True, text=True,
+    )
+    if r.returncode != 0:
+        print(r.stderr or r.stdout, file=sys.stderr)
+        return 1
+    r = subprocess.run(["git", "apply", str(PATCH)], cwd=ROOT, capture_output=True, text=True)
+    if r.returncode != 0:
+        print(r.stderr or r.stdout, file=sys.stderr)
+        return 1
+    print("Applied thin_agency_polish.patch to edge_state.py and think.py")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/thin_agency_polish.patch
+++ b/scripts/thin_agency_polish.patch
@@ -1,0 +1,179 @@
+diff --git a/cognition/memory/edge_state.py b/cognition/memory/edge_state.py
+index 3dc6554..3255cfb 100644
+--- a/cognition/memory/edge_state.py
++++ b/cognition/memory/edge_state.py
+@@ -132,6 +132,8 @@ class EdgeCognitiveState:
+         self._self_preference_counts: dict[str, int] = {}
+         self._self_preferences: dict[str, str] = {}
+         self._self_notes: deque[str] = deque(maxlen=5)
++        # Recent turn wall-clock seconds (bounded) for coarse "running hot".
++        self._turn_latencies: deque[float] = deque(maxlen=5)
+         self._lock = threading.RLock()
+         self._last_tick = time.monotonic()
+ 
+@@ -174,7 +176,7 @@ class EdgeCognitiveState:
+ 
+     def clear(self) -> None:
+         with self._lock:
+-            self._events.clear(); self._open_loops.clear(); self._goals.clear(); self._lessons.clear(); self._tool_outcomes.clear(); self._perceptions.clear(); self._activity = ""; self._response_reviews.clear(); self._contradictions.clear(); self._durable_lessons.clear(); self._lesson_counts.clear(); self._self_decisions.clear(); self._self_preference_counts.clear(); self._self_preferences.clear(); self._self_notes.clear(); self._affect = 0.0; self._energy = 0.5; self._uncertainty = 0.0; self._attention = ""
++            self._events.clear(); self._open_loops.clear(); self._goals.clear(); self._lessons.clear(); self._tool_outcomes.clear(); self._perceptions.clear(); self._activity = ""; self._response_reviews.clear(); self._contradictions.clear(); self._durable_lessons.clear(); self._lesson_counts.clear(); self._self_decisions.clear(); self._self_preference_counts.clear(); self._self_preferences.clear(); self._self_notes.clear(); self._turn_latencies.clear(); self._affect = 0.0; self._energy = 0.5; self._uncertainty = 0.0; self._attention = ""
+ 
+ 
+     @staticmethod
+@@ -540,6 +542,33 @@ class EdgeCognitiveState:
+         from cognition.memory.attempt_gate import is_critical_task as _crit
+         return _crit(user_input)
+ 
++    def record_turn_latency(self, seconds: float) -> None:
++        """Record one turn's wall-clock duration for coarse load sensing."""
++        if not EDGE_COGNITION_ENABLED:
++            return
++        try:
++            s = float(seconds)
++        except (TypeError, ValueError):
++            return
++        if s < 0:
++            return
++        with self._lock:
++            self._turn_latencies.appendleft(min(s, 120.0))
++
++    def load_signal(self) -> float:
++        """Coarse 0..1 load from recent turn latencies (not a full metrics stack).
++
++        ~median of last few turns: <4s → 0, ~12s → ~0.5, >=20s → 1.
++        """
++        with self._lock:
++            samples = list(self._turn_latencies)
++        if not samples:
++            return 0.0
++        ordered = sorted(samples)
++        mid = ordered[len(ordered) // 2]
++        # Map 4s..20s → 0..1
++        return max(0.0, min(1.0, (mid - 4.0) / 16.0))
++
+     def should_attempt(self, user_input: str, *, mode: str = "agentic") -> tuple[bool, str, str]:
+         """Decide whether to commit to a heavier execution path.
+ 
+@@ -556,6 +585,7 @@ class EdgeCognitiveState:
+             energy=float(snap.get("energy") or 0.5),
+             uncertainty=float(snap.get("uncertainty") or 0.0),
+             tool_outcomes=list(snap.get("tool_outcomes") or []),
++            load=self.load_signal(),
+             enabled=env_flag("EDGE_ATTEMPT_GATE", "1"),
+         )
+ 
+@@ -902,11 +932,33 @@ class EdgeCognitiveState:
+             flags.append("draft may not answer the user question")
+         if snap.get("contradictions"):
+             flags.append("recent user statements conflict; clarification may be needed")
++        # Light self-consistency: only recent Aiko lines, not SOUL.md.
++        self_flag = self._self_consistency_flag(text)
++        if self_flag:
++            flags.append(self_flag)
+         review = {"flags": flags, "confidence": "low" if len(flags) >= 2 else "moderate" if flags else "high", "response_chars": len(text)}
+         with self._lock:
+             self._response_reviews.appendleft(review)
+         return review
+ 
++    def _self_consistency_flag(self, response: str) -> str:
++        """Flag possible self-contradiction vs the last 1–2 Aiko replies only."""
++        draft_tokens = _tokens(response)
++        if len(draft_tokens) < 4:
++            return ""
++        draft_neg = bool(_NEGATION_RE.search(response or ""))
++        with self._lock:
++            recent = [e.assistant for e in list(self._events)[-2:] if e.assistant]
++        for prior in recent:
++            prior_tokens = _tokens(prior)
++            overlap = draft_tokens & prior_tokens
++            if len(overlap) < 3:
++                continue
++            prior_neg = bool(_NEGATION_RE.search(prior))
++            if draft_neg != prior_neg:
++                return "draft may conflict with a recent self-statement"
++        return ""
++
+     def grounded_context(self, now=None, idle_seconds: float = 0.0, resting: bool = False, scheduled_jobs: list[dict] | None = None, project_signals: list[str] | None = None) -> str:
+         """Render bounded real-world signals, including known scheduled work."""
+         if now is None:
+diff --git a/cognition/think.py b/cognition/think.py
+index e74eceb..83b8c74 100644
+--- a/cognition/think.py
++++ b/cognition/think.py
+@@ -526,6 +526,7 @@ class AikoThink:
+         with self._active_users_lock:
+             self._active_user_ids.add(user_id)
+         self._note_user_activity()
++        _route_t0 = time.monotonic()
+         # Approval commands ("approve run-<id>", "yes") must be handled
+         # BEFORE intent classification — the quaternary intent LLM labels
+         # terse commands like "Approve run-…" as chat, which would skip
+@@ -582,6 +583,11 @@ class AikoThink:
+                 return self.webchat(user_input, token_callback=token_callback, mem_kb_future=mem_kb_future, query_vec=query_vec)
+             return self.chat(user_input, token_callback=token_callback, _skip_search=True, mem_kb_future=mem_kb_future, query_vec=query_vec)
+         finally:
++            try:
++                from cognition.memory.edge_state import for_identity
++                for_identity(user_id).record_turn_latency(time.monotonic() - _route_t0)
++            except Exception:
++                pass
+             with self._active_users_lock:
+                 self._active_user_ids.discard(user_id)
+                 if not self._active_user_ids:
+@@ -968,6 +974,7 @@ class AikoThink:
+         """Handle defer / clarify / degrade_chat without starting agentic tools.
+ 
+         Used by route() (pre-routing) and agentic_chat() (direct agentic entry).
++        Prompts come from attempt_gate.soft_user_prompt (one short reply only).
+         """
+         try:
+             from cognition.memory.edge_state import for_identity
+@@ -977,44 +984,15 @@ class AikoThink:
+             state.persist()
+         except Exception:
+             pass
+-        if action == "defer":
+-            defer_prompt = (
+-                f"{user_input}\n\n"
+-                "[Internal note — do not mention system details. "
+-                "You are running low and this is not urgent. "
+-                "In one short in-character line, say you want to pick this up later "
+-                "and invite the user to continue when ready.]"
+-            )
+-            return self.chat(
+-                defer_prompt,
+-                token_callback=token_callback,
+-                _skip_search=True,
+-                mem_kb_future=mem_kb_future,
+-                query_vec=query_vec,
+-                store_turn=True,
+-            )
+-        if action == "clarify":
+-            clarify_prompt = (
+-                f"{user_input}\n\n"
+-                "[Internal note — do not mention system details. "
+-                "You are uncertain what they need. "
+-                "Ask one concrete clarifying question; do not start a multi-step task.]"
+-            )
+-            return self.chat(
+-                clarify_prompt,
+-                token_callback=token_callback,
+-                _skip_search=True,
+-                mem_kb_future=mem_kb_future,
+-                query_vec=query_vec,
+-                store_turn=True,
+-            )
+-        # degrade_chat (default soft path) — localchat, no tool loop
++        from cognition.memory.attempt_gate import soft_user_prompt
++        prompt = soft_user_prompt(user_input, action, reason)
+         return self.chat(
+-            user_input,
++            prompt,
+             token_callback=token_callback,
+             _skip_search=True,
+             mem_kb_future=mem_kb_future,
+             query_vec=query_vec,
++            store_turn=True,
+         )
+ 
+     def agentic_chat(self, user_input: str, token_callback=None, mem_kb_future=None, query_vec: np.ndarray | None = None) -> str:


### PR DESCRIPTION
## Scope (kept thin)

| Piece | What |
|-------|------|
| Structured soft prompts | `attempt_gate.soft_user_prompt` — one clarify/defer helper; no multi-step | 
| Load / running hot | `record_turn_latency` + `load_signal()` (median of last few turns) → `should_attempt(load=…)` | 
| Light self-consistency | `review_response` flags vs **last 1–2 Aiko lines only** (not SOUL.md) | 

## Already on this branch

- `cognition/memory/attempt_gate.py` — `soft_user_prompt` + optional `load`
- `scripts/thin_agency_polish.patch` + `scripts/apply_thin_agency_polish.py`

## Finish wire-up (required before merge)

Large `edge_state.py` / `think.py` are applied via patch (same pattern as pre-route gate):

```bash
git fetch origin
git checkout feat/thin-agency-polish
python3 scripts/apply_thin_agency_polish.py
git add cognition/memory/edge_state.py cognition/think.py
git commit -m "edge_state+think: load signal, soft prompts, light self-check"
git push
```

## Behaviour

- Soft gate replies use one structured style note (never quote system internals).
- If median recent turn latency is high **and** energy is soft → may `defer`.
- Existing `_finalize_response` still only soft-rewrites when **≥2** review flags.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added smarter handling for high-load situations, allowing the assistant to defer or request clarification when needed.
  - Improved soft responses with clearer, consistently formatted guidance.
  - Added detection for potential contradictions with recent assistant replies.
  - Improved tracking of response performance to support more reliable routing.

- **Bug Fixes**
  - Improved recurring-focus processing for more dependable state updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->