### PR TITLE
Make LLM and vision API keys configurable via YAML

### DIFF
--- a/agentic/toolkit/social.py
+++ b/agentic/toolkit/social.py
@@ -274,7 +274,7 @@ def _require_approved(draft_dir: Path) -> None:
 # photo caption-selection prompt).
 LLM_MODEL = os.getenv("REFLECT_MODEL", os.getenv("LLM_MODEL", "ministral"))
 LLM_BASE_URL = os.getenv("LLM_BASE_URL", "http://localhost:8080/v1")
-_LLM_CLIENT = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed")
+_LLM_CLIENT = OpenAI(base_url=LLM_BASE_URL, api_key=os.getenv("LLM_API_KEY", "") or "not-needed")
 
 
 # Lane A1 — Patreon dev-post syndication
@@ -744,7 +744,10 @@ MAX_CAPTION_CHARS = _int_env("PHOTO_SOCIAL_MAX_CHARS", 260)
 # the text-only Ministral endpoint used for selection.
 VISION_MODEL = os.getenv("VISION_MODEL", os.getenv("REFLECT_VISION_MODEL", "minicpm-v"))
 VISION_BASE_URL = os.getenv("VISION_BASE_URL", os.getenv("LLM_BASE_URL", "http://localhost:8080/v1"))
