### PR TITLE
Lingo: shared vocab pool + hourly spawn + Learn from unlearnt

### DIFF
--- a/interface/webui/lingo/__init__.py
+++ b/interface/webui/lingo/__init__.py
@@ -1,22 +1,14 @@
 """
 Lingo: Japanese conversation learning with spaced repetition.
 
-Main exports:
-- router: FastAPI router (include in your app)
-- LingoSRS: Spaced repetition scheduler (for testing/extensions)
-- VocabExtractor: Japanese -> vocabulary parser
-- MemoryBridge: vocab reviews -> Aiko long-term memory
-- ReviewGrade: Enum for SM-2 grades (0-4)
-
-Shared vocab content: interface/webui/lingo/vocab_pool.db (spawn.py)
-Per-user progress: USER_SPACE_ROOT/<uid>/agentic/lingo/vocab.db (srs.py)
+Shared vocab: interface/webui/lingo/vocab_pool.db
+Per-user progress: USER_SPACE_ROOT/<uid>/agentic/lingo/vocab.db
 """
 
 from .router import router
 from .srs import LingoSRS, ReviewGrade, LingoVocabCard, ReviewLog, init_srs_db
 from .vocab import VocabExtractor, MemoryBridge
 
-# Attach Learn API (shared pool → per-user progress) without rewriting router.py
 try:
     from .learn_api import attach_learn_routes
     from .router import get_lingo_session, _award_xp
@@ -25,11 +17,42 @@ except Exception:
     import logging
     logging.getLogger(__name__).warning("learn_api routes not attached", exc_info=True)
 
-# Hourly spawn handler + optional A+B startup warm (non-blocking)
 try:
     from .spawn import register_lingo_spawn_handler, warm_pools_on_startup, ensure_lingo_spawn_job
     register_lingo_spawn_handler(seed_jobs=False)
     warm_pools_on_startup()
+
+    # Post-login schedule bootstrap does not yet call ensure_lingo_spawn_job
+    # directly; wrap it so the hourly job is seeded with other user jobs.
+    def _wrap_bootstrap() -> None:
+        try:
+            from system import schedule as sched
+            if getattr(sched.bootstrap_non_system_jobs, "_lingo_spawn_wrapped", False):
+                return
+            _orig = sched.bootstrap_non_system_jobs
+
+            def _wrapped(*, think=None, memorize=None, timezone=None):
+                _orig(think=think, memorize=memorize, timezone=timezone)
+                try:
+                    uid = None
+                    if memorize is not None and hasattr(memorize, "get_user_id"):
+                        uid = memorize.get_user_id()
+                    ensure_lingo_spawn_job(timezone=timezone, user_id=uid)
+                except Exception:
+                    import logging
+                    logging.getLogger(__name__).exception(
+                        "Failed to seed lingo vocab spawn job"
+                    )
+
+            _wrapped._lingo_spawn_wrapped = True  # type: ignore[attr-defined]
+            sched.bootstrap_non_system_jobs = _wrapped  # type: ignore[assignment]
+        except Exception:
+            import logging
+            logging.getLogger(__name__).warning(
+                "Could not wrap schedule bootstrap for lingo spawn", exc_info=True
+            )
+
+    _wrap_bootstrap()
 except Exception:
     import logging
     logging.getLogger(__name__).warning("lingo spawn handler not registered", exc_info=True)
@@ -43,5 +66,4 @@ __all__ = [
     "init_srs_db",
     "VocabExtractor",
     "MemoryBridge",
-    "ensure_lingo_spawn_job",
 ]

--- a/interface/webui/lingo/__init__.py
+++ b/interface/webui/lingo/__init__.py
@@ -7,20 +7,41 @@ Main exports:
 - VocabExtractor: Japanese -> vocabulary parser
 - MemoryBridge: vocab reviews -> Aiko long-term memory
 - ReviewGrade: Enum for SM-2 grades (0-4)
+
+Shared vocab content: interface/webui/lingo/vocab_pool.db (spawn.py)
+Per-user progress: USER_SPACE_ROOT/<uid>/agentic/lingo/vocab.db (srs.py)
 """
 
 from .router import router
 from .srs import LingoSRS, ReviewGrade, LingoVocabCard, ReviewLog, init_srs_db
 from .vocab import VocabExtractor, MemoryBridge
 
-__version__ = "1.1.0"
+# Attach Learn API (shared pool → per-user progress) without rewriting router.py
+try:
+    from .learn_api import attach_learn_routes
+    from .router import get_lingo_session, _award_xp
+    attach_learn_routes(router, get_lingo_session, award_xp=_award_xp)
+except Exception:
+    import logging
+    logging.getLogger(__name__).warning("learn_api routes not attached", exc_info=True)
+
+# Hourly spawn handler + optional A+B startup warm (non-blocking)
+try:
+    from .spawn import register_lingo_spawn_handler, warm_pools_on_startup, ensure_lingo_spawn_job
+    register_lingo_spawn_handler(seed_jobs=False)
+    warm_pools_on_startup()
+except Exception:
+    import logging
+    logging.getLogger(__name__).warning("lingo spawn handler not registered", exc_info=True)
+
 __all__ = [
     "router",
     "LingoSRS",
-    "VocabExtractor",
-    "MemoryBridge",
     "ReviewGrade",
     "LingoVocabCard",
     "ReviewLog",
     "init_srs_db",
+    "VocabExtractor",
+    "MemoryBridge",
+    "ensure_lingo_spawn_job",
 ]

--- a/interface/webui/lingo/learn_api.py
+++ b/interface/webui/lingo/learn_api.py
@@ -1,16 +1,15 @@
 """
-Learn / Review helpers on top of the shared vocab pool + per-user SRS.
+Learn helpers on shared vocab pool + per-user SRS.
 
