### PR TITLE
fix(studio): bind views to authenticated user

### DIFF
--- a/cognition/memory/episode.py
+++ b/cognition/memory/episode.py
@@ -655,6 +655,13 @@ class EpisodicStore:
             self.flush_all()
         except Exception as e:
             log.debug("EMC flush_all on close: %s", e)
+        # Stop the embed worker thread if it's running
+        if self._embed_worker is not None and self._embed_worker.is_alive():
+            try:
+                self._embed_queue.put(None)
+                self._embed_worker.join(timeout=2.0)
+            except Exception as e:
+                log.debug("EMC embed worker shutdown: %s", e)
         with self._lock:
             try:
                 self._conn.close()

--- a/cognition/memory/memorize.py
+++ b/cognition/memory/memorize.py
@@ -2224,8 +2224,12 @@ class AikoMemorize:
 
     def _write_loop(self) -> None:
         while True:
-            user_input, response_text, user_id, display_name, is_active_turn, idle_since = self._write_queue.get()
+            item = self._write_queue.get()
             try:
+                if item is None:
+                    self._write_queue.task_done()
+                    return
+                user_input, response_text, user_id, display_name, is_active_turn, idle_since = item
                 self._wait_for_write_window(is_active_turn, idle_since)
                 self.add([
                     {"role": "user", "content": user_input[:500]},
@@ -2274,6 +2278,27 @@ class AikoMemorize:
                     return False
                 self._write_queue.all_tasks_done.wait(remaining)
         return True
+
+    def close(self) -> None:
+        """Stop the write-worker thread and close the sqlite connection."""
+        try:
+            if not self.wait_for_writes(timeout=5.0):
+                log.warning("AikoMemorize.close(): pending writes did not finish within 5s")
+        except Exception as e:
+            log.debug("AikoMemorize.close(): wait_for_writes: %s", e)
+        # Stop the write-worker thread if it's running
+        if self._write_worker is not None and self._write_worker.is_alive():
+            try:
+                self._write_queue.put(None)
+                self._write_worker.join(timeout=2.0)
+            except Exception as e:
+                log.debug("AikoMemorize.close(): write worker shutdown: %s", e)
+        if self._mem_backend is not None:
+            with self._mem._db_lock:
+                try:
+                    self._conn.close()
+                except Exception:
+                    pass
 
     # ── read ──────────────────────────────────────────────────────────────────
 

--- a/interface/webui/studio/approval/backend/api.py
+++ b/interface/webui/studio/approval/backend/api.py
@@ -126,7 +126,6 @@ def _scan_all_drafts() -> list[dict]:
 
 @app.get("/api/drafts")
 async def get_drafts(
-    user_id: str | None = Query(None, description="User id (default: current_user_id)"),
     status: str | None = Query(None, description="Filter: pending, approved, posted, rejected, all"),
 ):
     """Get all job post drafts for review."""

--- a/interface/webui/studio/memory/itm/backend/api.py
+++ b/interface/webui/studio/memory/itm/backend/api.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import threading
+from collections import OrderedDict
 from pathlib import Path
 from typing import Any
 
@@ -35,8 +36,9 @@ SHARED_DIR = Path(__file__).resolve().parents[3] / "shared"
 app.mount("/static", StaticFiles(directory=str(FRONTEND_DIR), html=True), name="itm-frontend")
 app.mount("/shared", StaticFiles(directory=str(SHARED_DIR), html=True), name="studio-shared")
 
-_stores_by_user: dict[str, object] = {}
+_stores_by_user: "OrderedDict[str, object]" = OrderedDict()
 _store_lock = threading.Lock()
+_STORE_CACHE_MAX = 10
 
 
 def _get_store(user_id: str | None = None):
@@ -51,9 +53,21 @@ def _get_store(user_id: str | None = None):
                 from cognition.memory.schema import _memory_db_path_for_user
                 import os
 
+                # Evict oldest entry if at capacity
+                if len(_stores_by_user) >= _STORE_CACHE_MAX:
+                    evict_user, evict_store = _stores_by_user.popitem(last=False)
+                    try:
+                        evict_store.close()
+                    except Exception:
+                        pass
+
                 embed_cache = os.getenv("EMBED_CACHE_PATH") or None
                 store = EpisodicStore(_memory_db_path_for_user(uid), user_id=uid, embed_cache=embed_cache)
                 _stores_by_user[uid] = store
+    else:
+        # Move to end (LRU: mark as recently used)
+        with _store_lock:
+            _stores_by_user.move_to_end(uid)
     return store
 
 

--- a/interface/webui/studio/memory/itm/backend/api.py
+++ b/interface/webui/studio/memory/itm/backend/api.py
@@ -35,29 +35,33 @@ SHARED_DIR = Path(__file__).resolve().parents[3] / "shared"
 app.mount("/static", StaticFiles(directory=str(FRONTEND_DIR), html=True), name="itm-frontend")
 app.mount("/shared", StaticFiles(directory=str(SHARED_DIR), html=True), name="studio-shared")
 
-_store = None
+_stores_by_user: dict[str, object] = {}
 _store_lock = threading.Lock()
 
 
 def _get_store(user_id: str | None = None):
-    """Reuse a single EpisodicStore for this process (mirrors LTM api.py)."""
-    global _store
-    if _store is None:
+    """Reuse one EpisodicStore per user, never another user's database."""
+    uid = user_id or "guest"
+    store = _stores_by_user.get(uid)
+    if store is None:
         with _store_lock:
-            if _store is None:
+            store = _stores_by_user.get(uid)
+            if store is None:
                 from cognition.memory.episode import EpisodicStore
                 from cognition.memory.schema import _memory_db_path_for_user
                 import os
 
-                uid = user_id or "guest"
                 embed_cache = os.getenv("EMBED_CACHE_PATH") or None
-                _store = EpisodicStore(_memory_db_path_for_user(uid), user_id=uid, embed_cache=embed_cache)
-    return _store
+                store = EpisodicStore(_memory_db_path_for_user(uid), user_id=uid, embed_cache=embed_cache)
+                _stores_by_user[uid] = store
+    return store
 
 
 def _resolve_user_id(user_id: str | None) -> str:
     from system.userspace import current_user_id
-    return (user_id or "").strip() or current_user_id()
+    # Studio identity comes from the authenticated request middleware.  Do
+    # not let a stale browser field or a crafted query override it.
+    return current_user_id()
 
 
 def _parse_entities(raw: Any) -> list[str]:

--- a/interface/webui/studio/memory/itm/frontend/index.html
+++ b/interface/webui/studio/memory/itm/frontend/index.html
@@ -51,7 +51,6 @@
       <div class="stat" id="pipe-total">—</div>
 
       <h2>Filters</h2>
-      <label>User id <input type="text" id="user-id" placeholder="(current)" /></label>
       <label>Stage
         <select id="stage">
           <option value="all">all</option>

--- a/interface/webui/studio/memory/itm/frontend/script.js
+++ b/interface/webui/studio/memory/itm/frontend/script.js
@@ -4,8 +4,6 @@ let currentView = 'episodes';
 
 function qs() {
   const p = new URLSearchParams();
-  const uid = document.getElementById('user-id').value.trim();
-  if (uid) p.set('user_id', uid);
   const stage = document.getElementById('stage').value;
   if (stage !== 'all') p.set('stage', stage);
   const df = document.getElementById('date-from').value;
@@ -40,8 +38,6 @@ function valBadge(tag) {
 async function loadPipeline() {
   try {
     const p = new URLSearchParams();
-    const uid = document.getElementById('user-id').value.trim();
-    if (uid) p.set('user_id', uid);
     const r = await fetch(`${API}/pipeline?` + p.toString());
     const d = await r.json();
     if (!d.ok) { return; }

--- a/interface/webui/studio/memory/kb/backend/api.py
+++ b/interface/webui/studio/memory/kb/backend/api.py
@@ -18,7 +18,6 @@ def health():
     return {"ok": True, "studio": "knowledge-graph"}
 @app.get("/api/graph")
 def api_graph(
-    user_id: str | None = Query(None, description="User id (default: current_user_id)"),
     limit: int = Query(200, ge=1, le=1000),
     include_history: bool = Query(True, description="Include superseded/archived knowledge"),
     include_entities: bool = Query(True, description="Add entity hub nodes"),
@@ -28,7 +27,8 @@ def api_graph(
     from .graph_export import export_knowledge_graph
     from system.userspace import current_user_id
     
-    uid = (user_id or "").strip() or current_user_id()
+    # The authenticated session bound by studio middleware is authoritative.
+    uid = current_user_id()
     try:
         return export_knowledge_graph(
             user_id=uid,

--- a/interface/webui/studio/memory/ltm/backend/api.py
+++ b/interface/webui/studio/memory/ltm/backend/api.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import threading
+from collections import OrderedDict
 from pathlib import Path
 
 from fastapi import FastAPI, Query
@@ -35,9 +36,12 @@ app.mount("/shared", StaticFiles(directory=str(SHARED_DIR), html=True), name="st
 
 # AikoMemorize __init__ opens a sqlite-vec connection AND spawns a daemon
 # write-worker thread. Constructing one per request leaks a connection +
-# thread for the lifetime of the process, so cache a single shared instance.
-_memorize_by_user: dict[str, object] = {}
+# thread for the lifetime of the process, so cache per-user instances with
+# bounded LRU eviction (max 10 users; oldest entry is closed + evicted when
+# capacity is reached and a new user arrives).
+_memorize_by_user: "OrderedDict[str, object]" = OrderedDict()
 _memorize_lock = threading.Lock()
+_MEMORIZE_CACHE_MAX = 10
 
 
 def _get_memorize(user_id: str):
@@ -49,12 +53,24 @@ def _get_memorize(user_id: str):
             if memorize is None:
                 from cognition.memory.memorize import AikoMemorize
 
+                # Evict oldest entry if at capacity
+                if len(_memorize_by_user) >= _MEMORIZE_CACHE_MAX:
+                    evict_user, evict_mem = _memorize_by_user.popitem(last=False)
+                    try:
+                        evict_mem.close()
+                    except Exception:
+                        pass
+
                 memorize = AikoMemorize(silent=True)
                 # The facade opens its database during construction, so it
                 # must be explicitly bound instead of inheriting a later
                 # request's contextvar.
                 memorize.switch_user(user_id)
                 _memorize_by_user[user_id] = memorize
+    else:
+        # Move to end (LRU: mark as recently used)
+        with _memorize_lock:
+            _memorize_by_user.move_to_end(user_id)
     return memorize
 
 

--- a/interface/webui/studio/memory/ltm/backend/api.py
+++ b/interface/webui/studio/memory/ltm/backend/api.py
@@ -36,24 +36,30 @@ app.mount("/shared", StaticFiles(directory=str(SHARED_DIR), html=True), name="st
 # AikoMemorize __init__ opens a sqlite-vec connection AND spawns a daemon
 # write-worker thread. Constructing one per request leaks a connection +
 # thread for the lifetime of the process, so cache a single shared instance.
-_memorize = None
+_memorize_by_user: dict[str, object] = {}
 _memorize_lock = threading.Lock()
 
 
-def _get_memorize():
-    global _memorize
-    if _memorize is None:
+def _get_memorize(user_id: str):
+    """Return a memory facade attached to this user's physical database."""
+    memorize = _memorize_by_user.get(user_id)
+    if memorize is None:
         with _memorize_lock:
-            if _memorize is None:
+            memorize = _memorize_by_user.get(user_id)
+            if memorize is None:
                 from cognition.memory.memorize import AikoMemorize
 
-                _memorize = AikoMemorize(silent=True)
-    return _memorize
+                memorize = AikoMemorize(silent=True)
+                # The facade opens its database during construction, so it
+                # must be explicitly bound instead of inheriting a later
+                # request's contextvar.
+                memorize.switch_user(user_id)
+                _memorize_by_user[user_id] = memorize
+    return memorize
 
 
 @app.get("/api/graph")
 def get_graph(
-    user_id: str | None = Query(None, description="User id (default: current_user_id)"),
     limit: int = Query(200, ge=1, le=2000),
     include_history: bool = Query(True, description="Include superseded memories"),
     include_entities: bool = Query(True, description="Add entity hub nodes"),
@@ -66,7 +72,7 @@ def get_graph(
     from interface.webui.studio.memory.ltm.backend.graph_export import export_memory_graph
     from system.userspace import current_user_id
 
-    uid = (user_id or "").strip() or current_user_id()
+    uid = current_user_id()
     return export_memory_graph(
         user_id=uid,
         limit=limit,
@@ -88,20 +94,19 @@ async def health():
 @app.get("/api/search")
 def search(
     q: str = Query(..., description="Search query across memory + knowledge"),
-    user_id: str | None = Query(None, description="User id (default: current_user_id)"),
     limit: int = Query(10, ge=1, le=100),
     include_history: bool = Query(False, description="Include superseded memories"),
 ):
     from interface.webui.studio.memory.ltm.backend.search_memory import search_memory
     from system.userspace import current_user_id
 
-    uid = (user_id or "").strip() or current_user_id()
+    uid = current_user_id()
     query = (q or "").strip()
     if not query:
         return {"query": "", "hits": [], "meta": {"user_id": uid}}
 
     try:
-        memorize = _get_memorize()
+        memorize = _get_memorize(uid)
     except Exception as e:
         return {"query": query, "hits": [], "meta": {"user_id": uid, "error": str(e)}}
 
@@ -131,12 +136,11 @@ def search(
 @app.get("/api/memory/{mem_id}/lineage")
 def memory_lineage(
     mem_id: str,
-    user_id: str | None = Query(None, description="User id (default: current_user_id)"),
 ):
     from system.userspace import current_user_id
 
-    uid = (user_id or "").strip() or current_user_id()
-    memorize = _get_memorize()
+    uid = current_user_id()
+    memorize = _get_memorize(uid)
     return memorize.get_lineage(mem_id, user_id=uid)
 
 

--- a/interface/webui/studio/memory/ltm/frontend/index.html
+++ b/interface/webui/studio/memory/ltm/frontend/index.html
@@ -32,7 +32,6 @@
       <button class="btn btn-primary" id="search-btn" style="width:100%;margin-top:4px">Search mem + KB</button>
       <div class="stat" id="search-stats">—</div>
       <h2>Filters</h2>
-      <label>User id <input type="text" id="user-id" placeholder="(current)" /></label>
       <label>Limit <input type="number" id="limit" value="200" min="1" max="2000" /></label>
       <label>From <input type="date" id="date-from" /></label>
       <label>To <input type="date" id="date-to" /></label>

--- a/interface/webui/studio/memory/ltm/frontend/script.js
+++ b/interface/webui/studio/memory/ltm/frontend/script.js
@@ -22,8 +22,6 @@ async function getCurrentUser() {
 
 function qs() {
   const p = new URLSearchParams();
-  const uid = document.getElementById('user-id').value.trim();
-  if (uid) p.set('user_id', uid);
   p.set('limit', document.getElementById('limit').value || '200');
   p.set('include_history', document.getElementById('include-history').checked);
   p.set('include_entities', document.getElementById('include-entities').checked);

--- a/interface/webui/studio/session_binding.py
+++ b/interface/webui/studio/session_binding.py
@@ -27,7 +27,12 @@ log = get_logger(__name__)
 
 
 def bind_login_session(app: FastAPI) -> None:
-    """Install login-session identity binding on a studio sub-app."""
+    """Install login-session identity binding on a studio sub-app.
+
+    The session identity is deliberately the only identity source for studio
+    API routes.  In particular, callers must not be able to select a
+    different store by appending ``?user_id=...`` to a request URL.
+    """
 
     @app.middleware("http")
     async def _bind_session_user(request: Request, call_next):

--- a/interface/webui/studio/session_binding.py
+++ b/interface/webui/studio/session_binding.py
@@ -26,6 +26,13 @@ from system.userspace import (
 log = get_logger(__name__)
 
 
+def _relative_path(scope: dict) -> str:
+    """Return the path relative to a mounted studio app's root path."""
+    path = scope.get("path", "")
+    root_path = scope.get("root_path", "")
+    return path.removeprefix(root_path) if root_path else path
+
+
 def bind_login_session(app: FastAPI) -> None:
     """Install login-session identity binding on a studio sub-app.
 
@@ -36,7 +43,12 @@ def bind_login_session(app: FastAPI) -> None:
 
     @app.middleware("http")
     async def _bind_session_user(request: Request, call_next):
-        if not request.url.path.startswith("/api"):
+        # Mounted ASGI sub-apps retain the public path in ``scope["path"]``
+        # (for example ``/studio/memory/ltm/api/graph``).  Their mount prefix
+        # is recorded separately in ``scope["root_path"]``.  Checking
+        # request.url.path here therefore skipped every mounted studio API and
+        # left current_user_id() at its guest/env fallback.
+        if not _relative_path(request.scope).startswith("/api"):
             return await call_next(request)
         from interface.webui.auth import require_session
 

--- a/interface/webui/webui.py
+++ b/interface/webui/webui.py
@@ -246,12 +246,12 @@ class AikoWeb:
             if uid in self._user_space_ready:
                 return
             self._user_space_ready.add(uid)
-        log.info("[aiko-web] first authenticated user (%s) — running deferred user-space seeding", uid)
-        try:
-            from system.prepare import run_post_auth
-            run_post_auth(uid, memorize=self._memorize, think=self._think)
-        except Exception:
-            log.exception("[aiko-web] post-auth initialization failed")
+            log.info("[aiko-web] first authenticated user (%s) — running deferred user-space seeding", uid)
+            try:
+                from system.prepare import run_post_auth
+                run_post_auth(uid, memorize=self._memorize, think=self._think)
+            except Exception:
+                log.exception("[aiko-web] post-auth initialization failed")
 
     def _start_servers(self) -> None:
         import socket

--- a/system/prepare.py
+++ b/system/prepare.py
@@ -44,64 +44,85 @@ def run_post_auth(uid: str, *, memorize=None, think=None) -> None:
         log.debug("[prepare] skipping post-auth init for %r", uid or "empty uid")       # nothing to initialize yet
         return
 
-    # Semantic cache warm under the REAL identity — moved out of wakeup boot:
-    # as guest, per-user npz disk caches can't be read or written (see
-    # reason.cache_vector_path's guest guard), so every boot recomputed from
-    # scratch. Here it loads the user's existing cache files and persists
-    # fresh vectors for the next session.
-    if think is not None:
-        try:
-            think.prewarm_caches()
-        except Exception:
-            log.exception("[prepare] semantic cache prewarm failed")
+    # ``run_post_auth`` runs in a background thread after the WebSocket login
+    # handler returns. ContextVars do not cross that thread boundary, and the
+    # live memory facade was constructed during guest-safe boot. Bind both
+    # explicitly before *any* user-space operation so cleanup, persona reads,
+    # schedules, and cache warmup use USER_SPACE_ROOT/<uid>, not guest.
+    from system.userspace import (
+        reset_current_display_name,
+        reset_current_user_id,
+        set_current_display_name,
+        set_current_user_id,
+    )
 
-    # Memory cleanup — boot skipped it for guest; the real per-user store is
-    # open now (parity with the old login-gated boot behaviour).
+    user_token = set_current_user_id(uid)
+    display_token = set_current_display_name(uid)
     try:
         if memorize is not None:
-            memorize.cleanup()
-    except Exception:
-        log.exception("[prepare] post-login memory cleanup failed")
+            memorize.switch_user(uid)
 
-    # Static anchor for Grasp relevance scoring — persona + pinned memories
-    # become the identity tokens that keep relevant turns resident longer in
-    # working memory (activates the previously-dead relevance factor).
-    if memorize is not None:
+        # Semantic cache warm under the REAL identity — moved out of wakeup boot:
+        # as guest, per-user npz disk caches can't be read or written (see
+        # reason.cache_vector_path's guest guard), so every boot recomputed from
+        # scratch. Here it loads the user's existing cache files and persists
+        # fresh vectors for the next session.
+        if think is not None:
+            try:
+                think.prewarm_caches()
+            except Exception:
+                log.exception("[prepare] semantic cache prewarm failed")
+
+        # Memory cleanup — boot skipped it for guest; the real per-user store is
+        # open now (parity with the old login-gated boot behaviour).
         try:
-            texts: list[str] = []
-            try:
-                texts.append(memorize.persona_context() or "")
-            except Exception:
-                pass
-            try:
-                for m in memorize.get_all():
-                    if m.get("pinned"):
-                        texts.append(m.get("memory") or m.get("text") or "")
-            except Exception:
-                pass
-            from cognition.memory.grasp import build_anchor_tokens, set_static_anchor_tokens
-            anchor = build_anchor_tokens(*texts)
-            if anchor:
-                set_static_anchor_tokens(anchor)
-                log.info("[prepare] Grasp static anchor set (%d tokens)", len(anchor))
-            else:
-                log.info("[prepare] Grasp static anchor empty — no persona/pinned text yet")
+            if memorize is not None:
+                memorize.cleanup()
         except Exception:
-            log.exception("[prepare] failed to set Grasp static anchor")
+            log.exception("[prepare] post-login memory cleanup failed")
 
-    # Playbook seeding — user-scoped playbook definitions under USER_SPACE_ROOT/<uid>/.
-    try:
-        from agentic.graph_engine import ensure_playbooks
-        ensure_playbooks(user_id=uid)
-    except Exception:
-        log.exception("[prepare] playbook seeding failed")
+        # Static anchor for Grasp relevance scoring — persona + pinned memories
+        # become the identity tokens that keep relevant turns resident longer in
+        # working memory (activates the previously-dead relevance factor).
+        if memorize is not None:
+            try:
+                texts: list[str] = []
+                try:
+                    texts.append(memorize.persona_context() or "")
+                except Exception:
+                    pass
+                try:
+                    for m in memorize.get_all():
+                        if m.get("pinned"):
+                            texts.append(m.get("memory") or m.get("text") or "")
+                except Exception:
+                    pass
+                from cognition.memory.grasp import build_anchor_tokens, set_static_anchor_tokens
+                anchor = build_anchor_tokens(*texts)
+                if anchor:
+                    set_static_anchor_tokens(anchor)
+                    log.info("[prepare] Grasp static anchor set (%d tokens)", len(anchor))
+                else:
+                    log.info("[prepare] Grasp static anchor empty — no persona/pinned text yet")
+            except Exception:
+                log.exception("[prepare] failed to set Grasp static anchor")
 
-    # Social schedule jobs (Threads/Bluesky/X/…) + knowledge-folder watcher —
-    # seeded per user only after we know who they are.
-    try:
-        from system.schedule import bootstrap_non_system_jobs
-        bootstrap_non_system_jobs(think=think, memorize=memorize)
-    except Exception:
-        log.exception("[prepare] schedule job bootstrap failed")
+        # Playbook seeding — user-scoped playbook definitions under USER_SPACE_ROOT/<uid>/.
+        try:
+            from agentic.graph_engine import ensure_playbooks
+            ensure_playbooks(user_id=uid)
+        except Exception:
+            log.exception("[prepare] playbook seeding failed")
 
-    log.info("[prepare] post-auth initialization complete for %s", uid)
+        # Social schedule jobs (Threads/Bluesky/X/…) + knowledge-folder watcher —
+        # seeded per user only after we know who they are.
+        try:
+            from system.schedule import bootstrap_non_system_jobs
+            bootstrap_non_system_jobs(think=think, memorize=memorize)
+        except Exception:
+            log.exception("[prepare] schedule job bootstrap failed")
+
+        log.info("[prepare] post-auth initialization complete for %s", uid)
+    finally:
+        reset_current_display_name(display_token)
+        reset_current_user_id(user_token)

--- a/system/schedule.py
+++ b/system/schedule.py
@@ -82,6 +82,7 @@ import json
 import os
 import threading
 import uuid
+from contextlib import contextmanager
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -100,6 +101,25 @@ from system.userspace import (
 log = get_logger(__name__)
 
 _knowledge_folder_watcher = None  # KnowledgeFolderWatcher instance (lazy)
+
+
+@contextmanager
+def _scheduler_run_lock(user_id: str, name: str):
+    """Serialize one scheduler stream across processes sharing user state."""
+    path = user_state_path(f".locks/scheduler-{name}.lock", user_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError:
+        os.close(fd)
+        yield False
+        return
+    try:
+        yield True
+    finally:
+        fcntl.flock(fd, fcntl.LOCK_UN)
+        os.close(fd)
 
 def workspace_root() -> Path:
     """Resolve the active user workspace root lazily."""
@@ -1434,6 +1454,7 @@ class ScheduleRunner:
         self._wakeup               = threading.Event()
         self._stop                 = threading.Event()
         self._thread: threading.Thread | None = None
+        self._catchup_lock          = threading.Lock()
 
         # calculated once at startup, updated after each fire
         self._next_daily   = _next_daily_reflect_and_dream()
@@ -1560,7 +1581,7 @@ class ScheduleRunner:
         self._catchup_dates = self._missing_reflection_dates()
         self._monthly_catchup_needed_flag = self._monthly_catchup_needed()
 
-        if self._catchup_dates and self._memorize and self._generate_and_post_fn:
+        if self._owner_promoted.is_set() and self._catchup_dates and self._memorize and self._generate_and_post_fn:
             log.info(
                 "Scheduler: running %d missed daily reflect+dream job(s) after owner resolution.",
                 len(self._catchup_dates),
@@ -1742,14 +1763,29 @@ class ScheduleRunner:
         belt-and-suspenders check against any window between the pop and
         the fire).
         """
-        while self._catchup_dates:
-            try:
-                date = self._catchup_dates.pop(0)
-            except IndexError:
-                break
-            if _reflection_post_exists(date):
-                continue
-            self._run_daily_reflect_and_dream(for_date=date)
+        if not self._catchup_lock.acquire(blocking=False):
+            log.info("Scheduler: daily catch-up already running — skipping duplicate worker.")
+            return
+        try:
+            while self._catchup_dates:
+                try:
+                    date = self._catchup_dates.pop(0)
+                except IndexError:
+                    break
+                with AIKO_BUSY_LOCK:
+                    uid = self._resolve_owner()
+                    if not uid or uid == "guest":
+                        return
+                    token = set_current_user_id(uid)
+                    try:
+                        self.set_user(uid)
+                        if self._memorize is not None:
+                            self._memorize.switch_user(uid)
+                        self._run_daily_reflect_and_dream(for_date=date)
+                    finally:
+                        reset_current_user_id(token)
+        finally:
+            self._catchup_lock.release()
 
     def _run_daily_reflect_and_dream(self, for_date: datetime | None = None) -> None:
         """
@@ -1819,33 +1855,43 @@ class ScheduleRunner:
                     target_local.strftime("%Y-%m-%d"),
                 )
                 return
+            try:
+                # Re-check after taking the lock. A catch-up worker and the
+                # midnight runner can both observe a missing post before one
+                # of them acquires the per-date lock.
+                already_reflected = _reflection_post_exists(target_local)
+                if already_reflected:
+                    log.info("daily_reflect_and_dream: reflection already exists for %s — skipping post.", target_local.date())
+                else:
+                    from cognition.consolidate.reflect import REFLECT_MAX_MEMS, filter_reflect_snippets
+                    memories = self._memorize.get_between(
+                        query_start, query_end, user_id=self._memorize.get_user_id()
+                    )
+                    memories = filter_reflect_snippets(memories, target_local)
+                    reflect_result = self._generate_and_post_fn(
+                        memories[:REFLECT_MAX_MEMS],
+                        date=target_local,
+                        memorize=self._memorize,
+                        display_name=self._memorize.get_display_name() if self._memorize else None,
+                    )
+                    if isinstance(reflect_result, dict) and not reflect_result.get("success", False):
+                        log.error(
+                            "daily_reflect_and_dream: reflect FAILED for %s — error=%s",
+                            target_local.date(), reflect_result.get("error", "unknown"),
+                        )
+                    else:
+                        log.info(
+                            "daily_reflect_and_dream: reflect done for %s — %s",
+                            target_local.date(), reflect_result,
+                        )
 
-            from cognition.consolidate.reflect import REFLECT_MAX_MEMS, filter_reflect_snippets
-            memories = self._memorize.get_between(
-                query_start, query_end, user_id=self._memorize.get_user_id()
-            )
-            memories = filter_reflect_snippets(memories, target_local)
-            reflect_result = self._generate_and_post_fn(
-                memories[:REFLECT_MAX_MEMS],
-                date=target_local,
-                memorize=self._memorize,
-                display_name=self._memorize.get_display_name() if self._memorize else None,
-            )
-            if isinstance(reflect_result, dict) and not reflect_result.get("success", False):
-                log.error(
-                    "daily_reflect_and_dream: reflect FAILED for %s — error=%s",
-                    target_local.date(), reflect_result.get("error", "unknown"),
-                )
-            else:
-                log.info(
-                    "daily_reflect_and_dream: reflect done for %s — %s",
-                    target_local.date(), reflect_result,
-                )
-
-            if for_date is None:
-                log.info("daily_reflect_and_dream: running dream...")
-                result = self._memorize.dream()
-                log.info("daily_reflect_and_dream: dream done — %s", result)
+                if for_date is None:
+                    log.info("daily_reflect_and_dream: running dream...")
+                    result = self._memorize.dream()
+                    log.info("daily_reflect_and_dream: dream done — %s", result)
+            finally:
+                fcntl.flock(lock_fd, fcntl.LOCK_UN)
+                os.close(lock_fd)
 
         except Exception as e:
             log.error("daily_reflect_and_dream failed: %s", e)
@@ -1930,6 +1976,16 @@ class ScheduleRunner:
         return False
 
     def _fire_due_user_jobs(self, user_id: str | None = None) -> None:
+        user_id = user_id or self._user_id
+        with _scheduler_run_lock(user_id, "jobs") as acquired:
+            if not acquired:
+                return
+            # A second process may have advanced next_due while this runner
+            # waited for the lock, so discard its in-process JSON cache.
+            _invalidate_cache(user_id)
+            self._fire_due_user_jobs_locked(user_id)
+
+    def _fire_due_user_jobs_locked(self, user_id: str) -> None:
         """Find due user jobs, reschedule recurring ones, disable one-shots.
 
         Jobs whose "handler" (or legacy "kind": "system_weekly_social") names
@@ -1940,7 +1996,6 @@ class ScheduleRunner:
         _run() now always passes it explicitly right after set_user(uid),
         so callers should not rely on the implicit fallback going forward.
         """
-        user_id = user_id or self._user_id
         jobs = _read_all(user_id=user_id)
         changed = False
         due_events: list[DueJob] = []
@@ -2013,6 +2068,13 @@ class ScheduleRunner:
 
     def _fire_due_schedule_graphs(self, user_id: str | None = None) -> None:
         user_id = user_id or self._user_id
+        with _scheduler_run_lock(user_id, "graphs") as acquired:
+            if not acquired:
+                return
+            _invalidate_graphs_cache(user_id)
+            self._fire_due_schedule_graphs_locked(user_id)
+
+    def _fire_due_schedule_graphs_locked(self, user_id: str) -> None:
         graphs = _read_schedule_graphs(user_id=user_id)
         changed = False
         now = bioclock.local_now()

--- a/system/schedule.py
+++ b/system/schedule.py
@@ -1842,7 +1842,7 @@ class ScheduleRunner:
             # per date wins; losers skip instead of double-posting.
             lock_path = user_state_path(
                 f".locks/reflect-{target_local.strftime('%Y-%m-%d')}.lock",
-                self._memorize.get_user_id(),
+                self._owner_user_id,
             )
             lock_path.parent.mkdir(parents=True, exist_ok=True)
             lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)

--- a/tests/unit/test_schedule_races.py
+++ b/tests/unit/test_schedule_races.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import ModuleType
+import sys
+
+
+class _Memorize:
+    def __init__(self) -> None:
+        self.user_id = "github_alice"
+
+    def get_user_id(self) -> str:
+        return self.user_id
+
+    def get_display_name(self) -> str:
+        return "Alice"
+
+    def get_between(self, *_args, **_kwargs):
+        return []
+
+
+def test_daily_reflection_rechecks_existence_after_lock(monkeypatch, tmp_path):
+    """A second runner sees the post produced by the first after locking."""
+    import system.schedule as schedule
+
+    monkeypatch.setenv("USER_SPACE_ROOT", str(tmp_path))
+    exists = {"value": False}
+    posted = []
+    monkeypatch.setattr(schedule, "_reflection_post_exists", lambda _date: exists["value"])
+    reflect = ModuleType("cognition.consolidate.reflect")
+    reflect.REFLECT_MAX_MEMS = 10
+    reflect.filter_reflect_snippets = lambda memories, _date: memories
+    monkeypatch.setitem(sys.modules, "cognition.consolidate.reflect", reflect)
+
+    def post(*_args, **_kwargs):
+        posted.append(True)
+        exists["value"] = True
+        return {"success": True}
+
+    runner = schedule.ScheduleRunner(
+        memorize=_Memorize(),
+        generate_and_post_fn=post,
+        user_id="github_alice",
+    )
+    target = datetime(2026, 8, 25, tzinfo=timezone.utc)
+    runner._run_daily_reflect_and_dream(for_date=target)
+    runner._run_daily_reflect_and_dream(for_date=target)
+
+    assert posted == [True]
+
+
+def test_scheduler_lock_is_released_after_critical_section(monkeypatch, tmp_path):
+    import system.schedule as schedule
+
+    monkeypatch.setenv("USER_SPACE_ROOT", str(tmp_path))
+    with schedule._scheduler_run_lock("github_alice", "jobs") as acquired:
+        assert acquired
+        with schedule._scheduler_run_lock("github_alice", "jobs") as contender:
+            assert not contender
+    with schedule._scheduler_run_lock("github_alice", "jobs") as acquired_after_release:
+        assert acquired_after_release

--- a/tests/unit/test_webui_user_context.py
+++ b/tests/unit/test_webui_user_context.py
@@ -7,6 +7,7 @@ import pytest
 
 from interface.webui.webui import AikoWeb
 from interface.webui.studio.session_binding import _relative_path
+from system.prepare import run_post_auth
 from system.userspace import current_display_name, current_user_id, reset_current_display_name, reset_current_user_id
 
 
@@ -88,3 +89,29 @@ def test_studio_api_path_is_relative_to_its_mount():
         "root_path": "/studio/memory/ltm",
     }) == "/api/graph"
     assert _relative_path({"path": "/api/graph", "root_path": ""}) == "/api/graph"
+
+
+def test_post_auth_binds_memory_to_logged_in_user():
+    class Memorize:
+        def __init__(self):
+            self.switched_to = []
+            self.cleanup_user = None
+
+        def switch_user(self, uid):
+            self.switched_to.append(uid)
+
+        def cleanup(self):
+            self.cleanup_user = current_user_id()
+
+        def persona_context(self):
+            return ""
+
+        def get_all(self):
+            return []
+
+    memorize = Memorize()
+    run_post_auth("github_alice", memorize=memorize)
+
+    assert memorize.switched_to == ["github_alice"]
+    assert memorize.cleanup_user == "github_alice"
+    assert current_user_id() == "guest"

--- a/tests/unit/test_webui_user_context.py
+++ b/tests/unit/test_webui_user_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import os
 import queue
+import threading
 
 import pytest
 
@@ -115,3 +116,83 @@ def test_post_auth_binds_memory_to_logged_in_user():
     assert memorize.switched_to == ["github_alice"]
     assert memorize.cleanup_user == "github_alice"
     assert current_user_id() == "guest"
+
+
+def test_concurrent_user_active_calls_run_post_auth_once(monkeypatch):
+    """Two concurrent _on_user_active calls for the same user should only run post-auth once."""
+    class Memorize:
+        def __init__(self):
+            self.switch_calls = []
+            self.cleanup_calls = 0
+
+        def switch_user(self, uid):
+            self.switch_calls.append(uid)
+
+        def cleanup(self):
+            self.cleanup_calls += 1
+
+        def persona_context(self):
+            return ""
+
+        def get_all(self):
+            return []
+
+    memorize = Memorize()
+    from system.wakeup import BootResult
+    boot_result = BootResult(memorize=memorize, think=None, speak=None, perceive=None, observe=None, navigate=None)
+    web = AikoWeb(boot_result=boot_result, defer_servers=True)
+
+    barrier = threading.Barrier(2)
+    def active_with_barrier(uid):
+        barrier.wait()
+        web._on_user_active(uid)
+
+    t1 = threading.Thread(target=active_with_barrier, args=("github_alice",))
+    t2 = threading.Thread(target=active_with_barrier, args=("github_alice",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert memorize.switch_calls == ["github_alice"]
+    assert memorize.cleanup_calls == 1
+
+
+def test_concurrent_user_active_different_users(monkeypatch):
+    """Two concurrent _on_user_active calls for different users should both run post-auth."""
+    class Memorize:
+        def __init__(self):
+            self.switch_calls = []
+            self.cleanup_calls = 0
+
+        def switch_user(self, uid):
+            self.switch_calls.append(uid)
+
+        def cleanup(self):
+            self.cleanup_calls += 1
+
+        def persona_context(self):
+            return ""
+
+        def get_all(self):
+            return []
+
+    memorize = Memorize()
+    from system.wakeup import BootResult
+    boot_result = BootResult(memorize=memorize, think=None, speak=None, perceive=None, observe=None, navigate=None)
+    web = AikoWeb(boot_result=boot_result, defer_servers=True)
+
+    barrier = threading.Barrier(2)
+    def active_with_barrier(uid):
+        barrier.wait()
+        web._on_user_active(uid)
+
+    t1 = threading.Thread(target=active_with_barrier, args=("github_alice",))
+    t2 = threading.Thread(target=active_with_barrier, args=("github_bob",))
+    t1.start()
+    t2.start()
+    t1.join()
+    t2.join()
+
+    assert set(memorize.switch_calls) == {"github_alice", "github_bob"}
+    assert memorize.cleanup_calls == 2

--- a/tests/unit/test_webui_user_context.py
+++ b/tests/unit/test_webui_user_context.py
@@ -6,6 +6,7 @@ import queue
 import pytest
 
 from interface.webui.webui import AikoWeb
+from interface.webui.studio.session_binding import _relative_path
 from system.userspace import current_display_name, current_user_id, reset_current_display_name, reset_current_user_id
 
 
@@ -78,3 +79,12 @@ def test_get_input_uses_queued_identity_not_shared_state(monkeypatch):
     assert web.get_input() == "hello"
     assert current_user_id() == "bob"
     assert current_display_name() == "Bobby"
+
+
+def test_studio_api_path_is_relative_to_its_mount():
+    """Mounted studio middleware must recognize its /api routes."""
+    assert _relative_path({
+        "path": "/studio/memory/ltm/api/graph",
+        "root_path": "/studio/memory/ltm",
+    }) == "/api/graph"
+    assert _relative_path({"path": "/api/graph", "root_path": ""}) == "/api/graph"


### PR DESCRIPTION
### Motivation
- Studio sub-apps were resolving user identity from query params, env fallbacks, or guest sentinel which could show the wrong user's memory/approval data in the WebUI.
- The goal is to ensure every studio API request uses the authenticated session identity so data shown always belongs to the logged-in user.

### Description
- Make the session identity authoritative for studio API routes by documenting the policy in `bind_login_session()` and ensuring middleware is the only identity source for `/api/*` requests.
- LTM: cache `AikoMemorize` instances per authenticated user and change `_get_memorize` to accept a `user_id` and `switch_user(user_id)` on construction so the in-process facade always binds to the correct physical DB (`interface/webui/studio/memory/ltm/backend/api.py`).
- ITM: create one `EpisodicStore` per user and stop honoring caller-supplied `user_id` parameters by resolving identity from `current_user_id()` only (`interface/webui/studio/memory/itm/backend/api.py`).
- KB & Approval: stop accepting or exposing `user_id` parameters on studio endpoints and use the session-bound identity for graph/draft lookups (`interface/webui/studio/memory/kb/backend/api.py`, `interface/webui/studio/approval/backend/api.py`).
- UI: remove the misleading `user-id` input controls and stop sending `user_id` from the LTM/ITM frontend scripts so the client cannot request another user's store (`interface/webui/studio/memory/ltm/frontend/*`, `interface/webui/studio/memory/itm/frontend/*`).

### Testing
- Compiled the modified modules with `python -m compileall -q <files>` which succeeded.
- Ran `git diff --check` to ensure whitespace/checks and it passed.
- Ran unit test invocation `python -m pytest tests/unit/test_webui_user_context.py -q` but collection failed due to missing `numpy` in the environment (`ModuleNotFoundError: No module named 'numpy'`), so the test could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8efd260dec8329b35bfbbff5e38e0c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security & Access**
  * Studio memory and knowledge features now consistently use the authenticated session identity.
  * Removed URL-based user ID selection to prevent cross-account data access.
  * Data stores and memory services are isolated per signed-in user.
  * Mounted Studio APIs now bind sessions correctly after login.

* **UI Improvements**
  * Removed obsolete User ID filters and updated requests to use the active session.

* **Bug Fixes**
  * Prevented duplicate scheduled daily reflections and improved job coordination across processes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->