-_VISION_CLIENT = OpenAI(base_url=VISION_BASE_URL, api_key="not-needed")
+_VISION_CLIENT = OpenAI(
+    base_url=VISION_BASE_URL,
+    api_key=os.getenv("VISION_API_KEY", "") or os.getenv("LLM_API_KEY", "") or "not-needed",
+)
 
 _CAPTION_PROMPT = (
     "Describe this image in one plain, factual sentence. No hashtags, no "

--- a/agentic/workflows/owner_email/toolset.py
+++ b/agentic/workflows/owner_email/toolset.py
@@ -234,7 +234,7 @@ def reply_owner_email(report_json: str = "", *, state=None) -> str:
                 import os as _os
                 base = _os.getenv("LLM_BASE_URL", "http://127.0.0.1:11434/v1")
                 model = _os.getenv("LLM_MODEL", "qwen2.5:7b")
-                client = OpenAI(base_url=base, api_key="not-needed")
+                client = OpenAI(base_url=base, api_key=_os.getenv("LLM_API_KEY", "") or "not-needed")
                 resp = client.chat.completions.create(
                     model=model,
                     messages=[{"role": "user", "content": prompt}],

--- a/cognition/consolidate/dream.py
+++ b/cognition/consolidate/dream.py
@@ -32,7 +32,7 @@ _LLM_CLIENT: OpenAI | None = None
 def _get_llm_client() -> OpenAI:
     global _LLM_CLIENT
     if _LLM_CLIENT is None:
-        _LLM_CLIENT = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed")
+        _LLM_CLIENT = OpenAI(base_url=LLM_BASE_URL, api_key=os.getenv("LLM_API_KEY", "") or "not-needed")
     return _LLM_CLIENT
 
 GITHUB_TOKEN      = os.getenv("GITHUB_TOKEN", "")

--- a/cognition/consolidate/reflect.py
+++ b/cognition/consolidate/reflect.py
@@ -32,7 +32,7 @@ _LLM_CLIENT: OpenAI | None = None
 def _get_llm_client() -> OpenAI:
     global _LLM_CLIENT
     if _LLM_CLIENT is None:
-        _LLM_CLIENT = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed")
+        _LLM_CLIENT = OpenAI(base_url=LLM_BASE_URL, api_key=os.getenv("LLM_API_KEY", "") or "not-needed")
     return _LLM_CLIENT
 
 SOUL_PATH         = os.path.expanduser(os.getenv("SOUL_PATH", "persona/SOUL.md"))

--- a/cognition/consolidate/schema.py
+++ b/cognition/consolidate/schema.py
@@ -82,7 +82,7 @@ _LLM_CLIENT: OpenAI | None = None
 def _get_llm_client() -> OpenAI:
     global _LLM_CLIENT
     if _LLM_CLIENT is None:
-        _LLM_CLIENT = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed", timeout=CONSOLIDATION_LLM_TIMEOUT)
+        _LLM_CLIENT = OpenAI(base_url=LLM_BASE_URL, api_key=os.getenv("LLM_API_KEY", "") or "not-needed", timeout=CONSOLIDATION_LLM_TIMEOUT)
     return _LLM_CLIENT
 
 

--- a/cognition/memory/memorize.py
+++ b/cognition/memory/memorize.py
@@ -244,7 +244,7 @@ class _MemoryBackend:
         self._user_id  = user_id or current_user_id()   # CHANGED
         self._llm_base = llm_base_url.rstrip("/")
         self._model    = model
-        self._client   = OpenAI(base_url=self._llm_base, api_key="not-needed")
+        self._client   = OpenAI(base_url=self._llm_base, api_key=os.getenv("LLM_API_KEY", "") or "not-needed")
         # Reuse the owner's shared embedder when given (keeps its TTL cache
         # warm and avoids re-reading the disk cache on every user switch);
         # standalone construction still works via embed_cache.

--- a/cognition/think.py
+++ b/cognition/think.py
@@ -439,7 +439,7 @@ def _extract_search_results_block(system_prompt: str) -> str:
 
 class AikoThink:
     def __init__(self) -> None:
-        self._client    = OpenAI(base_url=LLM_BASE_URL, api_key="not-needed")
+        self._client    = OpenAI(base_url=LLM_BASE_URL, api_key=os.getenv("LLM_API_KEY", "") or "not-needed")
         self._llm_model = LLM_MODEL
         self._router_model = ROUTER_MODEL
         self._memorize  = None    # injected later via set_memorize() — see system/wakeup.py

--- a/config/cognition.yaml
+++ b/config/cognition.yaml
@@ -8,6 +8,11 @@ LLM_BASE_URL: "http://localhost:8080/v1"  # OpenAI-compatible chat endpoint, usu
 LLM_MODEL: "ministral"  # Main chat model id/alias; must match the server model name.
 REFLECT_MODEL: "ministral"  # Model used for reflection/consolidation; often same as LLM_MODEL.
 LLM_TIMEOUT: "120"  # Seconds before chat/reflection LLM HTTP calls time out.
+# API key passed to every text LLM request. Leave blank for unauthenticated local
+# servers (Aiko supplies the harmless OpenAI-client placeholder automatically).
+# To use AISA Fable, set this to your AISA key, then set LLM_BASE_URL and
+# LLM_MODEL to the endpoint and exact model ID shown in AISA's documentation.
+LLM_API_KEY: ""
 
 # -- WebUI camera vision --
 # The camera button sends one in-memory JPEG to this OpenAI-compatible vision
@@ -15,6 +20,9 @@ LLM_TIMEOUT: "120"  # Seconds before chat/reflection LLM HTTP calls time out.
 WEBUI_VISION_MODEL: "minicpm-v"
 WEBUI_VISION_BASE_URL: ""
 WEBUI_VISION_TIMEOUT: "60"
+# Optional override for vision requests; blank falls back to LLM_API_KEY, then
+# the unauthenticated local-server placeholder.
+VISION_API_KEY: ""
 
 # -- Token budgets --
 LLM_MAX_TOKENS: "280"  # Base max tokens for normal chat replies.

--- a/interface/mcp_server/social/services/bluesky.py
+++ b/interface/mcp_server/social/services/bluesky.py
@@ -109,7 +109,7 @@ def _get_llm() -> OpenAI:
     global _LLM_CLIENT
     if _LLM_CLIENT is None:
         _LLM_CLIENT = OpenAI(
-            base_url=env("LLM_BASE_URL", "http://localhost:8080/v1"), api_key="not-needed"
+            base_url=env("LLM_BASE_URL", "http://localhost:8080/v1"), api_key=env("LLM_API_KEY", "") or "not-needed"
         )
     return _LLM_CLIENT
 

--- a/interface/mcp_server/social/services/mastodon.py
+++ b/interface/mcp_server/social/services/mastodon.py
@@ -135,7 +135,7 @@ def _get_llm():
         return None
     if _LLM_CLIENT is None:
         _LLM_CLIENT = OpenAI(
-            base_url=env("LLM_BASE_URL", "http://localhost:8080/v1"), api_key="not-needed"
+            base_url=env("LLM_BASE_URL", "http://localhost:8080/v1"), api_key=env("LLM_API_KEY", "") or "not-needed"
         )
     return _LLM_CLIENT
 

--- a/interface/mcp_server/social/services/threads.py
+++ b/interface/mcp_server/social/services/threads.py
@@ -217,7 +217,7 @@ def _get_llm_client() -> OpenAI:
     if _LLM_CLIENT is None:
         _LLM_CLIENT = OpenAI(
             base_url=env("LLM_BASE_URL", "http://localhost:8080/v1"),
-            api_key="not-needed",
+            api_key=env("LLM_API_KEY", "") or "not-needed",
         )
     return _LLM_CLIENT
 
@@ -227,7 +227,7 @@ def _get_vision_client() -> OpenAI:
     if _VISION_CLIENT is None:
         _VISION_CLIENT = OpenAI(
             base_url=env("VISION_BASE_URL", env("LLM_BASE_URL", "http://localhost:8080/v1")),
-            api_key="not-needed",
+            api_key=env("VISION_API_KEY", "") or env("LLM_API_KEY", "") or "not-needed",
         )
     return _VISION_CLIENT
 

--- a/interface/webui/webui.py
+++ b/interface/webui/webui.py
@@ -562,7 +562,7 @@ class AikoWeb:
         base_url = _vision_base_url()
         timeout = float(os.getenv("WEBUI_VISION_TIMEOUT", "60"))
         instruction = question or "Describe what you see in this camera image clearly and helpfully."
-        response = OpenAI(base_url=base_url, api_key=os.getenv("OPENAI_API_KEY", "not-needed")).chat.completions.create(
+        response = OpenAI(base_url=base_url, api_key=os.getenv("VISION_API_KEY", "") or os.getenv("LLM_API_KEY", "") or "not-needed").chat.completions.create(
             model=model,
             messages=[{"role": "user", "content": [
                 {"type": "text", "text": instruction[:1000]},

--- a/interface/webui/webui.py
+++ b/interface/webui/webui.py
@@ -562,7 +562,7 @@ class AikoWeb:
         base_url = _vision_base_url()
         timeout = float(os.getenv("WEBUI_VISION_TIMEOUT", "60"))
         instruction = question or "Describe what you see in this camera image clearly and helpfully."
-        response = OpenAI(base_url=base_url, api_key=os.getenv("VISION_API_KEY", "") or os.getenv("LLM_API_KEY", "") or "not-needed").chat.completions.create(
+        response = OpenAI(base_url=base_url, api_key=os.getenv("VISION_API_KEY", "") or os.getenv("LLM_API_KEY", "") or os.getenv("OPENAI_API_KEY", "") or "not-needed").chat.completions.create(
             model=model,
             messages=[{"role": "user", "content": [
                 {"type": "text", "text": instruction[:1000]},

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -477,3 +477,11 @@ class TestLoadConfigCaching:
         assert config_module._LOADED is False
         load_config()
         assert config_module._LOADED is True
+
+
+def test_cognition_config_exposes_blank_llm_api_key_defaults():
+    """Local OpenAI-compatible servers do not need credentials by default."""
+    cognition = load_yaml("cognition.yaml")
+
+    assert cognition["LLM_API_KEY"] == ""
+    assert cognition["VISION_API_KEY"] == ""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -37,6 +37,7 @@ from system.config import (
     _stringify,
     _strip_comment,
     load_config,
+    load_yaml,
 )
 
 

--- a/util/test_job_alerts.py
+++ b/util/test_job_alerts.py
@@ -180,7 +180,7 @@ def run_pipeline_steps(args) -> int:
         import os
         from openai import OpenAI
         llm_base_url = os.getenv("LLM_BASE_URL", "http://localhost:8080/v1")
-        llm_client = OpenAI(base_url=llm_base_url, api_key="not-needed")
+        llm_client = OpenAI(base_url=llm_base_url, api_key=os.getenv("LLM_API_KEY", "") or "not-needed")
         # Try to get model name from server
         try:
             models = llm_client.models.list()


### PR DESCRIPTION
### Motivation
- Centralize runtime LLM credentials so deployments can switch backends (e.g. AISA Fable) without editing source files.
- Keep unauthenticated local OpenAI-compatible servers working by default when no API key is provided.

### Description
- Added `LLM_API_KEY` and `VISION_API_KEY` keys to `config/cognition.yaml` (both default to an empty string) so credentials are tunable in YAML or via environment variables.
- Updated OpenAI-compatible client construction sites to read credentials from `LLM_API_KEY` and prefer `VISION_API_KEY` for vision calls, falling back to `LLM_API_KEY` then the local placeholder; examples include `cognition/think.py`, `cognition/memory/memorize.py`, `agentic/toolkit/social.py`, `cognition/consolidate/*`, `interface/mcp_server/social/services/*`, and `interface/webui/webui.py`.
- Added a unit assertion in `tests/unit/test_config.py` that the new YAML keys default to blank so local servers remain unauthenticated by default.
- No model or endpoint values were changed; to use AISA Fable 5.1 later, set `LLM_BASE_URL` and `LLM_MODEL` (and optionally `REFLECT_MODEL`) in `config/cognition.yaml` and place the AISA key in `LLM_API_KEY` (leave blank for local models).

### Testing
- Ran `python -m compileall -q cognition agentic interface util/test_job_alerts.py` and it completed successfully.
- Ran a smoke Python check that `config/cognition.yaml` exposes blank `LLM_API_KEY` and `VISION_API_KEY` and verified there are no remaining hard-coded `api_key="not-needed"` placeholders in production Python files; this check passed.
- Attempted `pytest tests/unit/test_config.py -q` but it could not run in this environment due to a missing runtime dependency (`numpy`), so full test suite was not executed here.
- Ran `git` operations to stage and commit the changes; commit message: `Make LLM API keys configurable`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a9b550440b0833287cb62cf3f1a526d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added separate configuration for text-generation and vision API keys.
  - Services now use the configured credentials when available, with support for local OpenAI-compatible servers that do not require authentication.
  - Vision requests support a dedicated key with fallback to the general language-model key.

- **Documentation**
  - Added configuration guidance and documented default credential behavior.

- **Tests**
  - Added coverage verifying the new API key settings default to blank values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->