-Mounted onto the main lingo router from __init__.py so we do not rewrite
-router.py in this PR.
+Mutating routes require a real authenticated session (no owner fallback).
 """
 from __future__ import annotations
 
 import logging
 from typing import List, Optional
 
-from fastapi import Depends, HTTPException
-from pydantic import BaseModel, Field
+from fastapi import Depends, HTTPException, Request
+from pydantic import BaseModel, Field, field_validator
 
 from .srs import LingoSRS
 from . import spawn
@@ -20,8 +19,8 @@ log = logging.getLogger(__name__)
 
 class LearnItem(BaseModel):
     pool_id: Optional[int] = None
-    front: str
-    back: str
+    front: str = ""
+    back: str = ""
     reading: str = ""
     kind: str = "kanji"
 
@@ -34,10 +33,30 @@ class LearnSession(BaseModel):
 class MarkLearnedRequest(BaseModel):
     items: List[LearnItem] = Field(default_factory=list)
 
+    @field_validator("items")
+    @classmethod
+    def _cap_items(cls, v: list) -> list:
+        if len(v) > spawn.LEARN_SESSION_N:
+            return v[: spawn.LEARN_SESSION_N]
+        return v
+
 
 class MarkLearnedResponse(BaseModel):
     learned: int
     xp: int = 0
+
+
+async def require_lingo_user(request: Request) -> dict:
+    """Authenticated session only — no AIKO_USER_ID fallback (for mutating routes)."""
+    from interface.webui import auth
+    try:
+        session = await auth.require_session(request)
+        return await auth.require_accepted_session(session)
+    except HTTPException:
+        raise
+    except Exception as e:
+        log.warning("Lingo auth required failed: %s", e)
+        raise HTTPException(status_code=401, detail="Authentication required")
 
 
 def attach_learn_routes(router, get_lingo_session, award_xp=None):
@@ -47,24 +66,31 @@ def attach_learn_routes(router, get_lingo_session, award_xp=None):
     async def learn_new(session: dict = Depends(get_lingo_session)):
         """Unlearnt shared-pool items (no LLM wait). Caps at 10."""
         uid = session["user_id"]
-        # A+B: if pool is low, top up in background — never block the response
         if spawn.pool_count() < spawn.POOL_MIN:
             spawn.top_up_pool_background(level="beginner")
         items = spawn.pool_take_unlearned(uid, n=spawn.LEARN_SESSION_N)
+        unlearned_total = spawn.pool_count_unlearned(uid)
         return LearnSession(
             items=[LearnItem(**it) for it in items],
-            pending_in_pool=max(0, spawn.pool_count() - len(items)),
+            pending_in_pool=max(0, unlearned_total - len(items)),
         )
 
     @router.post("/learn/mark", response_model=MarkLearnedResponse)
-    async def learn_mark(body: MarkLearnedRequest, session: dict = Depends(get_lingo_session)):
-        """Mark items as learnt → copy into per-user SRS + small XP."""
+    async def learn_mark(
+        body: MarkLearnedRequest,
+        session: dict = Depends(require_lingo_user),
+    ):
+        """Mark pool items as learnt → SRS + XP. Requires real auth; uses pool_id only."""
         uid = session["user_id"]
-        n = spawn.mark_learned(uid, [it.model_dump() for it in body.items])
+        # Only pool_ids are trusted; client front/back are ignored in mark_learned
+        payload = [{"pool_id": it.pool_id} for it in body.items if it.pool_id is not None]
+        if not payload:
+            raise HTTPException(status_code=400, detail="Each item needs a valid pool_id")
+        n = spawn.mark_learned(uid, payload)
         xp_total = 0
         if award_xp and n:
             try:
-                xp_total = award_xp(uid, n * 5)  # 5 XP per newly learnt card
+                xp_total = award_xp(uid, n * 5)
             except Exception:
                 log.warning("XP award on learn_mark failed", exc_info=True)
         return MarkLearnedResponse(learned=n, xp=xp_total)
@@ -76,6 +102,7 @@ def attach_learn_routes(router, get_lingo_session, award_xp=None):
         stats = srs.get_stats()
         return {
             "pool_size": spawn.pool_count(),
+            "pool_unlearned": spawn.pool_count_unlearned(uid),
             "user_cards": stats.get("total_cards", 0),
             "reviews_today": stats.get("reviews_today", 0),
             "learned_today": stats.get("learned_today", 0),

--- a/interface/webui/lingo/learn_api.py
+++ b/interface/webui/lingo/learn_api.py
@@ -1,0 +1,84 @@
+"""
+Learn / Review helpers on top of the shared vocab pool + per-user SRS.
+
+Mounted onto the main lingo router from __init__.py so we do not rewrite
+router.py in this PR.
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+from fastapi import Depends, HTTPException
+from pydantic import BaseModel, Field
+
+from .srs import LingoSRS
+from . import spawn
+
+log = logging.getLogger(__name__)
+
+
+class LearnItem(BaseModel):
+    pool_id: Optional[int] = None
+    front: str
+    back: str
+    reading: str = ""
+    kind: str = "kanji"
+
+
+class LearnSession(BaseModel):
+    items: List[LearnItem]
+    pending_in_pool: int = 0
+
+
+class MarkLearnedRequest(BaseModel):
+    items: List[LearnItem] = Field(default_factory=list)
+
+
+class MarkLearnedResponse(BaseModel):
+    learned: int
+    xp: int = 0
+
+
+def attach_learn_routes(router, get_lingo_session, award_xp=None):
+    """Register /learn/* routes on an existing APIRouter."""
+
+    @router.get("/learn/new", response_model=LearnSession)
+    async def learn_new(session: dict = Depends(get_lingo_session)):
+        """Unlearnt shared-pool items (no LLM wait). Caps at 10."""
+        uid = session["user_id"]
+        # A+B: if pool is low, top up in background — never block the response
+        if spawn.pool_count() < spawn.POOL_MIN:
+            spawn.top_up_pool_background(level="beginner")
+        items = spawn.pool_take_unlearned(uid, n=spawn.LEARN_SESSION_N)
+        return LearnSession(
+            items=[LearnItem(**it) for it in items],
+            pending_in_pool=max(0, spawn.pool_count() - len(items)),
+        )
+
+    @router.post("/learn/mark", response_model=MarkLearnedResponse)
+    async def learn_mark(body: MarkLearnedRequest, session: dict = Depends(get_lingo_session)):
+        """Mark items as learnt → copy into per-user SRS + small XP."""
+        uid = session["user_id"]
+        n = spawn.mark_learned(uid, [it.model_dump() for it in body.items])
+        xp_total = 0
+        if award_xp and n:
+            try:
+                xp_total = award_xp(uid, n * 5)  # 5 XP per newly learnt card
+            except Exception:
+                log.warning("XP award on learn_mark failed", exc_info=True)
+        return MarkLearnedResponse(learned=n, xp=xp_total)
+
+    @router.get("/learn/status")
+    async def learn_status(session: dict = Depends(get_lingo_session)):
+        uid = session["user_id"]
+        srs = LingoSRS(uid)
+        stats = srs.get_stats()
+        return {
+            "pool_size": spawn.pool_count(),
+            "user_cards": stats.get("total_cards", 0),
+            "reviews_today": stats.get("reviews_today", 0),
+            "learned_today": stats.get("learned_today", 0),
+            "review_session_size": spawn.REVIEW_SESSION_N,
+            "learn_session_size": spawn.LEARN_SESSION_N,
+        }

--- a/interface/webui/lingo/lessons.py
+++ b/interface/webui/lingo/lessons.py
@@ -1,10 +1,8 @@
 """
 Lingo lesson decks (static curated content for Learn mode).
 
-Static kana decks stay here. AI / hourly-spawned mixed vocab lives in the
-SHARED package-local pool (see spawn.py → vocab_pool.db next to this file).
-Per-user learnt progress and SRS schedule live under
-USER_SPACE_ROOT/<uid>/agentic/lingo/vocab.db — not in the shared pool.
+Static kana decks stay here. Legacy words-phrases pool remains on the
+previous shared path when present, with package-local fallback.
 """
 from typing import Dict, List
 
@@ -59,21 +57,53 @@ def get_deck(deck_id: str) -> dict | None:
 
 
 # ---------------------------------------------------------------------------
-# Back-compat aliases used by older router helpers (_ensure_lesson_pool).
-# New code should import from .spawn instead.
+# Legacy lesson_pool for /lessons/words-phrases (router still uses this).
+# Prefer existing USER_SPACE_ROOT/_shared/agentic/lingo/lesson_pool.db so
+# prior data is not orphaned; fall back to package-local path.
 # ---------------------------------------------------------------------------
 import sqlite3 as _sqlite3
 import time as _time
 from pathlib import Path as _Path
 
-POOL_DB = _Path(__file__).parent / "lesson_pool.db"  # legacy name; spawn uses vocab_pool.db
+
+def _legacy_pool_db_path() -> _Path:
+    candidates = []
+    try:
+        from system.userspace import _user_state_root_value
+        shared = (
+            _Path(_user_state_root_value()).expanduser()
+            / "_shared" / "agentic" / "lingo" / "lesson_pool.db"
+        )
+        candidates.append(shared)
+    except Exception:
+        pass
+    candidates.append(_Path(__file__).parent / "lesson_pool.db")
+    for p in candidates:
+        if p.is_file():
+            return p
+    # Prefer shared path for new writes when userspace works
+    try:
+        from system.userspace import _user_state_root_value
+        p = (
+            _Path(_user_state_root_value()).expanduser()
+            / "_shared" / "agentic" / "lingo" / "lesson_pool.db"
+        )
+        p.parent.mkdir(parents=True, exist_ok=True)
+        return p
+    except Exception:
+        return _Path(__file__).parent / "lesson_pool.db"
+
+
+POOL_DB = _legacy_pool_db_path()
 POOL_MIN = 10
 POOL_TOPUP = 15
 POOL_SERVE_N = 10
 
 
 def _pool_conn():
-    con = _sqlite3.connect(POOL_DB)
+    path = _legacy_pool_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = _sqlite3.connect(path)
     con.execute(
         """CREATE TABLE IF NOT EXISTS lesson_pool (
             id INTEGER PRIMARY KEY AUTOINCREMENT,

--- a/interface/webui/lingo/lessons.py
+++ b/interface/webui/lingo/lessons.py
@@ -1,14 +1,13 @@
 """
 Lingo lesson decks (static curated content for Learn mode).
 
-Unlike SRS cards (auto-extracted from conversation into the per-user DB),
-these decks are fixed study material: kana charts, starter words, daily
-phrases, and N5 kanji. Served read-only via GET /lessons and
-GET /lessons/{deck_id} — no SRS writes, no auth side effects.
+Static kana decks stay here. AI / hourly-spawned mixed vocab lives in the
+SHARED package-local pool (see spawn.py → vocab_pool.db next to this file).
+Per-user learnt progress and SRS schedule live under
+USER_SPACE_ROOT/<uid>/agentic/lingo/vocab.db — not in the shared pool.
 """
 from typing import Dict, List
 
-# Each card: (front, back, reading). Reading feeds the app's speak button.
 _DECKS: Dict[str, dict] = {}
 
 
@@ -47,19 +46,7 @@ _kana_deck("katakana", "Katakana", "46 basic characters", [
 ])
 
 
-# ============================================================================
-# Pregenerated LLM word/phrase pool (SQLite-backed)
-# ============================================================================
-# The Words & Phrases deck is LLM-generated but NOT generated live per
-# request: a background-topped pool keeps N fresh items ready per level so
-# opens are instant and repeat visits rotate stock. Served items graduate
-# into the user's SRS queue (router does the insert at serve time).
-import sqlite3 as _sqlite3
-import time as _time
-from pathlib import Path as _Path
-
 def list_decks() -> List[dict]:
-    """Deck metadata without cards (for the lesson picker)."""
     return [
         {"id": d["id"], "title": d["title"], "subtitle": d["subtitle"],
          "kind": d["kind"], "card_count": len(d["cards"])}
@@ -68,29 +55,25 @@ def list_decks() -> List[dict]:
 
 
 def get_deck(deck_id: str) -> dict | None:
-    """Full deck with cards, or None for unknown ids."""
     return _DECKS.get(deck_id)
 
 
-def _pool_db_path() -> _Path:
-    """Shared pregen pool (not per-user) under USER_SPACE_ROOT/_shared/agentic/lingo/."""
-    try:
-        from system.userspace import _user_state_root_value
-        root = _Path(_user_state_root_value()).expanduser() / "_shared" / "agentic" / "lingo"
-    except Exception:
-        root = _Path(__file__).parent
-    root.mkdir(parents=True, exist_ok=True)
-    return root / "lesson_pool.db"
+# ---------------------------------------------------------------------------
+# Back-compat aliases used by older router helpers (_ensure_lesson_pool).
+# New code should import from .spawn instead.
+# ---------------------------------------------------------------------------
+import sqlite3 as _sqlite3
+import time as _time
+from pathlib import Path as _Path
 
-
-POOL_DB = _pool_db_path()  # resolved at import; directory created as needed
-POOL_MIN = 10      # top up when a level's pool drops below this
-POOL_TOPUP = 15    # fresh items generated per top-up
-POOL_SERVE_N = 10  # cards per deck open
+POOL_DB = _Path(__file__).parent / "lesson_pool.db"  # legacy name; spawn uses vocab_pool.db
+POOL_MIN = 10
+POOL_TOPUP = 15
+POOL_SERVE_N = 10
 
 
 def _pool_conn():
-    con = _sqlite3.connect(_pool_db_path())
+    con = _sqlite3.connect(POOL_DB)
     con.execute(
         """CREATE TABLE IF NOT EXISTS lesson_pool (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -115,7 +98,6 @@ def pool_count(level: str) -> int:
 
 
 def pool_add(words: list, level: str) -> int:
-    """Insert pregenerated words; duplicates ignored. Returns rows added."""
     con = _pool_conn()
     try:
         added = 0
@@ -138,7 +120,6 @@ def pool_add(words: list, level: str) -> int:
 
 
 def pool_take(level: str, n: int = POOL_SERVE_N) -> list:
-    """Take the least-used words for a level and bump their use counts."""
     con = _pool_conn()
     try:
         rows = con.execute(

--- a/interface/webui/lingo/spawn.py
+++ b/interface/webui/lingo/spawn.py
@@ -1,20 +1,8 @@
 """
 Shared Lingo vocab spawn pool + hourly scheduler handler.
 
-Architecture (single-user friendly, multi-user ready):
-
-  * Content (spawned JP + EN items) lives in a SHARED SQLite DB next to
-    this package: interface/webui/lingo/vocab_pool.db — every process can
-    read it; hourly job writes ~20 mixed items (hiragana / katakana /
-    kanji / phrase / sentence).
-
-  * Progress (learnt vs not, SM-2 schedule, review logs) stays per-user
-    under USER_SPACE_ROOT/<uid>/agentic/lingo/vocab.db via LingoSRS.
-
-  * XP / streaks stay in the existing per-user files (data/xp, data/streaks).
-
-Learn serves pool rows the user has not yet inserted into their SRS.
-Review serves the user's SRS due/learnt cards (cap 10).
+  * Content: interface/webui/lingo/vocab_pool.db (shared)
+  * Progress: USER_SPACE_ROOT/<uid>/agentic/lingo/vocab.db (per-user SRS)
 """
 from __future__ import annotations
 
@@ -37,6 +25,8 @@ REVIEW_SESSION_N = 10
 ITEM_KINDS = ("hiragana", "katakana", "kanji", "phrase", "sentence")
 
 _pool_lock = threading.Lock()
+_topup_inflight: set[str] = set()
+_inflight_lock = threading.Lock()
 
 
 def _conn() -> sqlite3.Connection:
@@ -58,6 +48,28 @@ def _conn() -> sqlite3.Connection:
     return con
 
 
+def pool_get(pool_id: int) -> Optional[dict]:
+    """Fetch one pool row by id, or None."""
+    con = _conn()
+    try:
+        row = con.execute(
+            "SELECT id, front, back, reading, kind, level FROM vocab_pool WHERE id = ?",
+            (int(pool_id),),
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "pool_id": row[0],
+            "front": row[1],
+            "back": row[2],
+            "reading": row[3],
+            "kind": row[4],
+            "level": row[5],
+        }
+    finally:
+        con.close()
+
+
 def pool_count(level: Optional[str] = None) -> int:
     con = _conn()
     try:
@@ -70,8 +82,53 @@ def pool_count(level: Optional[str] = None) -> int:
         con.close()
 
 
+def _learned_keys(uid: str) -> set[tuple[str, str]]:
+    keys: set[tuple[str, str]] = set()
+    try:
+        from .srs import LingoSRS
+        srs = LingoSRS(uid)
+        con_u = sqlite3.connect(str(srs.db_path))
+        try:
+            rows = con_u.execute(
+                "SELECT hiragana, meaning FROM lingo_vocab_cards WHERE user_id = ?",
+                (uid,),
+            ).fetchall()
+            keys = {(r[0] or "", r[1] or "") for r in rows}
+        finally:
+            con_u.close()
+    except Exception:
+        log.warning("Could not load user learnt set for %s", uid, exc_info=True)
+    return keys
+
+
+def _is_learned(front: str, back: str, reading: str, learned: set[tuple[str, str]]) -> bool:
+    return (reading or front, back) in learned or (front, back) in learned
+
+
+def pool_count_unlearned(uid: str, level: Optional[str] = None) -> int:
+    """Count pool rows not yet in this user's SRS (same match rules as take)."""
+    learned = _learned_keys(uid)
+    con = _conn()
+    try:
+        if level:
+            rows = con.execute(
+                "SELECT front, back, reading FROM vocab_pool WHERE level = ?",
+                (level,),
+            ).fetchall()
+        else:
+            rows = con.execute(
+                "SELECT front, back, reading FROM vocab_pool"
+            ).fetchall()
+        n = 0
+        for front, back, reading in rows:
+            if not _is_learned(front or "", back or "", reading or "", learned):
+                n += 1
+        return n
+    finally:
+        con.close()
+
+
 def pool_add(items: list, level: str = "beginner") -> int:
-    """Insert spawned items. Returns rows actually added."""
     con = _conn()
     added = 0
     try:
@@ -106,25 +163,7 @@ def pool_take_unlearned(
     n: int = LEARN_SESSION_N,
     level: Optional[str] = None,
 ) -> List[dict]:
-    """Return up to n pool items the user has not yet put in their SRS."""
-    learned_keys: set[tuple[str, str]] = set()
-    try:
-        from .srs import LingoSRS
-        srs = LingoSRS(uid)
-        # Lightweight: all meanings+hiragana the user already has
-        import sqlite3 as _sq
-        con_u = _sq.connect(str(srs.db_path))
-        try:
-            rows = con_u.execute(
-                "SELECT hiragana, meaning FROM lingo_vocab_cards WHERE user_id = ?",
-                (uid,),
-            ).fetchall()
-            learned_keys = {(r[0] or "", r[1] or "") for r in rows}
-        finally:
-            con_u.close()
-    except Exception:
-        log.warning("Could not load user learnt set for %s", uid, exc_info=True)
-
+    learned_keys = _learned_keys(uid)
     con = _conn()
     try:
         if level:
@@ -143,9 +182,7 @@ def pool_take_unlearned(
         taken_ids = []
         for row in candidates:
             pid, front, back, reading, kind = row
-            if (reading or front, back) in learned_keys:
-                continue
-            if (front, back) in learned_keys:
+            if _is_learned(front, back, reading or "", learned_keys):
                 continue
             out.append({
                 "pool_id": pid,
@@ -170,19 +207,25 @@ def pool_take_unlearned(
 
 
 def mark_learned(uid: str, items: List[dict]) -> int:
-    """Graduate pool items into the user's SRS (now Reviewable). Returns count."""
+    """Graduate pool items into user SRS. Resolves by pool_id only; counts new rows."""
     from .srs import LingoSRS, LingoVocabCard
     srs = LingoSRS(uid)
     n = 0
-    for it in items:
-        front = str(it.get("front") or "").strip()
-        back = str(it.get("back") or "").strip()
-        reading = str(it.get("reading") or front).strip()
-        kind = str(it.get("kind") or "kanji")
-        if not front or not back:
+    for it in items[:LEARN_SESSION_N]:
+        pool_id = it.get("pool_id")
+        if pool_id is None:
             continue
+        stored = pool_get(int(pool_id))
+        if not stored:
+            log.warning("mark_learned: unknown pool_id %s", pool_id)
+            continue
+        front = stored["front"]
+        back = stored["back"]
+        reading = stored["reading"] or front
+        kind = stored["kind"] or "kanji"
         try:
-            srs.add_card(LingoVocabCard(
+            before = srs.get_stats().get("total_cards", 0)
+            card = srs.add_card(LingoVocabCard(
                 kanji=front if kind in ("kanji", "phrase", "sentence") else "",
                 hiragana=reading,
                 meaning=back,
@@ -190,14 +233,21 @@ def mark_learned(uid: str, items: List[dict]) -> int:
                 context="spawn",
                 source_context="hourly_spawn",
             ))
-            n += 1
+            # Only count if this is a newly inserted row (new id and total grew),
+            # or if add_card returned a card that was just created (review_count 0
+            # and created this call). Safest: compare totals.
+            after = srs.get_stats().get("total_cards", 0)
+            if after > before:
+                n += 1
+            elif card and getattr(card, "id", None) and getattr(card, "review_count", 0) == 0:
+                # Existing unreviewed card — do not re-award XP
+                pass
         except Exception:
-            log.warning("mark_learned failed for %s", front, exc_info=True)
+            log.warning("mark_learned failed for pool_id=%s", pool_id, exc_info=True)
     return n
 
 
 def _llm_spawn_batch(count: int = SPAWN_BATCH, level: str = "beginner") -> List[dict]:
-    """Ask the tutor LLM for a mixed batch. Empty if brain offline."""
     try:
         from interface.webui import auth
         if not auth.aiko_web_instance or not auth.aiko_web_instance._think:
@@ -212,8 +262,6 @@ def _llm_spawn_batch(count: int = SPAWN_BATCH, level: str = "beginner") -> List[
                     f"Produce exactly {count} items for a {level} learner. "
                     f"Roughly {per} of each kind: hiragana, katakana, kanji, phrase, sentence. "
                     "Each item needs natural Japanese, hiragana reading, and a short English meaning. "
-                    "For hiragana/katakana kinds use only that script on the front. "
-                    "For sentences keep them short (under 20 characters Japanese). "
                     "Output ONLY valid JSON: "
                     '{"items":[{"kind":"kanji","japanese":"...","hiragana":"...","meaning":"..."}]}'
                 )},
@@ -247,7 +295,6 @@ def _llm_spawn_batch(count: int = SPAWN_BATCH, level: str = "beginner") -> List[
 
 
 def top_up_pool(level: str = "beginner", force: bool = False) -> int:
-    """If pool is low (or force), generate SPAWN_BATCH items into shared pool."""
     with _pool_lock:
         if not force and pool_count(level) >= POOL_MIN:
             return 0
@@ -258,15 +305,26 @@ def top_up_pool(level: str = "beginner", force: bool = False) -> int:
 
 
 def top_up_pool_background(level: str = "beginner") -> None:
-    threading.Thread(target=top_up_pool, args=(level,), daemon=True).start()
+    """One in-flight top-up per level — avoids thread pile-up under concurrent Learn."""
+    with _inflight_lock:
+        if level in _topup_inflight:
+            return
+        _topup_inflight.add(level)
+
+    def _run() -> None:
+        try:
+            top_up_pool(level=level)
+        finally:
+            with _inflight_lock:
+                _topup_inflight.discard(level)
+
+    threading.Thread(target=_run, daemon=True).start()
 
 
 def handle_lingo_spawn_vocab(memorize: Any = None) -> str:
-    """Scheduler handler: spawn ~20 mixed items into the shared pool."""
     levels = ("beginner", "intermediate", "advanced")
     total = 0
     for level in levels:
-        # One batch per level keeps intermediate/advanced stocked too
         try:
             total += top_up_pool(level=level, force=False)
         except Exception:
@@ -280,7 +338,6 @@ LINGO_SPAWN_JOB_TITLE = "lingo_vocab_spawn"
 
 
 def ensure_lingo_spawn_job(timezone: str | None = None, user_id: str | None = None) -> None:
-    """Idempotently seed hourly shared-pool top-up in schedule.json."""
     try:
         from system import schedule as sched
         existing = {job.get("title") for job in sched._read_all(user_id=user_id)}
@@ -313,7 +370,6 @@ def register_lingo_spawn_handler(seed_jobs: bool = False, timezone: str | None =
 
 
 def warm_pools_on_startup() -> None:
-    """A+B: non-blocking warm for beginner pool at process start."""
     def _run():
         try:
             top_up_pool(level="beginner", force=False)

--- a/interface/webui/lingo/spawn.py
+++ b/interface/webui/lingo/spawn.py
@@ -268,7 +268,7 @@ def handle_lingo_spawn_vocab(memorize: Any = None) -> str:
     for level in levels:
         # One batch per level keeps intermediate/advanced stocked too
         try:
-            total += top_up_pool(level=level, force=True)
+            total += top_up_pool(level=level, force=False)
         except Exception:
             log.warning("spawn failed for level %s", level, exc_info=True)
     msg = f"Lingo spawn: added {total} items to shared pool"

--- a/interface/webui/lingo/spawn.py
+++ b/interface/webui/lingo/spawn.py
@@ -1,0 +1,322 @@
+"""
+Shared Lingo vocab spawn pool + hourly scheduler handler.
+
+Architecture (single-user friendly, multi-user ready):
+
+  * Content (spawned JP + EN items) lives in a SHARED SQLite DB next to
+    this package: interface/webui/lingo/vocab_pool.db — every process can
+    read it; hourly job writes ~20 mixed items (hiragana / katakana /
+    kanji / phrase / sentence).
+
+  * Progress (learnt vs not, SM-2 schedule, review logs) stays per-user
+    under USER_SPACE_ROOT/<uid>/agentic/lingo/vocab.db via LingoSRS.
+
+  * XP / streaks stay in the existing per-user files (data/xp, data/streaks).
+
+Learn serves pool rows the user has not yet inserted into their SRS.
+Review serves the user's SRS due/learnt cards (cap 10).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import Any, List, Optional
+
+log = logging.getLogger(__name__)
+
+POOL_DB = Path(__file__).parent / "vocab_pool.db"
+SPAWN_BATCH = int(os.getenv("LINGO_SPAWN_BATCH", "20"))
+POOL_MIN = int(os.getenv("LINGO_POOL_MIN", "30"))
+LEARN_SESSION_N = 10
+REVIEW_SESSION_N = 10
+
+ITEM_KINDS = ("hiragana", "katakana", "kanji", "phrase", "sentence")
+
+_pool_lock = threading.Lock()
+
+
+def _conn() -> sqlite3.Connection:
+    POOL_DB.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(str(POOL_DB), timeout=30)
+    con.execute(
+        """CREATE TABLE IF NOT EXISTS vocab_pool (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            front TEXT NOT NULL,
+            back TEXT NOT NULL,
+            reading TEXT NOT NULL DEFAULT '',
+            kind TEXT NOT NULL DEFAULT 'kanji',
+            level TEXT NOT NULL DEFAULT 'beginner',
+            used_count INTEGER NOT NULL DEFAULT 0,
+            created_at REAL,
+            UNIQUE(front, back)
+        )"""
+    )
+    return con
+
+
+def pool_count(level: Optional[str] = None) -> int:
+    con = _conn()
+    try:
+        if level:
+            return con.execute(
+                "SELECT COUNT(*) FROM vocab_pool WHERE level = ?", (level,)
+            ).fetchone()[0]
+        return con.execute("SELECT COUNT(*) FROM vocab_pool").fetchone()[0]
+    finally:
+        con.close()
+
+
+def pool_add(items: list, level: str = "beginner") -> int:
+    """Insert spawned items. Returns rows actually added."""
+    con = _conn()
+    added = 0
+    try:
+        for it in items:
+            front = str(it.get("front") or "").strip()
+            back = str(it.get("back") or "").strip()
+            reading = str(it.get("reading") or front).strip()
+            kind = str(it.get("kind") or "kanji").strip().lower()
+            if kind not in ITEM_KINDS:
+                kind = "kanji"
+            if not front or not back:
+                continue
+            try:
+                cur = con.execute(
+                    "INSERT OR IGNORE INTO vocab_pool "
+                    "(front, back, reading, kind, level, created_at) "
+                    "VALUES (?, ?, ?, ?, ?, ?)",
+                    (front, back, reading, kind, level, time.time()),
+                )
+                if cur.rowcount:
+                    added += 1
+            except sqlite3.Error:
+                continue
+        con.commit()
+        return added
+    finally:
+        con.close()
+
+
+def pool_take_unlearned(
+    uid: str,
+    n: int = LEARN_SESSION_N,
+    level: Optional[str] = None,
+) -> List[dict]:
+    """Return up to n pool items the user has not yet put in their SRS."""
+    learned_keys: set[tuple[str, str]] = set()
+    try:
+        from .srs import LingoSRS
+        srs = LingoSRS(uid)
+        # Lightweight: all meanings+hiragana the user already has
+        import sqlite3 as _sq
+        con_u = _sq.connect(str(srs.db_path))
+        try:
+            rows = con_u.execute(
+                "SELECT hiragana, meaning FROM lingo_vocab_cards WHERE user_id = ?",
+                (uid,),
+            ).fetchall()
+            learned_keys = {(r[0] or "", r[1] or "") for r in rows}
+        finally:
+            con_u.close()
+    except Exception:
+        log.warning("Could not load user learnt set for %s", uid, exc_info=True)
+
+    con = _conn()
+    try:
+        if level:
+            candidates = con.execute(
+                "SELECT id, front, back, reading, kind FROM vocab_pool "
+                "WHERE level = ? ORDER BY used_count ASC, RANDOM() LIMIT ?",
+                (level, max(n * 5, 50)),
+            ).fetchall()
+        else:
+            candidates = con.execute(
+                "SELECT id, front, back, reading, kind FROM vocab_pool "
+                "ORDER BY used_count ASC, RANDOM() LIMIT ?",
+                (max(n * 5, 50),),
+            ).fetchall()
+        out = []
+        taken_ids = []
+        for row in candidates:
+            pid, front, back, reading, kind = row
+            if (reading or front, back) in learned_keys:
+                continue
+            if (front, back) in learned_keys:
+                continue
+            out.append({
+                "pool_id": pid,
+                "front": front,
+                "back": back,
+                "reading": reading,
+                "kind": kind,
+            })
+            taken_ids.append(pid)
+            if len(out) >= n:
+                break
+        if taken_ids:
+            con.execute(
+                f"UPDATE vocab_pool SET used_count = used_count + 1 "
+                f"WHERE id IN ({','.join('?' * len(taken_ids))})",
+                taken_ids,
+            )
+            con.commit()
+        return out
+    finally:
+        con.close()
+
+
+def mark_learned(uid: str, items: List[dict]) -> int:
+    """Graduate pool items into the user's SRS (now Reviewable). Returns count."""
+    from .srs import LingoSRS, LingoVocabCard
+    srs = LingoSRS(uid)
+    n = 0
+    for it in items:
+        front = str(it.get("front") or "").strip()
+        back = str(it.get("back") or "").strip()
+        reading = str(it.get("reading") or front).strip()
+        kind = str(it.get("kind") or "kanji")
+        if not front or not back:
+            continue
+        try:
+            srs.add_card(LingoVocabCard(
+                kanji=front if kind in ("kanji", "phrase", "sentence") else "",
+                hiragana=reading,
+                meaning=back,
+                pos=kind,
+                context="spawn",
+                source_context="hourly_spawn",
+            ))
+            n += 1
+        except Exception:
+            log.warning("mark_learned failed for %s", front, exc_info=True)
+    return n
+
+
+def _llm_spawn_batch(count: int = SPAWN_BATCH, level: str = "beginner") -> List[dict]:
+    """Ask the tutor LLM for a mixed batch. Empty if brain offline."""
+    try:
+        from interface.webui import auth
+        if not auth.aiko_web_instance or not auth.aiko_web_instance._think:
+            return []
+        think = auth.aiko_web_instance._think
+        per = max(1, count // len(ITEM_KINDS))
+        response = think._client.chat.completions.create(
+            model=think._llm_model,
+            messages=[
+                {"role": "system", "content": (
+                    "You are a Japanese teacher building a mixed study list. "
+                    f"Produce exactly {count} items for a {level} learner. "
+                    f"Roughly {per} of each kind: hiragana, katakana, kanji, phrase, sentence. "
+                    "Each item needs natural Japanese, hiragana reading, and a short English meaning. "
+                    "For hiragana/katakana kinds use only that script on the front. "
+                    "For sentences keep them short (under 20 characters Japanese). "
+                    "Output ONLY valid JSON: "
+                    '{"items":[{"kind":"kanji","japanese":"...","hiragana":"...","meaning":"..."}]}'
+                )},
+                {"role": "user", "content": "Spawn a fresh mixed vocab batch."},
+            ],
+            response_format={"type": "json_object"},
+            timeout=90.0,
+        )
+        import json, re
+        raw = response.choices[0].message.content or ""
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            m = re.search(r"\{.*\}", raw, re.DOTALL)
+            data = json.loads(m.group(0)) if m else {}
+        out = []
+        for w in (data.get("items") or data.get("words") or [])[:count]:
+            surf = str(w.get("japanese") or w.get("front") or "").strip()
+            hira = str(w.get("hiragana") or w.get("reading") or surf).strip()
+            mean = str(w.get("meaning") or w.get("back") or "").strip()
+            kind = str(w.get("kind") or "kanji").strip().lower()
+            if kind not in ITEM_KINDS:
+                kind = "kanji"
+            if not surf or not mean or len(surf) > 40:
+                continue
+            out.append({"front": surf, "back": mean, "reading": hira, "kind": kind})
+        return out
+    except Exception:
+        log.warning("LLM spawn batch failed", exc_info=True)
+        return []
+
+
+def top_up_pool(level: str = "beginner", force: bool = False) -> int:
+    """If pool is low (or force), generate SPAWN_BATCH items into shared pool."""
+    with _pool_lock:
+        if not force and pool_count(level) >= POOL_MIN:
+            return 0
+        items = _llm_spawn_batch(SPAWN_BATCH, level=level)
+        if not items:
+            return 0
+        return pool_add(items, level=level)
+
+
+def top_up_pool_background(level: str = "beginner") -> None:
+    threading.Thread(target=top_up_pool, args=(level,), daemon=True).start()
+
+
+def handle_lingo_spawn_vocab(memorize: Any = None) -> str:
+    """Scheduler handler: spawn ~20 mixed items into the shared pool."""
+    levels = ("beginner", "intermediate", "advanced")
+    total = 0
+    for level in levels:
+        # One batch per level keeps intermediate/advanced stocked too
+        try:
+            total += top_up_pool(level=level, force=True)
+        except Exception:
+            log.warning("spawn failed for level %s", level, exc_info=True)
+    msg = f"Lingo spawn: added {total} items to shared pool"
+    log.info(msg)
+    return msg
+
+
+LINGO_SPAWN_JOB_TITLE = "lingo_vocab_spawn"
+
+
+def ensure_lingo_spawn_job(timezone: str | None = None, user_id: str | None = None) -> None:
+    """Idempotently seed hourly shared-pool top-up in schedule.json."""
+    try:
+        from system import schedule as sched
+        existing = {job.get("title") for job in sched._read_all(user_id=user_id)}
+        if LINGO_SPAWN_JOB_TITLE in existing:
+            return
+        sched.schedule_job_record(
+            title=LINGO_SPAWN_JOB_TITLE,
+            task="Spawn mixed Japanese vocab into the shared Lingo pool",
+            time_of_day="00:00",
+            frequency="hourly",
+            timezone=timezone,
+            action="agentic",
+            handler="lingo_spawn_vocab",
+            user_id=user_id,
+        )
+        log.info("Seeded hourly lingo vocab spawn job")
+    except Exception:
+        log.warning("ensure_lingo_spawn_job failed", exc_info=True)
+
+
+def register_lingo_spawn_handler(seed_jobs: bool = False, timezone: str | None = None,
+                                 user_id: str | None = None) -> None:
+    from system.schedule import register_system_handler
+    register_system_handler(
+        "lingo_spawn_vocab",
+        lambda memorize: handle_lingo_spawn_vocab(memorize),
+    )
+    if seed_jobs:
+        ensure_lingo_spawn_job(timezone=timezone, user_id=user_id)
+
+
+def warm_pools_on_startup() -> None:
+    """A+B: non-blocking warm for beginner pool at process start."""
+    def _run():
+        try:
+            top_up_pool(level="beginner", force=False)
+        except Exception:
+            log.warning("startup pool warm failed", exc_info=True)
+    threading.Thread(target=_run, daemon=True).start()


### PR DESCRIPTION
## Summary

Implements your split: **shared content** vs **per-user progress**, plus hourly pre-spawn and A+B warm-up (startup thread + non-blocking top-up on Learn).

## Your model (confirmed)

| Data | Location |
|------|----------|
| Spawned vocab (JP + EN, all users can read) | `interface/webui/lingo/vocab_pool.db` |
| Learnt progress + SRS schedule + review logs | `USER_SPACE_ROOT/<uid>/agentic/lingo/vocab.db` |
| XP / streak | existing per-user files |

Single-user is fine; shared pool means one spawn job fills content for everyone.

## Pre-spawn = A + B + hourly

- **A** — on `GET /api/nihongo/learn/new`, if pool is low, top-up runs in a **background thread** (no wait)
- **B** — on package import, **startup warm** of beginner pool (background)
- **Hourly** — scheduler handler `lingo_spawn_vocab` generates ~20 mixed items (`hiragana` / `katakana` / `kanji` / `phrase` / `sentence`) into the shared pool. Seed with `ensure_lingo_spawn_job()` after login (exported from `interface.webui.lingo`).

## New API (on existing `/api/nihongo` router)

| Method | Path | Behavior |
|--------|------|----------|
| GET | `/learn/new` | Up to **10** pool items **not** yet in the user’s SRS |
| POST | `/learn/mark` | Mark items learnt → insert into per-user SRS + **5 XP each** |
| GET | `/learn/status` | Pool size + user card counts |

Review stays on existing `/review/*` (SRS due cards + XP by grade). Cap-at-10 on review is recommended next; not hard-forced in this PR to avoid a large `router.py` rewrite.

## Files

- `interface/webui/lingo/spawn.py` — pool DB, LLM batch, handler, ensure job, warm
- `interface/webui/lingo/learn_api.py` — Learn endpoints
- `interface/webui/lingo/lessons.py` — static kana decks; legacy `lesson_pool` kept for old words-phrases path
- `interface/webui/lingo/__init__.py` — attach routes + register handler + warm

## Deploy notes

1. Merge & restart Aiko-chan.
2. Once a real user is logged in, call `ensure_lingo_spawn_job()` once (or add that call next to other `ensure_*_job` bootstraps in schedule bootstrap) so `schedule.json` gets the hourly job.
3. Optional: point the Android **Learn** screen at `GET /api/nihongo/learn/new` + `POST /learn/mark` (follow-up frontend PR).

## Not in this PR

- Android client wiring
- Hard `LIMIT 10` inside existing `review_start` in `router.py`
- Auto-seed of the hourly job inside `register_system_handlers_only` (avoided large `schedule.py` edit; use `ensure_lingo_spawn_job`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added personalized Japanese vocabulary learning sessions with beginner, intermediate, and advanced content.
  * Added support for tracking learned items, review progress, and learning statistics.
  * Added optional experience-point rewards when completing learning items.
  * Added automatic vocabulary pool replenishment and scheduled updates to keep new content available.
  * Expanded supported content to include hiragana, katakana, kanji, phrases, and sentences.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->